### PR TITLE
Add missing preset button and import placeholder

### DIFF
--- a/frontend/src/app/import/page.tsx
+++ b/frontend/src/app/import/page.tsx
@@ -3,7 +3,43 @@ import { useState } from 'react';
 import { useCalculatorStore } from '@/store/calculator-store';
 
 export default function ImportPage() {
-  const [seed, setSeed] = useState('');
+  const placeholderParams = {
+    combat_style: 'melee',
+    strength_level: 75,
+    strength_boost: 0,
+    strength_prayer: 1,
+    attack_level: 75,
+    attack_boost: 0,
+    attack_prayer: 1,
+    melee_strength_bonus: 40,
+    melee_attack_bonus: 60,
+    attack_style_bonus_strength: 3,
+    attack_style_bonus_attack: 0,
+    attack_type: 'slash',
+    void_melee: false,
+    gear_multiplier: 1,
+    special_multiplier: 1,
+    target_defence_level: 100,
+    target_defence_bonus: 20,
+    attack_speed: 2.4,
+    equipment: {
+      head: { id: 1163, name: 'Rune full helm' },
+      body: { id: 1127, name: 'Rune platebody' },
+      legs: { id: 1079, name: 'Rune platelegs' },
+      mainhand: { id: 1333, name: 'Rune scimitar' },
+      offhand: { id: 1201, name: 'Rune kiteshield' },
+      hands: { id: 7462, name: 'Barrows gloves' },
+      feet: { id: 3105, name: 'Climbing boots' },
+      ring: { id: 2550, name: 'Ring of recoil' },
+      cape: { id: 6568, name: 'Obsidian cape' },
+      neck: { id: 1704, name: 'Amulet of glory' },
+      ammo: null,
+    },
+  };
+
+  const defaultSeed = btoa(JSON.stringify(placeholderParams));
+
+  const [seed, setSeed] = useState(defaultSeed);
 
   const handleImport = () => {
     try {

--- a/frontend/src/components/features/calculator/PresetSelector.tsx
+++ b/frontend/src/components/features/calculator/PresetSelector.tsx
@@ -120,6 +120,10 @@ export function PresetSelector({ onPresetLoad }: PresetSelectorProps) {
           </div>
           <Dialog open={saveDialogOpen} onOpenChange={setSaveDialogOpen}>
             <DialogTrigger asChild>
+              <Button size="sm">
+                <Save className="h-4 w-4 mr-2" />
+                Add
+              </Button>
             </DialogTrigger>
             <DialogContent>
               <DialogHeader>
@@ -158,15 +162,11 @@ export function PresetSelector({ onPresetLoad }: PresetSelectorProps) {
           </div>
         ) : (
           <Tabs defaultValue="all">
-            <TabsList className="grid grid-cols-5 mb-4 align-middle w-auto">
+            <TabsList className="grid grid-cols-4 mb-4 align-middle w-auto">
               <TabsTrigger value="all">All</TabsTrigger>
               <TabsTrigger value="melee">Melee</TabsTrigger>
               <TabsTrigger value="ranged">Ranged</TabsTrigger>
               <TabsTrigger value="magic">Magic</TabsTrigger>
-                <Button size="sm">
-                <Save className="h-4 w-4 mr-2" />
-                Save
-              </Button>
             </TabsList>
             {Object.entries(groupedPresets).map(([key, group]) => (
               <TabsContent key={key} value={key} className="space-y-2">


### PR DESCRIPTION
## Summary
- show a button to add loadout presets
- add a default placeholder seed on the import page

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684560c375e8832e8d7959d0b41e3298