### PR TITLE
Fix import paths and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ source venv/bin/activate  # On Windows: venv\Scripts\activate
 pip install -r requirements.txt
 
 # Run development server
-uvicorn main:app --reload
+uvicorn app.main:app --reload
 
 The API will be available at http://localhost:8000
 📚 Documentation

--- a/backend/app/README.md
+++ b/backend/app/README.md
@@ -22,11 +22,11 @@ Clone the repository
 
 
 ```bash
-cd backend/app
+cd backend
 python -m venv venv
 source venv/bin/activate
 pip install -r requirements.txt
-uvicorn main:app --reload
+uvicorn app.main:app --reload
 ```
 
 The API will then be available at `http://localhost:8000`.
@@ -36,5 +36,5 @@ The API will then be available at `http://localhost:8000`.
 Run unit tests from the `testing` folder:
 
 ```bash
-python testing/UnitTest.py
+python app/testing/UnitTest.py
 ```

--- a/backend/app/calculators/magic.py
+++ b/backend/app/calculators/magic.py
@@ -1,6 +1,6 @@
 import math
 from typing import Dict, Any
-from config.constants import (
+from ..config.constants import (
     EFFECTIVE_LEVEL_BASE,
     EQUIPMENT_BONUS_OFFSET,
     VOID_MAGIC_MULTIPLIER,

--- a/backend/app/calculators/melee.py
+++ b/backend/app/calculators/melee.py
@@ -1,6 +1,6 @@
 import math
 from typing import Dict, Any
-from config.constants import (
+from ..config.constants import (
     EFFECTIVE_LEVEL_BASE,
     VOID_MELEE_MULTIPLIER,
     EQUIPMENT_BONUS_OFFSET,

--- a/backend/app/calculators/ranged.py
+++ b/backend/app/calculators/ranged.py
@@ -1,6 +1,6 @@
 import math
 from typing import Dict, Any
-from config.constants import (
+from ..config.constants import (
     EFFECTIVE_LEVEL_BASE,
     EQUIPMENT_BONUS_OFFSET,
     VOID_RANGED_ATTACK_MULTIPLIER,

--- a/backend/app/testing/UnitTest.py
+++ b/backend/app/testing/UnitTest.py
@@ -5,11 +5,11 @@ import json
 import sys
 import os
 
-# Add parent directory to path to import calculator modules
-sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+# Add backend directory to path to import the app package
+sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 
 # Import calculator modules 
-from calculators import DpsCalculator, MeleeCalculator, RangedCalculator, MagicCalculator
+from app.calculators import DpsCalculator, MeleeCalculator, RangedCalculator, MagicCalculator
 
 class TestDpsCalculator(unittest.TestCase):
     """Test the main DPS Calculator dispatch logic."""
@@ -18,7 +18,7 @@ class TestDpsCalculator(unittest.TestCase):
         """Test that melee calculations are dispatched correctly."""
         params = {"combat_style": "melee"}
         
-        with patch('calculators.MeleeCalculator.calculate_dps') as mock_melee:
+        with patch('app.calculators.MeleeCalculator.calculate_dps') as mock_melee:
             mock_melee.return_value = {"dps": 10.0}
             result = DpsCalculator.calculate_dps(params)
             
@@ -29,7 +29,7 @@ class TestDpsCalculator(unittest.TestCase):
         """Test that ranged calculations are dispatched correctly."""
         params = {"combat_style": "ranged"}
         
-        with patch('calculators.RangedCalculator.calculate_dps') as mock_ranged:
+        with patch('app.calculators.RangedCalculator.calculate_dps') as mock_ranged:
             mock_ranged.return_value = {"dps": 8.5}
             result = DpsCalculator.calculate_dps(params)
             
@@ -40,7 +40,7 @@ class TestDpsCalculator(unittest.TestCase):
         """Test that magic calculations are dispatched correctly."""
         params = {"combat_style": "magic"}
         
-        with patch('calculators.MagicCalculator.calculate_dps') as mock_magic:
+        with patch('app.calculators.MagicCalculator.calculate_dps') as mock_magic:
             mock_magic.return_value = {"dps": 7.2}
             result = DpsCalculator.calculate_dps(params)
             
@@ -247,7 +247,7 @@ class TestRangedCalculator(unittest.TestCase):
         tbow_params["weapon_name"] = "Twisted bow"
         tbow_params["target_magic_level"] = 200  # High magic level target
         
-        with patch('calculators.RangedCalculator.calculate_twisted_bow_bonus') as mock_tbow:
+        with patch('app.calculators.RangedCalculator.calculate_twisted_bow_bonus') as mock_tbow:
             # Mock the Twisted Bow bonus calculation
             mock_tbow.return_value = {
                 "accuracy_multiplier": 1.299,  # 29.9% accuracy boost


### PR DESCRIPTION
## Summary
- update calculator imports to use app package
- add backend to `sys.path` for tests
- adjust patch paths in tests
- document API server startup from the backend directory
- show correct test invocation in backend README

## Testing
- `python backend/app/testing/UnitTest.py`
- `uvicorn app.main:app --reload`

------
https://chatgpt.com/codex/tasks/task_e_6844dc1efec4832eb2c2355935a6e77c