### PR TITLE
Add equipped armor and weapon placeholders

### DIFF
--- a/frontend/src/app/import/page.tsx
+++ b/frontend/src/app/import/page.tsx
@@ -35,6 +35,21 @@ export default function ImportPage() {
       neck: { id: 1704, name: 'Amulet of glory' },
       ammo: null,
     },
+    equipped_armor: {
+      head: { id: 1163, name: 'Rune full helm' },
+      body: { id: 1127, name: 'Rune platebody' },
+      legs: { id: 1079, name: 'Rune platelegs' },
+      hands: { id: 7462, name: 'Barrows gloves' },
+      feet: { id: 3105, name: 'Climbing boots' },
+      shield: { id: 1201, name: 'Rune kiteshield' },
+      cape: { id: 6568, name: 'Obsidian cape' },
+      neck: { id: 1704, name: 'Amulet of glory' },
+      ring: { id: 2550, name: 'Ring of recoil' },
+    },
+    equipped_weapon: {
+      mainhand: { id: 1333, name: 'Rune scimitar' },
+      offhand: { id: 1201, name: 'Rune kiteshield' },
+    },
   };
 
   const defaultSeed = btoa(JSON.stringify(placeholderParams));


### PR DESCRIPTION
## Summary
- expand `placeholderParams` in the import page to also include an `equipped_weapon` section

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684562cca824832eb593cb50f0bcaf73