### PR TITLE
Improve toggle visuals

### DIFF
--- a/frontend/src/components/features/calculator/CalculatorForms.tsx
+++ b/frontend/src/components/features/calculator/CalculatorForms.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Button } from '@/components/ui/button';
-import { Switch } from '@/components/ui/switch';
+import { ToggleBox } from '@/components/ui/toggle-box';
 import { Label } from '@/components/ui/label';
 import { useState } from 'react';
 import { RotateCcw, Sword, Target, Zap } from 'lucide-react';
@@ -30,7 +30,11 @@ export function CalculatorForms({
   return (
     <div className="w-full mb-6">
       <div className="flex items-center space-x-2 mb-4">
-        <Switch id="manual-toggle" checked={showManual} onCheckedChange={setShowManual} />
+        <ToggleBox
+          id="manual-toggle"
+          pressed={showManual}
+          onPressedChange={setShowManual}
+        />
         <Label htmlFor="manual-toggle">Show Manual Inputs</Label>
         
       </div>

--- a/frontend/src/components/features/calculator/DefenceReductionPanel.tsx
+++ b/frontend/src/components/features/calculator/DefenceReductionPanel.tsx
@@ -3,7 +3,7 @@ import { useCalculatorStore } from '@/store/calculator-store';
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Switch } from '@/components/ui/switch';
+import { ToggleBox } from '@/components/ui/toggle-box';
 import { useRef } from 'react';
 import { 
   Shield
@@ -124,10 +124,10 @@ export function DefenceReductionPanel() {
 
         {toggleEffects.map(({ key, label }) => (
           <div key={key} className="flex items-center gap-2">
-            <Switch
-              checked={!!params[key]}
-              onCheckedChange={(value) => setParams({ [key]: value })}
-              className="data-[state=checked]:bg-rs-gold"
+            <ToggleBox
+              pressed={!!params[key]}
+              onPressedChange={(value) => setParams({ [key]: value })}
+              className="data-[state=on]:bg-rs-gold"
             />
             <Label className="text-sm font-medium whitespace-nowrap text-rs-gold">{label}</Label>
           </div>

--- a/frontend/src/components/ui/switch.tsx
+++ b/frontend/src/components/ui/switch.tsx
@@ -21,7 +21,7 @@ function Switch({
       <SwitchPrimitive.Thumb
         data-slot="switch-thumb"
         className={cn(
-          "bg-background dark:data-[state=unchecked]:bg-foreground dark:data-[state=checked]:bg-primary-foreground pointer-events-none block size-4 rounded-full ring-0 transition-transform data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0"
+          "pointer-events-none block size-4 rounded-full ring-0 border-2 border-rs-gold data-[state=checked]:bg-rs-gold data-[state=unchecked]:bg-transparent transition-transform data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0"
         )}
       />
     </SwitchPrimitive.Root>

--- a/frontend/src/components/ui/toggle-box.tsx
+++ b/frontend/src/components/ui/toggle-box.tsx
@@ -1,0 +1,21 @@
+"use client"
+
+import * as React from "react"
+import * as TogglePrimitive from "@radix-ui/react-toggle"
+
+import { cn } from "@/lib/utils"
+
+function ToggleBox({ className, ...props }: React.ComponentProps<typeof TogglePrimitive.Root>) {
+  return (
+    <TogglePrimitive.Root
+      data-slot="toggle-box"
+      className={cn(
+        "inline-flex size-4 items-center justify-center rounded-full border-2 border-rs-gold data-[state=on]:bg-rs-gold data-[state=off]:bg-transparent focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] outline-none transition-colors disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { ToggleBox }

--- a/frontend/src/components/ui/toggle.tsx
+++ b/frontend/src/components/ui/toggle.tsx
@@ -7,7 +7,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const toggleVariants = cva(
-  "inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium hover:bg-muted hover:text-muted-foreground disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-primary data-[state=on]:text-primary-foreground data-[state=off]:bg-muted/50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 [&_svg]:shrink-0 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] outline-none transition-[color,box-shadow] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive whitespace-nowrap",
+  "inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium hover:bg-muted hover:text-muted-foreground disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-primary data-[state=on]:text-primary-foreground data-[state=off]:bg-muted/50 data-[state=on]:ring-2 data-[state=on]:ring-ring [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 [&_svg]:shrink-0 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] outline-none transition-[color,box-shadow] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive whitespace-nowrap",
   {
     variants: {
       variant: {


### PR DESCRIPTION
## Summary
- replace Switch uses for manual inputs and defense reduction with new `ToggleBox`
- add simple `ToggleBox` component with gold ring styling

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845738ac704832e9e67a39be11ce4ce