### PR TITLE
Fix layout centering and button placement

### DIFF
--- a/frontend/src/components/features/calculator/BossSelector.tsx
+++ b/frontend/src/components/features/calculator/BossSelector.tsx
@@ -381,19 +381,13 @@ export function BossSelector({ onSelectBoss, onSelectForm }: BossSelectorProps) 
         {/* Form selector (if the boss has multiple forms) */}
         {selectedBoss && bossDetails?.forms && bossDetails.forms.length > 0 && (
           <div className="space-y-2">
-            <div className="flex items-center justify-between">
-              <label className="text-sm font-medium">Select Form/Phase</label>
-              <Button variant="outline" size="sm" onClick={handleResetBoss}">
-                <RotateCcw className="h-4 w-4 mr-2" />
-                Reset
-              </Button>
-            </div>
+            <label className="text-sm font-medium">Select Form/Phase</label>
             {isLoadingDetails ? (
               <div className="flex items-center text-sm text-muted-foreground">
                 <Loader2 className="mr-2 h-4 w-4 animate-spin" />
                 Loading boss details...
               </div>
-            ) : (
+            ) : (<div className="flex items-center gap-2">
               <Select
                 value={selectedForm?.id.toString() || ''}
                 onValueChange={(value: string) => {
@@ -419,6 +413,11 @@ export function BossSelector({ onSelectBoss, onSelectForm }: BossSelectorProps) 
                   ))}
                 </SelectContent>
               </Select>
+                <Button variant="outline" size="sm" onClick={handleResetBoss}>
+                  <RotateCcw className="h-4 w-4 mr-2" />
+                  Reset
+                </Button>
+              </div>
             )}
           </div>
         )}

--- a/frontend/src/components/features/calculator/CombatStatsSummary.tsx
+++ b/frontend/src/components/features/calculator/CombatStatsSummary.tsx
@@ -68,7 +68,7 @@ export function CombatStatsSummary({
             </span>
           </div>
         )}
-        <div>
+        <div className="col-span-2">
           <span className="text-muted-foreground">Target Defense Type:</span>{' '}
           <span className="font-medium capitalize">
             {(params.target_defence_type || 'defence_slash').replace('defence_', '')}

--- a/frontend/src/components/features/calculator/CombinedEquipmentDisplay.tsx
+++ b/frontend/src/components/features/calculator/CombinedEquipmentDisplay.tsx
@@ -370,7 +370,7 @@ export function CombinedEquipmentDisplay({ onEquipmentUpdate, bossForm }: Combin
 
       <CardContent>
         {Object.keys(loadout).length > 0 && (
-          <div className="flex justify-end mb-2">
+          <div className="flex justify-center mb-2">
             <Button variant="outline" size="sm" onClick={handleResetEquipment}
             >
               Reset Equipment

--- a/frontend/src/components/features/calculator/DirectBossSelector.tsx
+++ b/frontend/src/components/features/calculator/DirectBossSelector.tsx
@@ -288,21 +288,13 @@ export function DirectBossSelector({ onSelectBoss, onSelectForm }: DirectBossSel
         {/* Form selector */}
         {selectedBoss && bossDetails?.forms && bossDetails.forms.length > 0 && (
           <div className="space-y-2">
-            <div className="flex items-center justify-between">
-              <label className="text-sm font-medium">Select Form/Phase</label>
-
-              <Button variant="outline" size="sm" onClick={handleResetBoss}>
-
-                <RotateCcw className="h-4 w-4 mr-2" />
-                Reset
-              </Button>
-            </div>
+            <label className="text-sm font-medium">Select Form/Phase</label>
             {isLoadingDetails ? (
               <div className="flex items-center text-sm text-muted-foreground">
                 <Loader2 className="mr-2 h-4 w-4 animate-spin" />
                 Loading boss details...
               </div>
-            ) : (
+            ) : (<div className="flex items-center gap-2">
               <Select
                 value={selectedForm?.id.toString() || ''}
                 onValueChange={(value: string) => {
@@ -323,6 +315,11 @@ export function DirectBossSelector({ onSelectBoss, onSelectForm }: DirectBossSel
                   ))}
                 </SelectContent>
               </Select>
+                <Button variant="outline" size="sm" onClick={handleResetBoss}>
+                  <RotateCcw className="h-4 w-4 mr-2" />
+                  Reset
+                </Button>
+              </div>
             )}
           </div>
         )}

--- a/frontend/src/components/features/calculator/DpsResultDisplay.tsx
+++ b/frontend/src/components/features/calculator/DpsResultDisplay.tsx
@@ -12,7 +12,7 @@ interface DpsResultDisplayProps {
 export function DpsResultDisplay({ params, results, appliedPassiveEffects }: DpsResultDisplayProps) {
   return (
     <div className="mt-8 space-y-4">
-      <h2 className="text-xl font-bold border-b pb-2 flex items-center section-heading">
+      <h2 className="text-xl font-bold border-b pb-2 flex items-center justify-center section-heading">
         <Calculator className="h-5 w-5 mr-2 text-primary" />
         Calculation Results
       </h2>
@@ -36,33 +36,6 @@ export function DpsResultDisplay({ params, results, appliedPassiveEffects }: Dps
           </CardContent>
         </Card>
       </div>
-      {appliedPassiveEffects && appliedPassiveEffects.isApplicable && (
-        <Card className="bg-muted/30 border mt-4">
-          <CardContent className="pt-6">
-            <h3 className="text-base font-medium mb-2">Applied Passive Effects</h3>
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-              {appliedPassiveEffects.accuracy !== 1.0 && (
-                <div className="p-3 bg-muted/50 rounded-md">
-                  <span className="text-sm text-muted-foreground">Accuracy Bonus:</span>{' '}
-                  <span className="font-medium text-green-500">+{((appliedPassiveEffects.accuracy - 1) * 100).toFixed(1)}%</span>
-                </div>
-              )}
-              {appliedPassiveEffects.damage !== 1.0 && (
-                <div className="p-3 bg-muted/50 rounded-md">
-                  <span className="text-sm text-muted-foreground">Damage Bonus:</span>{' '}
-                  <span className="font-medium text-green-500">+{((appliedPassiveEffects.damage - 1) * 100).toFixed(1)}%</span>
-                </div>
-              )}
-              {appliedPassiveEffects.maxHit > 0 && (
-                <div className="p-3 bg-muted/50 rounded-md">
-                  <span className="text-sm text-muted-foreground">Max Hit Bonus:</span>{' '}
-                  <span className="font-medium text-green-500">+{appliedPassiveEffects.maxHit}</span>
-                </div>
-              )}
-            </div>
-          </CardContent>
-        </Card>
-      )}
     </div>
   );
 }

--- a/frontend/src/components/features/calculator/EquipmentPanel.tsx
+++ b/frontend/src/components/features/calculator/EquipmentPanel.tsx
@@ -58,7 +58,7 @@ export function EquipmentPanel({ onEquipmentUpdate, bossForm }: EquipmentPanelPr
 
       <CardContent>
         {Object.keys(currentLoadout).length > 0 && (
-          <div className="flex justify-end mb-2">
+          <div className="flex justify-center mb-2">
             <Button
               variant="outline"
               size="sm"


### PR DESCRIPTION
## Summary
- center reset buttons in equipment panels
- center target defense type row in combat stats
- move boss selector reset button below the label
- center calculation results header
- remove inline passive effects card

## Testing
- `npm test` *(fails: jest not found)*
- `pytest` *(fails: ModuleNotFoundError: httpx)*

------
https://chatgpt.com/codex/tasks/task_e_6845864a973c832ebc168dd4d5e64a2f