### PR TITLE
UI layout fixes

### DIFF
--- a/frontend/src/components/features/calculator/BossSelector.tsx
+++ b/frontend/src/components/features/calculator/BossSelector.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { Search, Loader2, RotateCcw } from 'lucide-react';
+import { Command as CommandPrimitive } from 'cmdk';
 import { 
   Command, 
   CommandEmpty, 
@@ -303,14 +304,6 @@ export function BossSelector({ onSelectBoss, onSelectForm }: BossSelectorProps) 
         <CardDescription>Select a boss to calculate DPS against</CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
-        {selectedBoss && (
-          <div className="flex justify-end">
-            <Button variant="outline" size="sm" onClick={handleResetBoss}>
-              <RotateCcw className="h-4 w-4 mr-2" />
-              Reset
-            </Button>
-          </div>
-        )}
         {bossLocked && (
           <Alert className="mb-4 border-blue-200 dark:border-blue-800 bg-blue-100 dark:bg-blue-900">
             <AlertDescription>
@@ -343,7 +336,12 @@ export function BossSelector({ onSelectBoss, onSelectForm }: BossSelectorProps) 
             </PopoverTrigger>
             <PopoverContent className="w-[300px] p-0">
               <Command>
-                <CommandInput placeholder="Search bosses..." className="h-9" />
+                <div className="flex h-9 items-center gap-2 border-b px-3">
+                  <CommandPrimitive.Input
+                    placeholder="Search bosses..."
+                    className="placeholder:text-muted-foreground flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50"
+                  />
+                </div>
                 <CommandEmpty>No boss found.</CommandEmpty>
                 <CommandGroup>
                   <CommandList>
@@ -383,7 +381,13 @@ export function BossSelector({ onSelectBoss, onSelectForm }: BossSelectorProps) 
         {/* Form selector (if the boss has multiple forms) */}
         {selectedBoss && bossDetails?.forms && bossDetails.forms.length > 0 && (
           <div className="space-y-2">
-            <label className="text-sm font-medium">Select Form/Phase</label>
+            <div className="flex items-center justify-between">
+              <label className="text-sm font-medium">Select Form/Phase</label>
+              <Button variant="outline" size="sm" onClick={handleResetBoss}">
+                <RotateCcw className="h-4 w-4 mr-2" />
+                Reset
+              </Button>
+            </div>
             {isLoadingDetails ? (
               <div className="flex items-center text-sm text-muted-foreground">
                 <Loader2 className="mr-2 h-4 w-4 animate-spin" />
@@ -426,7 +430,7 @@ export function BossSelector({ onSelectBoss, onSelectForm }: BossSelectorProps) 
               <img
                 src={selectedForm.icons?.[0] || selectedForm.image_url}
                 alt="icon"
-                className="w-24 h-24"
+                className="w-24 h-auto object-contain"
               />
             )}
             <h4 className="text-sm font-semibold">Target Stats</h4>

--- a/frontend/src/components/features/calculator/CombatStatsSummary.tsx
+++ b/frontend/src/components/features/calculator/CombatStatsSummary.tsx
@@ -34,7 +34,7 @@ export function CombatStatsSummary({
   return (
     <div className="mt-4 p-3 bg-slate-100 dark:bg-slate-800 rounded-md">
       <h4 className="font-medium text-sm mb-2">Combat Setup:</h4>
-      <div className="grid grid-cols-2 gap-2 text-sm">
+      <div className="grid grid-cols-2 gap-2 text-sm text-center">
         <div>
           <span className="text-muted-foreground">Combat Style:</span>{' '}
           <span className="font-medium capitalize">{combatStyle}</span>

--- a/frontend/src/components/features/calculator/CombinedEquipmentDisplay.tsx
+++ b/frontend/src/components/features/calculator/CombinedEquipmentDisplay.tsx
@@ -351,7 +351,7 @@ export function CombinedEquipmentDisplay({ onEquipmentUpdate, bossForm }: Combin
               className="mr-2"
             />
             <Label htmlFor="use-2h" className="text-sm">
-              {show2hOption ? 'Use 1H + Shield' : 'Use 2H'}
+              {show2hOption ? 'Use 1H' : 'Use 2H'}
             </Label>
           </div>
           

--- a/frontend/src/components/features/calculator/DirectBossSelector.tsx
+++ b/frontend/src/components/features/calculator/DirectBossSelector.tsx
@@ -217,14 +217,6 @@ export function DirectBossSelector({ onSelectBoss, onSelectForm }: DirectBossSel
         <CardDescription>Select a boss to calculate DPS against</CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
-        {selectedBoss && (
-          <div className="flex justify-end">
-            <Button variant="outline" size="sm" onClick={handleResetBoss}>
-              <RotateCcw className="h-4 w-4 mr-2" />
-              Reset
-            </Button>
-          </div>
-        )}
         {bossLocked && (
           <Alert className="mb-4">
             <AlertDescription>
@@ -296,7 +288,13 @@ export function DirectBossSelector({ onSelectBoss, onSelectForm }: DirectBossSel
         {/* Form selector */}
         {selectedBoss && bossDetails?.forms && bossDetails.forms.length > 0 && (
           <div className="space-y-2">
-            <label className="text-sm font-medium">Select Form/Phase</label>
+            <div className="flex items-center justify-between">
+              <label className="text-sm font-medium">Select Form/Phase</label>
+              <Button variant="outline" size="sm" onClick={handleResetBoss}">
+                <RotateCcw className="h-4 w-4 mr-2" />
+                Reset
+              </Button>
+            </div>
             {isLoadingDetails ? (
               <div className="flex items-center text-sm text-muted-foreground">
                 <Loader2 className="mr-2 h-4 w-4 animate-spin" />
@@ -329,12 +327,12 @@ export function DirectBossSelector({ onSelectBoss, onSelectForm }: DirectBossSel
 
         {/* Display the selected boss stats */}
         {selectedForm && (
-          <div className="pt-2 space-y-2 bg-slate-100 dark:bg-slate-800 p-3 rounded-md flex flex-col items-center">
+          <div className="pt-2 space-y-2 bg-slate-100 dark:bg-slate-800 p-2 rounded-md flex flex-col items-center">
             {(selectedForm.icons?.[0] || selectedForm.image_url) && (
               <img
                 src={selectedForm.icons?.[0] || selectedForm.image_url}
                 alt="icon"
-                className="w-28 h-28 mb-2"
+                className="w-28 h-auto mb-2 object-contain"
               />
             )}
             <h4 className="text-sm font-semibold">Target Stats</h4>

--- a/frontend/src/components/features/calculator/ImprovedDpsCalculator.tsx
+++ b/frontend/src/components/features/calculator/ImprovedDpsCalculator.tsx
@@ -85,11 +85,11 @@ export function ImprovedDpsCalculator() {
       {/* Two-column layout for middle sections */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* Left column */}
-        <div className="space-y-6">
+        <div className="space-y-6 flex flex-col">
           {/* Character equipment section */}
           <CombinedEquipmentDisplay onEquipmentUpdate={handleEquipmentUpdate} bossForm={currentBossForm} />
           {/* Prayer/Potion selector */}
-          <PrayerPotionSelector />
+          <PrayerPotionSelector className="flex-grow" />
         </div>
 
         {/* Right column */}

--- a/frontend/src/components/features/calculator/PassiveEffectsDisplay.tsx
+++ b/frontend/src/components/features/calculator/PassiveEffectsDisplay.tsx
@@ -270,8 +270,8 @@ export function PassiveEffectsDisplay({ loadout, target }: PassiveEffectsDisplay
         <h3 className="text-sm font-semibold mb-2">Active Passive Effects</h3>
         <div className="space-y-2">
           {activeEffects.map((effect, index) => (
-            <div key={index} className="flex flex-col space-y-1 rounded-md border p-2">
-              <div className="flex items-center">
+            <div key={index} className="flex flex-col items-center space-y-1 rounded-md border p-2">
+              <div className="flex items-center justify-center">
                 <Badge variant="secondary" className="mr-2">Active</Badge>
                 <span className="font-medium text-sm">{effect.name}</span>
               </div>

--- a/frontend/src/components/features/calculator/PrayerPotionSelector.tsx
+++ b/frontend/src/components/features/calculator/PrayerPotionSelector.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { ToggleBox } from '@/components/ui/toggle-box';
@@ -66,7 +67,7 @@ const POTION_OPTIONS = {
 // Define preserve prayer option
 const PRESERVE_OPTION = { value: 'preserve', label: 'Preserve', description: 'Boosted stats last 50% longer' };
 
-export function PrayerPotionSelector() {
+export function PrayerPotionSelector({ className }: { className?: string }) {
   const { params, setParams } = useCalculatorStore();
   const combatStyle = params.combat_style;
   
@@ -228,7 +229,7 @@ export function PrayerPotionSelector() {
   };
   
   return (
-    <Card>
+    <Card className={cn(className)}>
       <CardHeader>
         <CardTitle className="flex items-center">
           Prayer & Potion Selection


### PR DESCRIPTION
## Summary
- remove search icon from boss selector input
- better image sizing in boss preview
- center passive effects content
- align reset button next to form select
- center combat summary text
- stretch prayer/potion selector
- label says `Use 1H`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68458159ae68832e90bae4f7b389b17c