### PR TITLE
Split database workflow

### DIFF
--- a/.github/workflows/generate-boss-database.yml
+++ b/.github/workflows/generate-boss-database.yml
@@ -1,4 +1,4 @@
-name: Generate Databases
+name: Generate Boss Database
 
 on:
   schedule:
@@ -8,38 +8,26 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    
+
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
           python-version: '3.11'
           cache: 'pip'
           cache-dependency-path: 'backend/requirements.txt'
-      
+
       - name: Install dependencies
         run: |
           pip install -r backend/requirements.txt
-          
-      - name: Generate valid item list
-        run: |
-          cd backend/webscraper/runescape-items/
-          python generate_valid_items.py
-      
-      - name: Run item scraper
-        run: |
-          cd backend/webscraper/runescape-items/
-          python osrs_item_scraper.py
-      
+
       - name: Run boss scraper
         run: python backend/webscraper/runescape-bosses/extract.py
-      
-      - name: Upload databases
+
+      - name: Upload boss database
         uses: actions/upload-artifact@v4
         with:
-          name: osrs-databases
-          path: |
-            backend/webscraper/runescape-items/*.db
-            backend/webscraper/runescape-bosses/osrs_bosses.db
+          name: osrs-boss-database
+          path: backend/webscraper/runescape-bosses/osrs_bosses.db

--- a/.github/workflows/generate-item-database.yml
+++ b/.github/workflows/generate-item-database.yml
@@ -1,0 +1,40 @@
+name: Generate Item Database
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'  # Runs weekly on Sunday at midnight
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: 'backend/requirements.txt'
+
+      - name: Install dependencies
+        run: |
+          pip install -r backend/requirements.txt
+
+      - name: Generate valid item list
+        run: |
+          cd backend/webscraper/runescape-items/
+          python generate_valid_items.py
+
+      - name: Run item scraper
+        run: |
+          cd backend/webscraper/runescape-items/
+          python osrs_item_scraper.py
+
+      - name: Upload item database
+        uses: actions/upload-artifact@v4
+        with:
+          name: osrs-item-database
+          path: backend/webscraper/runescape-items/*.db


### PR DESCRIPTION
## Summary
- split the database generation workflow into two separate workflows
  - `generate-item-database.yml` builds item database
  - `generate-boss-database.yml` builds boss database
- remove the old combined workflow

## Testing
- `npm ci`
- `npm test` *(fails: Jest encountered unexpected tokens)*

------
https://chatgpt.com/codex/tasks/task_e_68455ec3c570832e9cc578b39945da46