### PR TITLE
Adjust UI toggles and layout

### DIFF
--- a/frontend/src/components/features/calculator/CalculatorForms.tsx
+++ b/frontend/src/components/features/calculator/CalculatorForms.tsx
@@ -29,7 +29,7 @@ export function CalculatorForms({
 
   return (
     <div className="w-full mb-6">
-      <div className="flex items-center space-x-2 mb-4">
+      <div className="flex items-center gap-4 mb-4">
         <ToggleBox
           id="manual-toggle"
           pressed={showManual}

--- a/frontend/src/components/features/calculator/CombinedEquipmentDisplay.tsx
+++ b/frontend/src/components/features/calculator/CombinedEquipmentDisplay.tsx
@@ -3,7 +3,8 @@ import {
   Card, CardContent, CardDescription, CardHeader, CardTitle
 } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { Toggle } from '@/components/ui/toggle';
+import { Switch } from '@/components/ui/switch';
+import { Label } from '@/components/ui/label';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { useCalculatorStore } from '@/store/calculator-store';
 import { Item, CalculatorParams, BossForm } from '@/types/calculator';
@@ -327,30 +328,32 @@ export function CombinedEquipmentDisplay({ onEquipmentUpdate, bossForm }: Combin
           <CardDescription>Manage and inspect your gear</CardDescription>
         </div>
         <div className="flex flex-col items-center justify-center">
-          <Toggle
-            className="mb-2"
-            pressed={show2hOption}
-            onPressedChange={() => {
-              setShow2hOption(prev => !prev);
-              const current = { ...loadout };
-              if (show2hOption) {
-                delete current['2h'];
-              } else {
-                delete current['mainhand'];
-                delete current['offhand'];
-              }
-              setLoadout(current);
+          <div className="flex items-center mb-2 gap-2">
+            <Switch
+              id="use-2h"
+              checked={show2hOption}
+              onCheckedChange={(checked) => {
+                setShow2hOption(checked);
+                const current = { ...loadout };
+                if (checked) {
+                  delete current['mainhand'];
+                  delete current['offhand'];
+                } else {
+                  delete current['2h'];
+                }
+                setLoadout(current);
 
-              // Reset weapon stats when switching modes
-              setWeaponStats({
-                attackStyles: {},
-                baseAttackSpeed: 2.4
-              });
-            }}
-            size="sm"
-          >
-            {show2hOption ? 'Use 1H + Shield' : 'Use 2H'}
-          </Toggle>
+                setWeaponStats({
+                  attackStyles: {},
+                  baseAttackSpeed: 2.4,
+                });
+              }}
+              className="mr-2"
+            />
+            <Label htmlFor="use-2h" className="text-sm">
+              {show2hOption ? 'Use 1H + Shield' : 'Use 2H'}
+            </Label>
+          </div>
           
           {/* Attack style selector component */}
           <AttackStyleSelector

--- a/frontend/src/components/features/calculator/ImprovedDpsCalculator.tsx
+++ b/frontend/src/components/features/calculator/ImprovedDpsCalculator.tsx
@@ -75,6 +75,13 @@ export function ImprovedDpsCalculator() {
         </CardContent>
       </Card>
 
+      {Object.keys(currentLoadout).length > 0 && (
+        <PassiveEffectsDisplay
+          loadout={currentLoadout}
+          target={currentBossForm}
+        />
+      )}
+
       {/* Two-column layout for middle sections */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* Left column */}
@@ -84,9 +91,9 @@ export function ImprovedDpsCalculator() {
           {/* Prayer/Potion selector */}
           <PrayerPotionSelector />
         </div>
-        
+
         {/* Right column */}
-        <div className="space-y-6">
+        <div className="space-y-6 flex flex-col">
           {/* Target selection section */}
           <DirectBossSelector onSelectForm={handleBossUpdate} />
           
@@ -96,14 +103,12 @@ export function ImprovedDpsCalculator() {
               <DefenceReductionPanel />
             </CardContent>
           </Card>
-          
-          {/* Display passive effects relevant to the current loadout and boss */}
-          {Object.keys(currentLoadout).length > 0 && (
-            <PassiveEffectsDisplay loadout={currentLoadout} target={currentBossForm} />
-          )}
-          
+
           {/* Preset selector */}
-          <PresetSelector onPresetLoad={() => toast.success("Preset loaded successfully!")} />
+          <PresetSelector
+            className="flex-grow"
+            onPresetLoad={() => toast.success("Preset loaded successfully!")}
+          />
 
         </div>
         {/* Full-width comparison table at the bottom */}

--- a/frontend/src/components/features/calculator/PrayerPotionSelector.tsx
+++ b/frontend/src/components/features/calculator/PrayerPotionSelector.tsx
@@ -276,7 +276,7 @@ export function PrayerPotionSelector() {
                 </Select>
               </div>
               
-              <div className="flex items-center space-x-2 pt-2">
+              <div className="flex items-center gap-4 pt-2">
                 <ToggleBox
                   id="preserve"
                   pressed={preserveActive}

--- a/frontend/src/components/features/calculator/PresetSelector.tsx
+++ b/frontend/src/components/features/calculator/PresetSelector.tsx
@@ -24,8 +24,11 @@ import { useCalculatorStore } from '@/store/calculator-store';
 import { CombatStyle, CalculatorParams } from '@/types/calculator';
 import { Badge } from '@/components/ui/badge';
 
+import { cn } from '@/lib/utils';
+
 interface PresetSelectorProps {
   onPresetLoad?: () => void;
+  className?: string;
 }
 
 interface Preset {
@@ -36,7 +39,7 @@ interface Preset {
   params: CalculatorParams;
 }
 
-export function PresetSelector({ onPresetLoad }: PresetSelectorProps) {
+export function PresetSelector({ onPresetLoad, className }: PresetSelectorProps) {
   const { params, setParams, switchCombatStyle } = useCalculatorStore();
   const [hasMounted, setHasMounted] = useState(false);
   const [saveDialogOpen, setSaveDialogOpen] = useState(false);
@@ -111,7 +114,7 @@ export function PresetSelector({ onPresetLoad }: PresetSelectorProps) {
   if (!hasMounted) return null;
 
   return (
-    <Card className="w-full">
+    <Card className={cn('w-full flex flex-col', className)}>
       <CardHeader>
         <CardTitle>Loadout Presets</CardTitle>
         <CardDescription>Save and load your equipment setups</CardDescription>


### PR DESCRIPTION
## Summary
- increase gap for manual inputs and preserve toggles
- revert 2H equipment option back to a switch
- show passive effects above equipment/boss selectors
- allow preset card to stretch and fill column

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68457d444dc8832e94ab22ef6821cf8f