### PR TITLE
Fix boss list retrieval

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -199,39 +199,39 @@ class DatabaseService:
                 bosses = []
                 for row in cursor.fetchall():
                     icon = None
-                try:
-                    cursor.execute(
-                        """
-                    SELECT icons, image_url
-                    FROM boss_forms
-                    WHERE boss_id = ?
-                    ORDER BY form_order
-                    LIMIT 1
-                    """,
-                        (row[0],),
+                    try:
+                        cursor.execute(
+                            """
+                        SELECT icons, image_url
+                        FROM boss_forms
+                        WHERE boss_id = ?
+                        ORDER BY form_order
+                        LIMIT 1
+                        """,
+                            (row[0],),
+                        )
+                        form_row = cursor.fetchone()
+                        if form_row:
+                            try:
+                                icons = json.loads(form_row[0]) if form_row[0] else []
+                            except json.JSONDecodeError:
+                                icons = []
+                            if icons:
+                                icon = icons[0]
+                            elif form_row[1]:
+                                icon = form_row[1]
+                    except Exception:
+                        icon = None
+                    bosses.append(
+                        {
+                            "id": row[0],
+                            "name": row[1],
+                            "raid_group": row[2],
+                            "location": row[3],
+                            "has_multiple_forms": bool(row[4]),
+                            "icon_url": icon,
+                        }
                     )
-                    form_row = cursor.fetchone()
-                    if form_row:
-                        try:
-                            icons = json.loads(form_row[0]) if form_row[0] else []
-                        except json.JSONDecodeError:
-                            icons = []
-                        if icons:
-                            icon = icons[0]
-                        elif form_row[1]:
-                            icon = form_row[1]
-                except Exception:
-                    icon = None
-                bosses.append(
-                    {
-                        "id": row[0],
-                        "name": row[1],
-                        "raid_group": row[2],
-                        "location": row[3],
-                        "has_multiple_forms": bool(row[4]),
-                        "icon_url": icon,
-                    }
-                )
 
             return bosses
         except Exception as e:


### PR DESCRIPTION
## Summary
- ensure `get_all_bosses` loops correctly when reading from the boss database

## Testing
- `pip install -q -r backend/requirements.txt`
- `PYTHONPATH=backend pytest backend/app/testing/test_database.py -q`
- `npm test` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68455df7b688832ea841e19ff78e9524