### PR TITLE
Fix boss query connection and unit test

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -247,7 +247,7 @@ class DatabaseService:
             with sqlite3.connect(self.boss_db_path) as conn:
                 cursor = conn.cursor()
                 # Get boss main data
-            cursor.execute(
+                cursor.execute(
                 """
             SELECT
                 id, name, raid_group, examine, location,
@@ -259,28 +259,28 @@ class DatabaseService:
                 (boss_id,),
             )
 
-            boss_row = cursor.fetchone()
+                boss_row = cursor.fetchone()
 
-            if not boss_row:
-                return None
+                if not boss_row:
+                    return None
 
-            boss_data = {
-                "id": boss_row[0],
-                "name": boss_row[1],
-                "raid_group": boss_row[2],
-                "examine": boss_row[3],
-                "location": boss_row[4],
-                "release_date": boss_row[5],
-                "slayer_level": boss_row[6],
-                "slayer_xp": boss_row[7],
-                "slayer_category": boss_row[8],
-                "has_multiple_forms": bool(boss_row[9]),
-                "forms": [],
-                "icon_url": None,
-            }
+                boss_data = {
+                    "id": boss_row[0],
+                    "name": boss_row[1],
+                    "raid_group": boss_row[2],
+                    "examine": boss_row[3],
+                    "location": boss_row[4],
+                    "release_date": boss_row[5],
+                    "slayer_level": boss_row[6],
+                    "slayer_xp": boss_row[7],
+                    "slayer_category": boss_row[8],
+                    "has_multiple_forms": bool(boss_row[9]),
+                    "forms": [],
+                    "icon_url": None,
+                }
 
-            # Get all forms for this boss
-            cursor.execute(
+                # Get all forms for this boss
+                cursor.execute(
                 """
             SELECT
                 id, form_name, form_order, combat_level, hitpoints,
@@ -303,64 +303,65 @@ class DatabaseService:
                 (boss_id,),
             )
 
-            for form_row in cursor.fetchall():
-                form_data = {
-                    "id": form_row[0],
-                    "boss_id": boss_id,
-                    "form_name": form_row[1],
-                    "form_order": form_row[2],
-                    "combat_level": form_row[3],
-                    "hitpoints": form_row[4],
-                    "max_hit": form_row[5],
-                    "attack_speed": form_row[6],
-                    "attack_style": form_row[7],
-                    "attack_level": form_row[8],
-                    "strength_level": form_row[9],
-                    "defence_level": form_row[10],
-                    "magic_level": form_row[11],
-                    "ranged_level": form_row[12],
-                    "aggressive_attack_bonus": form_row[13],
-                    "aggressive_strength_bonus": form_row[14],
-                    "aggressive_magic_bonus": form_row[15],
-                    "aggressive_magic_strength_bonus": form_row[16],
-                    "aggressive_ranged_bonus": form_row[17],
-                    "aggressive_ranged_strength_bonus": form_row[18],
-                    "defence_stab": form_row[19],
-                    "defence_slash": form_row[20],
-                    "defence_crush": form_row[21],
-                    "defence_magic": form_row[22],
-                    "elemental_weakness_type": form_row[23],
-                    "elemental_weakness_percent": form_row[24],
-                    "defence_ranged_light": form_row[25],
-                    "defence_ranged_standard": form_row[26],
-                    "defence_ranged_heavy": form_row[27],
-                    "attribute": form_row[28],
-                    "xp_bonus": form_row[29],
-                    "aggressive": form_row[30],
-                    "poisonous": form_row[31],
-                    "poison_immunity": form_row[32],
-                    "venom_immunity": form_row[33],
-                    "melee_immunity": form_row[34],
-                    "magic_immunity": form_row[35],
-                    "ranged_immunity": form_row[36],
-                    "cannon_immunity": form_row[37],
-                    "thrall_immunity": form_row[38],
-                    "special_mechanics": form_row[39],
-                    "image_url": form_row[40],
-                    "icons": json.loads(form_row[41]) if form_row[41] else [],
-                    "size": form_row[42],
-                    "npc_ids": form_row[43],
-                    "assigned_by": form_row[44],
-                }
+                for form_row in cursor.fetchall():
+                    form_data = {
+                        "id": form_row[0],
+                        "boss_id": boss_id,
+                        "form_name": form_row[1],
+                        "form_order": form_row[2],
+                        "combat_level": form_row[3],
+                        "hitpoints": form_row[4],
+                        "max_hit": form_row[5],
+                        "attack_speed": form_row[6],
+                        "attack_style": form_row[7],
+                        "attack_level": form_row[8],
+                        "strength_level": form_row[9],
+                        "defence_level": form_row[10],
+                        "magic_level": form_row[11],
+                        "ranged_level": form_row[12],
+                        "aggressive_attack_bonus": form_row[13],
+                        "aggressive_strength_bonus": form_row[14],
+                        "aggressive_magic_bonus": form_row[15],
+                        "aggressive_magic_strength_bonus": form_row[16],
+                        "aggressive_ranged_bonus": form_row[17],
+                        "aggressive_ranged_strength_bonus": form_row[18],
+                        "defence_stab": form_row[19],
+                        "defence_slash": form_row[20],
+                        "defence_crush": form_row[21],
+                        "defence_magic": form_row[22],
+                        "elemental_weakness_type": form_row[23],
+                        "elemental_weakness_percent": form_row[24],
+                        "defence_ranged_light": form_row[25],
+                        "defence_ranged_standard": form_row[26],
+                        "defence_ranged_heavy": form_row[27],
+                        "attribute": form_row[28],
+                        "xp_bonus": form_row[29],
+                        "aggressive": form_row[30],
+                        "poisonous": form_row[31],
+                        "poison_immunity": form_row[32],
+                        "venom_immunity": form_row[33],
+                        "melee_immunity": form_row[34],
+                        "magic_immunity": form_row[35],
+                        "ranged_immunity": form_row[36],
+                        "cannon_immunity": form_row[37],
+                        "thrall_immunity": form_row[38],
+                        "special_mechanics": form_row[39],
+                        "image_url": form_row[40],
+                        "icons": json.loads(form_row[41]) if form_row[41] else [],
+                        "size": form_row[42],
+                        "npc_ids": form_row[43],
+                        "assigned_by": form_row[44],
+                    }
 
-                boss_data["forms"].append(form_data)
-            if boss_data["forms"]:
-                first = boss_data["forms"][0]
-                icons = first.get("icons", []) if isinstance(first.get("icons"), list) else []
-                if icons:
-                    boss_data["icon_url"] = icons[0]
-                elif first.get("image_url"):
-                    boss_data["icon_url"] = first.get("image_url")
+                    boss_data["forms"].append(form_data)
+
+                if boss_data["forms"]:
+                    first = boss_data["forms"][0]
+                    icons = first.get("icons", []) if isinstance(first.get("icons"), list) else []
+                    if icons:
+                        boss_data["icon_url"] = icons[0]
+                    elif first.get("image_url"):
+                        boss_data["icon_url"] = first.get("image_url")
 
                 return boss_data
         except Exception as e:

--- a/backend/app/testing/test_database.py
+++ b/backend/app/testing/test_database.py
@@ -1,0 +1,140 @@
+import os
+import sqlite3
+import tempfile
+import shutil
+import unittest
+
+from app.database import DatabaseService
+
+
+class TestDatabaseService(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        boss_db = os.path.join(self.temp_dir, "osrs_bosses.db")
+        conn = sqlite3.connect(boss_db)
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            CREATE TABLE bosses (
+                id INTEGER PRIMARY KEY,
+                name TEXT,
+                raid_group TEXT,
+                examine TEXT,
+                location TEXT,
+                release_date TEXT,
+                slayer_level INTEGER,
+                slayer_xp INTEGER,
+                slayer_category TEXT,
+                has_multiple_forms INTEGER
+            )
+            """
+        )
+        cursor.execute(
+            """
+            CREATE TABLE boss_forms (
+                id INTEGER PRIMARY KEY,
+                boss_id INTEGER,
+                form_name TEXT,
+                form_order INTEGER,
+                combat_level INTEGER,
+                hitpoints INTEGER,
+                max_hit INTEGER,
+                attack_speed REAL,
+                attack_style TEXT,
+                attack_level INTEGER,
+                strength_level INTEGER,
+                defence_level INTEGER,
+                magic_level INTEGER,
+                ranged_level INTEGER,
+                aggressive_attack_bonus INTEGER,
+                aggressive_strength_bonus INTEGER,
+                aggressive_magic_bonus INTEGER,
+                aggressive_magic_strength_bonus INTEGER,
+                aggressive_ranged_bonus INTEGER,
+                aggressive_ranged_strength_bonus INTEGER,
+                defence_stab INTEGER,
+                defence_slash INTEGER,
+                defence_crush INTEGER,
+                defence_magic INTEGER,
+                elemental_weakness_type TEXT,
+                elemental_weakness_percent REAL,
+                defence_ranged_light INTEGER,
+                defence_ranged_standard INTEGER,
+                defence_ranged_heavy INTEGER,
+                attribute TEXT,
+                xp_bonus INTEGER,
+                aggressive INTEGER,
+                poisonous INTEGER,
+                poison_immunity INTEGER,
+                venom_immunity INTEGER,
+                melee_immunity INTEGER,
+                magic_immunity INTEGER,
+                ranged_immunity INTEGER,
+                cannon_immunity INTEGER,
+                thrall_immunity INTEGER,
+                special_mechanics TEXT,
+                image_url TEXT,
+                icons TEXT,
+                size INTEGER,
+                npc_ids TEXT,
+                assigned_by TEXT
+            )
+            """
+        )
+        cursor.execute(
+            """
+            INSERT INTO bosses (id, name, raid_group, examine, location, release_date, slayer_level, slayer_xp, slayer_category, has_multiple_forms)
+            VALUES (1, 'Test Boss', NULL, 'A boss', 'Somewhere', '2020-01-01', 1, 100, 'Demon', 0)
+            """
+        )
+        cursor.execute(
+            """
+            INSERT INTO bosses (id, name, raid_group, examine, location, release_date, slayer_level, slayer_xp, slayer_category, has_multiple_forms)
+            VALUES (2, 'No Form Boss', NULL, 'Another boss', 'Nowhere', '2020-01-02', 1, 100, 'Undead', 0)
+            """
+        )
+        cursor.execute(
+            """
+            INSERT INTO boss_forms (
+                id, boss_id, form_name, form_order, combat_level, hitpoints,
+                max_hit, attack_speed, attack_style, attack_level, strength_level,
+                defence_level, magic_level, ranged_level, aggressive_attack_bonus,
+                aggressive_strength_bonus, aggressive_magic_bonus,
+                aggressive_magic_strength_bonus, aggressive_ranged_bonus,
+                aggressive_ranged_strength_bonus, defence_stab, defence_slash,
+                defence_crush, defence_magic, elemental_weakness_type,
+                elemental_weakness_percent, defence_ranged_light,
+                defence_ranged_standard, defence_ranged_heavy, attribute,
+                xp_bonus, aggressive, poisonous, poison_immunity, venom_immunity,
+                melee_immunity, magic_immunity, ranged_immunity, cannon_immunity,
+                thrall_immunity, special_mechanics, image_url, icons, size,
+                npc_ids, assigned_by
+            ) VALUES (
+                1, 1, 'Normal', 1, 100, 200, 20, 4.0, 'melee', 100, 100,
+                100, 50, 50, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 'none', 0, 0, 0, 0, NULL,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, '', '', '[]', 1, '', ''
+            )
+            """
+        )
+        conn.commit()
+        conn.close()
+        self.service = DatabaseService(db_dir=self.temp_dir)
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir)
+
+    def test_get_boss_with_and_without_forms(self):
+        boss = self.service.get_boss(1)
+        self.assertIsNotNone(boss)
+        self.assertEqual(boss["id"], 1)
+        self.assertEqual(len(boss["forms"]), 1)
+
+        boss_no_forms = self.service.get_boss(2)
+        self.assertIsNotNone(boss_no_forms)
+        self.assertEqual(boss_no_forms["id"], 2)
+        self.assertEqual(boss_no_forms["forms"], [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- keep `get_boss` queries inside the connection context
- always return boss data even when no forms exist
- add regression test verifying `DatabaseService.get_boss`

## Testing
- `pytest backend/app/testing`

------
https://chatgpt.com/codex/tasks/task_e_6845593636b8832ea28dc1eb03cb2835