### PR TITLE
Capture boss size for scythe effect

### DIFF
--- a/frontend/src/components/features/calculator/DirectBossSelector.tsx
+++ b/frontend/src/components/features/calculator/DirectBossSelector.tsx
@@ -355,6 +355,12 @@ export function DirectBossSelector({ onSelectBoss, onSelectForm }: DirectBossSel
                 <span className="text-muted-foreground">Magic Level:</span>{' '}
                 <span className="font-medium">{selectedForm.magic_level || 'Unknown'}</span>
               </div>
+              <div>
+                <span className="text-muted-foreground">Size:</span>{' '}
+                <span className="font-medium">
+                  {selectedForm.size ? `${selectedForm.size}x${selectedForm.size}` : 'Unknown'}
+                </span>
+              </div>
               
               <div className="col-span-2 mt-1">
                 <h5 className="text-xs font-semibold mb-1">Defence Bonuses</h5>

--- a/frontend/src/components/features/calculator/PassiveEffectCalculator.tsx
+++ b/frontend/src/components/features/calculator/PassiveEffectCalculator.tsx
@@ -234,23 +234,21 @@ export function calculatePassiveEffectBonuses(
       }
     }
     
-    // Scythe of Vitur multi-hit effect
-    if (itemName.includes('scythe of vitur')) {
-      // Note: This is a special case that depends on target size
-      // Since we don't have target size data yet, we'll just show info about the effect
-      const effectApplicable = target && target.hitpoints && target.hitpoints > 0;
-      
-      if (effectApplicable) {
+    // Scythe of Vitur multi-hit effect based on target size
+    if (itemName.includes('scythe of vitur') && target?.size) {
+      // 1x1 = 1 hit, 2x2 = 2 hits, 3x3+ = 3 hits
+      const hits = target.size >= 3 ? 3 : target.size >= 2 ? 2 : 1;
+
+      if (hits > 1) {
         bonus.isApplicable = true;
-        
-        // The actual damage calculation for Scythe is complex and depends on max hit:
-        // 1st hit: 100% damage
-        // 2nd hit: 50% damage
-        // 3rd hit: 25% damage
-        // This is handled in the DPS calculator, but we'll flag that it's active
+
+        // 1 hit = 100%, 2 hits = 150%, 3 hits = 175%
+        const multiplier = hits === 2 ? 1.5 : 1.75;
+        bonus.damage = (bonus.damage || 1.0) * multiplier;
+
         effects.push({
           name: 'Scythe of Vitur',
-          description: 'Multi-hit weapon: Hits 3 times with 100%, 50%, and 25% damage against large targets'
+          description: `Multi-hit weapon: Hits ${hits} times against ${target.size}x${target.size} targets`
         });
       }
     }

--- a/frontend/src/components/features/calculator/PassiveEffectsDisplay.tsx
+++ b/frontend/src/components/features/calculator/PassiveEffectsDisplay.tsx
@@ -124,12 +124,15 @@ export function PassiveEffectsDisplay({ loadout, target }: PassiveEffectsDisplay
         }
       }
       
-      // Scythe of Vitur passive effect
-      if (itemName.includes('scythe of vitur')) {
-        effects.push({
-          name: 'Scythe of Vitur',
-          description: 'Multi-hit: 100%, 50%, and 25% damage against large targets'
-        });
+      // Scythe of Vitur passive effect based on target size
+      if (itemName.includes('scythe of vitur') && target?.size) {
+        const hits = target.size >= 3 ? 3 : target.size >= 2 ? 2 : 1;
+        if (hits > 1) {
+          effects.push({
+            name: 'Scythe of Vitur',
+            description: `Multi-hit: ${hits} hits against ${target.size}x${target.size} targets`
+          });
+        }
       }
       
       if (itemName.includes('dragon hunter') && isTargetDraconic(target)) {

--- a/frontend/src/types/calculator.ts
+++ b/frontend/src/types/calculator.ts
@@ -206,6 +206,7 @@ export interface BossForm {
   attack_styles?: string[];
   immunities?: string[];
   icons?: string[];
+  size?: number;
 }
 
 export interface Item {


### PR DESCRIPTION
## Summary
- include `size` on `BossForm` type
- show scythe passive effect only on large bosses
- scale scythe damage when target size is greater than one tile
- show the boss size in the target stats panel

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68458750e5c0832eac562cddf56af52d