### PR TITLE
Update combat style handling

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -255,7 +255,36 @@ async def get_item(item_id: int):
                             "ranged strength": 20,
                             "magic damage": "+0%",
                             "prayer": 0
-                        }
+                        },
+                        "combat_styles": [
+                            {
+                                "name": "Accurate",
+                                "attack_type": "Ranged",
+                                "style": "Accurate",
+                                "speed": "5 ticks (3.0s)",
+                                "range": "10 tiles",
+                                "experience": "",
+                                "boost": "+3 Attack"
+                            },
+                            {
+                                "name": "Rapid",
+                                "attack_type": "Ranged",
+                                "style": "Rapid",
+                                "speed": "4 ticks (2.4s)",
+                                "range": "10 tiles",
+                                "experience": "",
+                                "boost": ""
+                            },
+                            {
+                                "name": "Longrange",
+                                "attack_type": "Ranged",
+                                "style": "Longrange",
+                                "speed": "5 ticks (3.0s)",
+                                "range": "10 tiles",
+                                "experience": "",
+                                "boost": "+3 Defence"
+                            }
+                        ]
                     }
                 }
             elif item_id == 2:  # Abyssal whip
@@ -287,7 +316,45 @@ async def get_item(item_id: int):
                             "ranged strength": 0,
                             "magic damage": "+0%",
                             "prayer": 0
-                        }
+                        },
+                        "combat_styles": [
+                            {
+                                "name": "Chop",
+                                "attack_type": "Slash",
+                                "style": "Accurate",
+                                "speed": "5 ticks (3.0s)",
+                                "range": "1 tile",
+                                "experience": "",
+                                "boost": "+3 Attack"
+                            },
+                            {
+                                "name": "Slash",
+                                "attack_type": "Slash",
+                                "style": "Aggressive",
+                                "speed": "5 ticks (3.0s)",
+                                "range": "1 tile",
+                                "experience": "",
+                                "boost": "+3 Strength"
+                            },
+                            {
+                                "name": "Lunge",
+                                "attack_type": "Stab",
+                                "style": "Controlled",
+                                "speed": "5 ticks (3.0s)",
+                                "range": "1 tile",
+                                "experience": "",
+                                "boost": "+1 Attack, Strength, Defence"
+                            },
+                            {
+                                "name": "Block",
+                                "attack_type": "Slash",
+                                "style": "Defensive",
+                                "speed": "5 ticks (3.0s)",
+                                "range": "1 tile",
+                                "experience": "",
+                                "boost": "+3 Defence"
+                            }
+                        ]
                     }
                 }
             else:

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -53,6 +53,7 @@ class ItemStats(BaseModel):
     attack_bonuses: Dict[str, int] = Field(default_factory=dict)
     defence_bonuses: Dict[str, int] = Field(default_factory=dict)
     other_bonuses: Dict[str, Union[int, str]] = Field(default_factory=dict)
+    combat_styles: Optional[List[Dict[str, Any]]] = Field(default_factory=list)
 
 class Item(BaseModel):
     """Represents an equipment item with metadata and stats."""

--- a/frontend/src/components/features/calculator/AttackStyleSelector.tsx
+++ b/frontend/src/components/features/calculator/AttackStyleSelector.tsx
@@ -5,7 +5,6 @@ import {
   Tooltip, TooltipContent, TooltipProvider, TooltipTrigger
 } from '@/components/ui/tooltip';
 import { Item } from '@/types/calculator';
-import { useCalculatorStore } from '@/store/calculator-store';
 import { BossForm } from '@/types/calculator';
 
 // Define attack styles with their bonuses
@@ -111,50 +110,10 @@ export function AttackStyleSelector({
   selectedAttackStyle,
   onSelectAttackStyle
 }: AttackStyleSelectorProps) {
-  const { params, setParams } = useCalculatorStore();
-  
-  // Render melee-specific attack type selector
-  const renderMeleeAttackTypeSelector = () => {
-    if (combatStyle !== 'melee') return null;
-    
-    return (
-      <>
-        <div className="mb-1 text-sm text-muted-foreground">Attack Type:</div>
-        <div className="flex gap-2 justify-center mb-2">
-          {(['stab', 'slash', 'crush'] as const).map((type) => {
-            return (
-              <Button
-                key={type}
-                variant={params.attack_type === type ? 'default' : 'outline'}
-                size="sm"
-                onClick={() => {
-                  const weapon = loadout['2h'] || loadout['mainhand'];
-                  const attackBonuses = weapon?.combat_stats?.attack_bonuses || {};
-                  const bonus = attackBonuses[type] || 0;
 
-                  const defenceBonus = bossForm?.[`defence_${type}` as keyof BossForm] ?? 0;
-
-                  setParams({
-                    attack_type: type,
-                    melee_attack_bonus: bonus,
-                    target_defence_type: ATTACK_TYPE_TO_DEFENCE_TYPE[type],
-                    target_defence_bonus: defenceBonus
-                  });
-                }}
-              >
-                {type.charAt(0).toUpperCase() + type.slice(1)}
-              </Button>
-            );
-          })}
-        </div>
-      </>
-    );
-  };
 
   return (
     <div className="p-3 text-center">
-      {renderMeleeAttackTypeSelector()}
-
       <div className="mb-1 text-sm text-muted-foreground">
         {combatStyle === 'melee' 
           ? "Combat Style:" 


### PR DESCRIPTION
## Summary
- include `combat_styles` info in backend mock items
- allow combat styles field in backend models
- drop redundant melee attack type selector so weapon options show

## Testing
- `npm test --silent` *(fails: jest not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844eeb68570832eb74a31a3b88ee400