### PR TITLE
Improve CI and add scheduled data workflow

### DIFF
--- a/.github/workflows/azure-static-web-apps-yellow-stone-0daf36a0f.yml
+++ b/.github/workflows/azure-static-web-apps-yellow-stone-0daf36a0f.yml
@@ -23,6 +23,20 @@ jobs:
         with:
           submodules: true
           lfs: false
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          cache: 'npm'
+          cache-dependency-path: './frontend/package-lock.json'
+      - name: Install frontend dependencies
+        run: |
+          cd frontend
+          npm ci
+      - name: Run frontend tests
+        run: |
+          cd frontend
+          npm test --ci
       - name: Install OIDC Client from Core Package
         run: npm install @actions/core@1.6.0 @actions/http-client
       - name: Get Id Token
@@ -36,11 +50,13 @@ jobs:
       - name: Build And Deploy
         id: builddeploy
         uses: Azure/static-web-apps-deploy@v1
+        env:
+          NEXT_PUBLIC_API_URL: ${{ secrets.BACKEND_URL }}
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_YELLOW_STONE_0DAF36A0F }}
           action: "upload"
           app_location: "./frontend"
-          api_location: ""  # EMPTY - no API with Static Web App
+          api_location: "./api"
           output_location: "out"
           github_id_token: ${{ steps.idtoken.outputs.result }}
 

--- a/.github/workflows/deploy-backend-function-app.yml
+++ b/.github/workflows/deploy-backend-function-app.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [ main ]
     paths: [ 'backend/**', 'api/**' ]  # Trigger when backend changes
+  pull_request:
+    branches: [ main ]
+    paths: [ 'backend/**', 'api/**' ]
   workflow_dispatch:  # Allow manual deployment
 
 env:
@@ -23,6 +26,8 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ env.PYTHON_VERSION }}
+        cache: 'pip'
+        cache-dependency-path: '${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}/requirements.txt'
 
     - name: 'Create and start virtual environment'
       run: |
@@ -36,20 +41,27 @@ jobs:
         source venv/bin/activate
         pip install -r requirements.txt
 
-    # Optional: Run tests
     - name: 'Run tests'
       run: |
         cd ${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}
         source venv/bin/activate
-        # python -m pytest tests/ --if-present
-        echo "Tests would run here"
+        python app/testing/UnitTest.py
 
     - name: 'Login to Azure'
       uses: azure/login@v1
       with:
         creds: ${{ secrets.AZURE_CREDENTIALS }}
 
+    - name: 'Deploy to Azure Functions (PR)'
+      if: github.event_name == 'pull_request'
+      uses: Azure/functions-action@v1
+      with:
+        app-name: ${{ env.AZURE_FUNCTIONAPP_NAME }}
+        package: ${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}
+        slot-name: 'staging'
+
     - name: 'Deploy to Azure Functions'
+      if: github.event_name != 'pull_request'
       uses: Azure/functions-action@v1
       with:
         app-name: ${{ env.AZURE_FUNCTIONAPP_NAME }}

--- a/.github/workflows/generate-databases.yml
+++ b/.github/workflows/generate-databases.yml
@@ -1,0 +1,38 @@
+name: Generate Databases
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: 'backend/app/requirements.txt'
+
+      - name: Install dependencies
+        run: |
+          pip install -r backend/app/requirements.txt
+
+      - name: Run item scraper
+        run: python backend/webscraper/runescape-items/osrs_item_scraper.py
+
+      - name: Run boss scraper
+        run: python backend/webscraper/runescape-bosses/extract.py
+
+      - name: Upload databases
+        uses: actions/upload-artifact@v3
+        with:
+          name: osrs-databases
+          path: |
+            backend/webscraper/runescape-items/*.db
+            backend/webscraper/runescape-bosses/osrs_bosses.db
+

--- a/README.md
+++ b/README.md
@@ -126,7 +126,9 @@ Create a .env.local file in the root directory:
 
 NEXT_PUBLIC_API_URL=http://localhost:8000
 
-For production, set this to your deployed API URL.
+For production, set this to your deployed API URL. The deployment workflows
+expect a repository secret named `BACKEND_URL` which will be exposed as
+`NEXT_PUBLIC_API_URL` during the frontend build.
 Database Setup
 
 The application uses two SQLite databases:
@@ -140,6 +142,9 @@ bash
 
 python osrs_item_scraper.py
 python extract.py
+
+The GitHub workflow `generate-databases.yml` runs these scrapers weekly and
+uploads the resulting `.db` files as artifacts.
 
 🔄 API Reference
 Calculate DPS

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -1,8 +1,13 @@
 module.exports = {
-  preset: 'ts-jest',
+  preset: 'ts-jest/presets/js-with-ts-esm',
   testEnvironment: 'jsdom',
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
   },
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  globals: {
+    'ts-jest': {
+      tsconfig: './tsconfig.json',
+    },
+  },
 };


### PR DESCRIPTION
## Summary
- set `NEXT_PUBLIC_API_URL` from `BACKEND_URL` secret and deploy API with frontend
- cache Node and Python dependencies, run frontend tests
- enable backend tests and add deployment slot for PRs
- add scheduled workflow to regenerate SQLite databases
- document new secret and workflow

## Testing
- `npm test --ci` *(fails: Jest couldn't parse TSX)*
- `python app/testing/UnitTest.py`

------
https://chatgpt.com/codex/tasks/task_e_684524d2af50832e8c6f0068d97da40f