### PR TITLE
Add equipped armor and weapon placeholders

### DIFF
--- a/frontend/src/__tests__/calculator-store.test.ts
+++ b/frontend/src/__tests__/calculator-store.test.ts
@@ -27,4 +27,15 @@ describe('calculator store', () => {
     });
     expect(useCalculatorStore.getState().params.combat_style).toBe('magic');
   });
+
+  it('stores equipment loadout', () => {
+    act(() => {
+      useCalculatorStore.getState().setLoadout({ head: { id: 1, name: 'Bronze helm' } } as any);
+    });
+    expect(useCalculatorStore.getState().loadout.head?.name).toBe('Bronze helm');
+    act(() => {
+      useCalculatorStore.getState().setLoadout({});
+    });
+    expect(Object.keys(useCalculatorStore.getState().loadout).length).toBe(0);
+  });
 });

--- a/frontend/src/app/import/page.tsx
+++ b/frontend/src/app/import/page.tsx
@@ -35,6 +35,21 @@ export default function ImportPage() {
       neck: { id: 1704, name: 'Amulet of glory' },
       ammo: null,
     },
+    equipped_armor: {
+      head: { id: 1163, name: 'Rune full helm' },
+      body: { id: 1127, name: 'Rune platebody' },
+      legs: { id: 1079, name: 'Rune platelegs' },
+      hands: { id: 7462, name: 'Barrows gloves' },
+      feet: { id: 3105, name: 'Climbing boots' },
+      shield: { id: 1201, name: 'Rune kiteshield' },
+      cape: { id: 6568, name: 'Obsidian cape' },
+      neck: { id: 1704, name: 'Amulet of glory' },
+      ring: { id: 2550, name: 'Ring of recoil' },
+    },
+    equipped_weapon: {
+      mainhand: { id: 1333, name: 'Rune scimitar' },
+      offhand: { id: 1201, name: 'Rune kiteshield' },
+    },
   };
 
   const defaultSeed = btoa(JSON.stringify(placeholderParams));
