### PR TITLE
Fix inconsistent style for prayer and potion selectors

### DIFF
--- a/frontend/src/components/features/calculator/PrayerPotionSelector.tsx
+++ b/frontend/src/components/features/calculator/PrayerPotionSelector.tsx
@@ -258,24 +258,22 @@ export function PrayerPotionSelector({ className }: { className?: string }) {
           
           <TabsContent value="prayer" className="space-y-4">
             <div className="space-y-2">
-              <div className="flex items-center justify-between">
-                <Label htmlFor="prayer-select">Combat Prayer</Label>
-                <Select
-                  value={selectedPrayer}
-                  onValueChange={handlePrayerChange}
-                >
-                  <SelectTrigger id="prayer-select" className="w-[250px]">
-                    <SelectValue placeholder="Select prayer" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {PRAYER_OPTIONS[combatStyle].map((prayer) => (
-                      <SelectItem key={prayer.value} value={prayer.value}>
-                        {prayer.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
+              <Label htmlFor="prayer-select">Combat Prayer</Label>
+              <Select
+                value={selectedPrayer}
+                onValueChange={handlePrayerChange}
+              >
+                <SelectTrigger id="prayer-select" className="w-full">
+                  <SelectValue placeholder="Select prayer" />
+                </SelectTrigger>
+                <SelectContent>
+                  {PRAYER_OPTIONS[combatStyle].map((prayer) => (
+                    <SelectItem key={prayer.value} value={prayer.value}>
+                      {prayer.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
               
               <div className="flex items-center gap-4 pt-2">
                 <ToggleBox


### PR DESCRIPTION
## Summary
- align Prayer selection layout with Potion selection
- keep label and trigger vertical for consistency

## Testing
- `npm --prefix frontend test` *(fails: ts-jest can't parse TSX)*
- `python3 -m unittest discover backend/app/testing`

------
https://chatgpt.com/codex/tasks/task_e_684588a321ec832ea39ece265a7c6445