### PR TITLE
UI tweaks for calculator headers and toggles

### DIFF
--- a/frontend/src/components/features/calculator/BossSelector.tsx
+++ b/frontend/src/components/features/calculator/BossSelector.tsx
@@ -299,20 +299,18 @@ export function BossSelector({ onSelectBoss, onSelectForm }: BossSelectorProps) 
   return (
     <Card>
       <CardHeader>
-        <div className="flex justify-between items-center">
-          <div>
-            <CardTitle>Target Selection</CardTitle>
-            <CardDescription>Select a boss to calculate DPS against</CardDescription>
-          </div>
-          {selectedBoss && (
+        <CardTitle>Target Selection</CardTitle>
+        <CardDescription>Select a boss to calculate DPS against</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {selectedBoss && (
+          <div className="flex justify-end">
             <Button variant="outline" size="sm" onClick={handleResetBoss}>
               <RotateCcw className="h-4 w-4 mr-2" />
               Reset
             </Button>
-          )}
-        </div>
-      </CardHeader>
-      <CardContent className="space-y-4">
+          </div>
+        )}
         {bossLocked && (
           <Alert className="mb-4 border-blue-200 dark:border-blue-800 bg-blue-100 dark:bg-blue-900">
             <AlertDescription>
@@ -423,12 +421,12 @@ export function BossSelector({ onSelectBoss, onSelectForm }: BossSelectorProps) 
 
         {/* Display the selected boss stats if a form is selected */}
         {selectedForm && (
-          <div className="pt-2 space-y-2">
+          <div className="pt-2 space-y-2 flex flex-col items-center">
             {(selectedForm.icons?.[0] || selectedForm.image_url) && (
               <img
                 src={selectedForm.icons?.[0] || selectedForm.image_url}
                 alt="icon"
-                className="w-10 h-10"
+                className="w-24 h-24"
               />
             )}
             <h4 className="text-sm font-semibold">Target Stats</h4>

--- a/frontend/src/components/features/calculator/DirectBossSelector.tsx
+++ b/frontend/src/components/features/calculator/DirectBossSelector.tsx
@@ -213,20 +213,18 @@ export function DirectBossSelector({ onSelectBoss, onSelectForm }: DirectBossSel
   return (
     <Card>
       <CardHeader>
-        <div className="flex justify-between items-center">
-          <div>
-            <CardTitle>Target Selection</CardTitle>
-            <CardDescription>Select a boss to calculate DPS against</CardDescription>
-          </div>
-          {selectedBoss && (
+        <CardTitle>Target Selection</CardTitle>
+        <CardDescription>Select a boss to calculate DPS against</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {selectedBoss && (
+          <div className="flex justify-end">
             <Button variant="outline" size="sm" onClick={handleResetBoss}>
               <RotateCcw className="h-4 w-4 mr-2" />
               Reset
             </Button>
-          )}
-        </div>
-      </CardHeader>
-      <CardContent className="space-y-4">
+          </div>
+        )}
         {bossLocked && (
           <Alert className="mb-4">
             <AlertDescription>
@@ -331,12 +329,12 @@ export function DirectBossSelector({ onSelectBoss, onSelectForm }: DirectBossSel
 
         {/* Display the selected boss stats */}
         {selectedForm && (
-          <div className="pt-2 space-y-2 bg-slate-100 dark:bg-slate-800 p-3 rounded-md">
+          <div className="pt-2 space-y-2 bg-slate-100 dark:bg-slate-800 p-3 rounded-md flex flex-col items-center">
             {(selectedForm.icons?.[0] || selectedForm.image_url) && (
               <img
                 src={selectedForm.icons?.[0] || selectedForm.image_url}
                 alt="icon"
-                className="w-10 h-10"
+                className="w-24 h-24"
               />
             )}
             <h4 className="text-sm font-semibold">Target Stats</h4>

--- a/frontend/src/components/features/calculator/DpsComparison.tsx
+++ b/frontend/src/components/features/calculator/DpsComparison.tsx
@@ -118,18 +118,14 @@ export function DpsComparison() {
   return (
     <Card>
       <CardHeader>
-        <CardTitle className="flex justify-center items-center">
-          <span>DPS Comparison</span>
-          <Button 
-            variant="outline" 
-            size="sm" 
-            onClick={clearComparisonResults}
-          >
-            Clear All
-          </Button>
-        </CardTitle>
+        <CardTitle className="text-center">DPS Comparison</CardTitle>
       </CardHeader>
       <CardContent>
+        <div className="flex justify-end mb-2">
+          <Button variant="outline" size="sm" onClick={clearComparisonResults}>
+            Clear All
+          </Button>
+        </div>
         <div className="flex gap-2 mb-4 justify-center items-center">
           <Input
             value={label}

--- a/frontend/src/components/features/calculator/EquipmentLoadout.tsx
+++ b/frontend/src/components/features/calculator/EquipmentLoadout.tsx
@@ -413,21 +413,14 @@ export function EquipmentLoadout({ onEquipmentUpdate }: EquipmentLoadoutProps) {
         </div>
         <div className="flex space-x-2">
           {/* Add weapon toggle button */}
-          <Button 
-            variant="outline" 
-            size="sm" 
+          <Button
+            variant="outline"
+            size="sm"
             onClick={toggleWeaponDisplay}
             title={show2hOption ? "Switch to 1H + Shield" : "Switch to 2H weapon"}
           >
             {show2hOption ? <Shield className="h-4 w-4" /> : <Sword className="h-4 w-4" />}
           </Button>
-          
-          {Object.values(loadout).some(item => item !== null) && (
-            <Button variant="outline" size="sm" onClick={handleResetEquipment}>
-              <RotateCcw className="h-4 w-4 mr-2" />
-              Reset
-            </Button>
-          )}
           <Button variant="ghost" size="sm" onClick={() => setIsExpanded(!isExpanded)}>
             {isExpanded ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
           </Button>
@@ -436,6 +429,14 @@ export function EquipmentLoadout({ onEquipmentUpdate }: EquipmentLoadoutProps) {
 
       {isExpanded && (
         <CardContent>
+          {Object.values(loadout).some(item => item !== null) && (
+            <div className="flex justify-end mb-2">
+              <Button variant="outline" size="sm" onClick={handleResetEquipment}>
+                <RotateCcw className="h-4 w-4 mr-2" />
+                Reset
+              </Button>
+            </div>
+          )}
           {gearLocked && (
             <Alert className="mb-4 border-blue-200 dark:border-blue-800 bg-blue-100 dark:bg-blue-900">
               <AlertDescription>

--- a/frontend/src/components/features/calculator/EquipmentPanel.tsx
+++ b/frontend/src/components/features/calculator/EquipmentPanel.tsx
@@ -54,19 +54,20 @@ export function EquipmentPanel({ onEquipmentUpdate, bossForm }: EquipmentPanelPr
           <CardTitle>Equipment</CardTitle>
           <CardDescription>Configure your gear and attack style</CardDescription>
         </div>
-        
-        {Object.keys(currentLoadout).length > 0 && (
-          <Button 
-            variant="outline" 
-            size="sm" 
-            onClick={handleResetEquipment}
-          >
-            Reset Equipment
-          </Button>
-        )}
       </CardHeader>
 
       <CardContent>
+        {Object.keys(currentLoadout).length > 0 && (
+          <div className="flex justify-end mb-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleResetEquipment}
+            >
+              Reset Equipment
+            </Button>
+          </div>
+        )}
         {Object.keys(currentLoadout).length === 0 && (
           <Alert className="mb-4">
             <AlertDescription>

--- a/frontend/src/components/features/calculator/PresetSelector.tsx
+++ b/frontend/src/components/features/calculator/PresetSelector.tsx
@@ -113,11 +113,11 @@ export function PresetSelector({ onPresetLoad }: PresetSelectorProps) {
   return (
     <Card className="w-full">
       <CardHeader>
-        <div className="flex justify-between items-center">
-          <div>
-            <CardTitle>Loadout Presets</CardTitle>
-            <CardDescription>Save and load your equipment setups</CardDescription>
-          </div>
+        <CardTitle>Loadout Presets</CardTitle>
+        <CardDescription>Save and load your equipment setups</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="flex justify-end mb-4">
           <Dialog open={saveDialogOpen} onOpenChange={setSaveDialogOpen}>
             <DialogTrigger asChild>
               <Button size="sm">
@@ -153,8 +153,6 @@ export function PresetSelector({ onPresetLoad }: PresetSelectorProps) {
             </DialogContent>
           </Dialog>
         </div>
-      </CardHeader>
-      <CardContent>
         {presets.length === 0 ? (
           <div className="text-center py-8 text-muted-foreground">
             <p>You haven&apos;t saved any presets yet.</p>

--- a/frontend/src/components/ui/switch.tsx
+++ b/frontend/src/components/ui/switch.tsx
@@ -13,7 +13,7 @@ function Switch({
     <SwitchPrimitive.Root
       data-slot="switch"
       className={cn(
-        "peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-input focus-visible:border-ring focus-visible:ring-ring/50 dark:data-[state=unchecked]:bg-input/80 inline-flex h-[1.15rem] w-8 shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        "peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-muted focus-visible:border-ring focus-visible:ring-ring/50 dark:data-[state=unchecked]:bg-muted/50 inline-flex h-[1.15rem] w-8 shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
         className
       )}
       {...props}

--- a/frontend/src/components/ui/toggle.tsx
+++ b/frontend/src/components/ui/toggle.tsx
@@ -7,7 +7,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const toggleVariants = cva(
-  "inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium hover:bg-muted hover:text-muted-foreground disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 [&_svg]:shrink-0 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] outline-none transition-[color,box-shadow] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive whitespace-nowrap",
+  "inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium hover:bg-muted hover:text-muted-foreground disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-primary data-[state=on]:text-primary-foreground data-[state=off]:bg-muted/50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 [&_svg]:shrink-0 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] outline-none transition-[color,box-shadow] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive whitespace-nowrap",
   {
     variants: {
       variant: {


### PR DESCRIPTION
## Summary
- move header action buttons into card content
- adjust toggle styles for clearer inactive state
- center boss images and enlarge them

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68456f479304832ebc15906ad8673341