@@ -45,7 +60,12 @@ export default function ImportPage() {
     try {
       const jsonStr = atob(seed.trim());
       const data = JSON.parse(jsonStr);
-      useCalculatorStore.getState().setParams(data);
+      const { equipment, equipped_armor, equipped_weapon, ...params } = data;
+      const loadout = equipment || { ...equipped_armor, ...equipped_weapon };
+      useCalculatorStore.getState().setParams(params);
+      if (loadout) {
+        useCalculatorStore.getState().setLoadout(loadout);
+      }
       alert('Profile imported');
     } catch (e) {
       alert('Invalid seed');

--- a/frontend/src/components/features/calculator/CombinedEquipmentDisplay.tsx
+++ b/frontend/src/components/features/calculator/CombinedEquipmentDisplay.tsx
@@ -48,8 +48,7 @@ interface CombinedEquipmentDisplayProps {
 }
 
 export function CombinedEquipmentDisplay({ onEquipmentUpdate, bossForm }: CombinedEquipmentDisplayProps) {
-  const { params, setParams, gearLocked } = useCalculatorStore();
-  const [loadout, setLoadout] = useState<Record<string, Item | null>>({});
+  const { params, setParams, gearLocked, loadout, setLoadout } = useCalculatorStore();
   const [show2hOption, setShow2hOption] = useState(true);
   const [availableAttackStyles, setAvailableAttackStyles] = useState<string[]>([]);
   const [selectedAttackStyle, setSelectedAttackStyle] = useState<string>('');
@@ -295,7 +294,7 @@ export function CombinedEquipmentDisplay({ onEquipmentUpdate, bossForm }: Combin
   // Handle equipment loadout changes
   const handleUpdateLoadout = useCallback((newLoadout: Record<string, Item | null>) => {
     setLoadout(newLoadout);
-  }, []);
+  }, [setLoadout]);
 
   // Handle attack style selection
   const handleSelectAttackStyle = useCallback((style: string) => {
@@ -326,16 +325,14 @@ export function CombinedEquipmentDisplay({ onEquipmentUpdate, bossForm }: Combin
             className="mb-2" 
             onClick={() => {
               setShow2hOption(prev => !prev);
-              setLoadout(prev => {
-                const copy = { ...prev };
-                if (show2hOption) {
-                  delete copy['2h'];
-                } else {
-                  delete copy['mainhand'];
-                  delete copy['offhand'];
-                }
-                return copy;
-              });
+              const current = { ...loadout };
+              if (show2hOption) {
+                delete current['2h'];
+              } else {
+                delete current['mainhand'];
+                delete current['offhand'];
+              }
+              setLoadout(current);
               
               // Reset weapon stats when switching modes
               setWeaponStats({

--- a/frontend/src/hooks/useDpsCalculator.ts
+++ b/frontend/src/hooks/useDpsCalculator.ts
@@ -14,11 +14,17 @@ export function useDpsCalculator() {
   const switchCombatStyle = useCalculatorStore((s) => s.switchCombatStyle);
   const resetParams = useCalculatorStore((s) => s.resetParams);
   const resetLocks = useCalculatorStore((s) => s.resetLocks);
+  const storeLoadout = useCalculatorStore((s) => s.loadout);
+  const setStoreLoadout = useCalculatorStore((s) => s.setLoadout);
 
   const [activeTab, setActiveTab] = useState<CombatStyle>(params.combat_style);
-  const [currentLoadout, setCurrentLoadout] = useState<Record<string, Item | null>>({});
+  const [currentLoadout, setCurrentLoadout] = useState<Record<string, Item | null>>(storeLoadout);
   const [currentBossForm, setCurrentBossForm] = useState<BossForm | null>(null);
   const [appliedPassiveEffects, setAppliedPassiveEffects] = useState<any>(null);
+
+  useEffect(() => {
+    setCurrentLoadout(storeLoadout);
+  }, [storeLoadout]);
 
   const calculateEffects = useCallback(() => {
     return calculatePassiveEffectBonuses(params, currentLoadout, currentBossForm);
@@ -112,6 +118,7 @@ export function useDpsCalculator() {
     setResults(null);
     setAppliedPassiveEffects(null);
     setCurrentLoadout({});
+    setStoreLoadout({});
     setCurrentBossForm(null);
     toast.success('Calculator reset to defaults');
   };
@@ -124,6 +131,7 @@ export function useDpsCalculator() {
 
   const handleEquipmentUpdate = (loadout: Record<string, Item | null>) => {
     setCurrentLoadout(loadout);
+    setStoreLoadout(loadout);
   };
 
   const handleBossUpdate = (bossForm: BossForm | null) => {

--- a/frontend/src/store/calculator-store.ts
+++ b/frontend/src/store/calculator-store.ts
@@ -1,11 +1,12 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
-import { 
-  CalculatorParams, 
+import {
+  CalculatorParams,
   DpsResult,
   MeleeCalculatorParams,
   RangedCalculatorParams,
-  MagicCalculatorParams
+  MagicCalculatorParams,
+  Item
 } from '@/types/calculator';
 
 interface CalculatorState {
@@ -18,6 +19,7 @@ interface CalculatorState {
   }>;
   gearLocked: boolean;
   bossLocked: boolean;
+  loadout: Record<string, Item | null>;
 
   setParams: (params: Partial<CalculatorParams>) => void;
   switchCombatStyle: (style: 'melee' | 'ranged' | 'magic') => void;
@@ -31,6 +33,7 @@ interface CalculatorState {
   lockBoss: () => void;
   unlockBoss: () => void;
   resetLocks: () => void;
+  setLoadout: (loadout: Record<string, Item | null>) => void;
 }
 
 const defaultMeleeParams: MeleeCalculatorParams = {
@@ -109,6 +112,7 @@ export const useCalculatorStore = create<CalculatorState>()(
       comparisonResults: [],
       gearLocked: false,
       bossLocked: false,
+      loadout: {},
 
       setParams: (newParams: Partial<CalculatorParams>) => set((state): Partial<CalculatorState> => {
         const currentStyle = state.params.combat_style;
@@ -195,14 +199,16 @@ export const useCalculatorStore = create<CalculatorState>()(
       unlockGear: () => set({ gearLocked: false }),
       lockBoss: () => set({ bossLocked: true }),
       unlockBoss: () => set({ bossLocked: false }),
-      resetLocks: () => set({ gearLocked: false, bossLocked: false })
+      resetLocks: () => set({ gearLocked: false, bossLocked: false }),
+      setLoadout: (loadout) => set({ loadout })
     }),
     {
       name: 'osrs-calculator-storage',
-      partialize: (state) => ({ 
+      partialize: (state) => ({
         params: state.params,
         gearLocked: state.gearLocked,
-        bossLocked: state.bossLocked
+        bossLocked: state.bossLocked,
+        loadout: state.loadout
       })
     }
   )


### PR DESCRIPTION
## Summary
- expand `placeholderParams` in the import page to also include an `equipped_weapon` section
- when importing, save the loadout and params to the calculator store
- persist equipment in the calculator store and sync the loadout across the UI

## Testing
- `pytest -q` *(fails: Client.__init__ got unexpected keyword argument 'app')*

------
https://chatgpt.com/codex/tasks/task_e_684562cca824832eb593cb50f0bcaf73