### PR TITLE
Improve equipment panel UX

### DIFF
--- a/frontend/src/components/features/calculator/CombatStatsSummary.tsx
+++ b/frontend/src/components/features/calculator/CombatStatsSummary.tsx
@@ -15,6 +15,22 @@ export function CombatStatsSummary({
   selectedAttackStyle,
   getAttackStylesForDisplay
 }: CombatStatsSummaryProps) {
+  const totalDefence = {
+    stab: 0,
+    slash: 0,
+    crush: 0,
+    magic: 0,
+    ranged: 0,
+  };
+  Object.values(loadout).forEach((item) => {
+    const def = item?.combat_stats?.defence_bonuses;
+    if (!def) return;
+    totalDefence.stab += def.stab || 0;
+    totalDefence.slash += def.slash || 0;
+    totalDefence.crush += def.crush || 0;
+    totalDefence.magic += def.magic || 0;
+    totalDefence.ranged += def.ranged || 0;
+  });
   return (
     <div className="mt-4 p-3 bg-slate-100 dark:bg-slate-800 rounded-md">
       <h4 className="font-medium text-sm mb-2">Combat Setup:</h4>
@@ -190,6 +206,29 @@ export function CombatStatsSummary({
             <span className="font-medium">
               +{params.attack_style_bonus_strength || 0}
             </span>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-3 gap-x-4 gap-y-1 text-xs mt-2">
+          <div>
+            <span className="text-muted-foreground">Def Stab:</span>{' '}
+            <span className="font-medium">{totalDefence.stab}</span>
+          </div>
+          <div>
+            <span className="text-muted-foreground">Def Slash:</span>{' '}
+            <span className="font-medium">{totalDefence.slash}</span>
+          </div>
+          <div>
+            <span className="text-muted-foreground">Def Crush:</span>{' '}
+            <span className="font-medium">{totalDefence.crush}</span>
+          </div>
+          <div>
+            <span className="text-muted-foreground">Def Magic:</span>{' '}
+            <span className="font-medium">{totalDefence.magic}</span>
+          </div>
+          <div>
+            <span className="text-muted-foreground">Def Ranged:</span>{' '}
+            <span className="font-medium">{totalDefence.ranged}</span>
           </div>
         </div>
       </div>

--- a/frontend/src/components/features/calculator/CombinedEquipmentDisplay.tsx
+++ b/frontend/src/components/features/calculator/CombinedEquipmentDisplay.tsx
@@ -49,7 +49,7 @@ interface CombinedEquipmentDisplayProps {
 }
 
 export function CombinedEquipmentDisplay({ onEquipmentUpdate, bossForm }: CombinedEquipmentDisplayProps) {
-  const { params, setParams, gearLocked, loadout, setLoadout } = useCalculatorStore();
+  const { params, setParams, gearLocked, loadout, setLoadout, resetParams, resetLocks } = useCalculatorStore();
   // Start with 1H + Shield by default
   const [show2hOption, setShow2hOption] = useState(false);
   const [availableAttackStyles, setAvailableAttackStyles] = useState<string[]>([]);
@@ -61,6 +61,12 @@ export function CombinedEquipmentDisplay({ onEquipmentUpdate, bossForm }: Combin
     attackStyles: {},
     baseAttackSpeed: 2.4 // Default 4 ticks
   });
+
+  const handleResetEquipment = () => {
+    setLoadout({});
+    resetParams();
+    resetLocks();
+  };
   
   const combatStyle = params.combat_style;
 
@@ -360,6 +366,15 @@ export function CombinedEquipmentDisplay({ onEquipmentUpdate, bossForm }: Combin
       </CardHeader>
 
       <CardContent>
+        {Object.keys(loadout).length > 0 && (
+          <div className="flex justify-end mb-2">
+            <Button variant="outline" size="sm" onClick={handleResetEquipment}
+            >
+              Reset Equipment
+            </Button>
+          </div>
+        )}
+
         {gearLocked && (
           <Alert className="mb-4 border-blue-300 dark:border-blue-800 bg-blue-100 dark:bg-blue-900">
             <AlertDescription>Gear bonuses are locked in for simulation.</AlertDescription>

--- a/frontend/src/components/features/calculator/DirectBossSelector.tsx
+++ b/frontend/src/components/features/calculator/DirectBossSelector.tsx
@@ -247,7 +247,7 @@ export function DirectBossSelector({ onSelectBoss, onSelectForm }: DirectBossSel
             <Command className="rounded-lg border shadow-md pl-7">
               <CommandInput
                 placeholder="Search bosses..."
-                className="h-9"
+                className="h-9 pl-2"
                 value={searchQuery}
                 onValueChange={(value) => {
                   setSearchQuery(value);
@@ -334,7 +334,7 @@ export function DirectBossSelector({ onSelectBoss, onSelectForm }: DirectBossSel
               <img
                 src={selectedForm.icons?.[0] || selectedForm.image_url}
                 alt="icon"
-                className="w-24 h-24"
+                className="w-28 h-28 mb-2"
               />
             )}
             <h4 className="text-sm font-semibold">Target Stats</h4>

--- a/frontend/src/components/features/calculator/EquipmentGrid.tsx
+++ b/frontend/src/components/features/calculator/EquipmentGrid.tsx
@@ -106,7 +106,7 @@ export function EquipmentGrid({ loadout, show2hOption, combatStyle, onUpdateLoad
     return (
       <>
         <p className="font-bold">{item.name}</p>
-        {(item.combat_stats && (slot === 'mainhand' || slot === '2h')) && (
+        {item.combat_stats && (
           <div className="text-xs mt-1">
             {combatStyle === 'melee' && (
               <>
@@ -136,7 +136,7 @@ export function EquipmentGrid({ loadout, show2hOption, combatStyle, onUpdateLoad
 
   return (
     <>
-      <div className="grid grid-cols-3 grid-rows-5 gap-2 justify-items-center mb-4">
+      <div className="grid grid-cols-3 grid-rows-5 gap-2 justify-items-center mb-4 px-4">
         {getDisplaySlots().map(({ slot, name, position }) => (
           <div
             key={slot}
@@ -169,9 +169,6 @@ export function EquipmentGrid({ loadout, show2hOption, combatStyle, onUpdateLoad
                 </TooltipContent>
               </Tooltip>
             </TooltipProvider>
-            <div className="text-xs truncate w-full text-center">
-              {loadout[slot]?.name || name}
-            </div>
           </div>
         ))}
       </div>

--- a/frontend/src/components/features/calculator/ImprovedDpsCalculator.tsx
+++ b/frontend/src/components/features/calculator/ImprovedDpsCalculator.tsx
@@ -106,8 +106,10 @@ export function ImprovedDpsCalculator() {
           <PresetSelector onPresetLoad={() => toast.success("Preset loaded successfully!")} />
 
         </div>
-           {/* Full-width comparison table at the bottom */}
+        {/* Full-width comparison table at the bottom */}
+        <div className="lg:col-span-2">
           <DpsComparison />
+        </div>
       </div>
       
     </div>


### PR DESCRIPTION
## Summary
- tighten equipment grid spacing and clean up tooltip
- add reset loadout button
- show defensive totals in combat stats
- tweak boss selector layout and image sizing
- keep DPS comparison aligned with other panels

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684575bea5e4832e8379187925c424de