### PR TITLE
Update default equipment config and seed import

### DIFF
--- a/frontend/src/components/features/calculator/CombinedEquipmentDisplay.tsx
+++ b/frontend/src/components/features/calculator/CombinedEquipmentDisplay.tsx
@@ -49,7 +49,8 @@ interface CombinedEquipmentDisplayProps {
 
 export function CombinedEquipmentDisplay({ onEquipmentUpdate, bossForm }: CombinedEquipmentDisplayProps) {
   const { params, setParams, gearLocked, loadout, setLoadout } = useCalculatorStore();
-  const [show2hOption, setShow2hOption] = useState(true);
+  // Start with 1H + Shield by default
+  const [show2hOption, setShow2hOption] = useState(false);
   const [availableAttackStyles, setAvailableAttackStyles] = useState<string[]>([]);
   const [selectedAttackStyle, setSelectedAttackStyle] = useState<string>('');
   const [weaponStats, setWeaponStats] = useState<{

--- a/frontend/src/components/features/calculator/EquipmentLoadout.tsx
+++ b/frontend/src/components/features/calculator/EquipmentLoadout.tsx
@@ -66,7 +66,8 @@ export function EquipmentLoadout({ onEquipmentUpdate }: EquipmentLoadoutProps) {
   const [loadout, setLoadout] = useState<Record<string, Item | null>>({});
   const [isExpanded, setIsExpanded] = useState(true);
   const [selectedBossForm, setSelectedBossForm] = useState(null);
-  const [show2hOption, setShow2hOption] = useState(true); // Add missing state
+  // Default to 1H weapon with offhand
+  const [show2hOption, setShow2hOption] = useState(false); // Add missing state
 
   const [totals, setTotals] = useState<Record<string, number>>({
     stab: 0,


### PR DESCRIPTION
## Summary
- default all equipment screens to 1h+offhand instead of 2h
- reference item ids in the placeholder seed
- when importing a seed, fetch items from the API so full stats are loaded

## Testing
- `npx -y jest --runInBand` *(fails: Preset ts-jest/presets/js-with-ts-esm not found)*
- `python app/testing/UnitTest.py`

------
https://chatgpt.com/codex/tasks/task_e_6845671c1020832ebe2b0b1cefb60c7a