### PR TITLE
Adjust layout and alignment

### DIFF
--- a/frontend/src/components/features/calculator/CombatStatsSummary.tsx
+++ b/frontend/src/components/features/calculator/CombatStatsSummary.tsx
@@ -61,14 +61,14 @@ export function CombatStatsSummary({
           </span>
         </div>
         {Object.keys(getAttackStylesForDisplay()).length > 0 && (
-          <div className="col-span-2">
+          <div>
             <span className="text-muted-foreground">Style Bonus:</span>{' '}
             <span className="font-medium">
               {getAttackStylesForDisplay()[selectedAttackStyle]?.description || 'None'}
             </span>
           </div>
         )}
-        <div className="col-span-2">
+        <div>
           <span className="text-muted-foreground">Target Defense Type:</span>{' '}
           <span className="font-medium capitalize">
             {(params.target_defence_type || 'defence_slash').replace('defence_', '')}
@@ -146,7 +146,7 @@ export function CombatStatsSummary({
       {/* Equipment totals */}
       <div className="mt-2 pt-2 border-t border-border/50">
         <h5 className="text-sm font-medium mb-1">Equipment Totals:</h5>
-        <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs">
+        <div className="grid grid-cols-3 gap-x-4 gap-y-1 text-xs">
           {combatStyle === 'melee' && (
             <>
               <div>
@@ -161,6 +161,7 @@ export function CombatStatsSummary({
                   {params.melee_strength_bonus || 0}
                 </span>
               </div>
+              <div />
             </>
           )}
           {combatStyle === 'ranged' && (
@@ -177,6 +178,7 @@ export function CombatStatsSummary({
                   {params.ranged_strength_bonus || 0}
                 </span>
               </div>
+              <div />
             </>
           )}
           {combatStyle === 'magic' && (
@@ -193,6 +195,7 @@ export function CombatStatsSummary({
                   {Math.round((params.magic_damage_bonus || 0) * 100)}%
                 </span>
               </div>
+              <div />
             </>
           )}
           <div>
@@ -207,6 +210,7 @@ export function CombatStatsSummary({
               +{params.attack_style_bonus_strength || 0}
             </span>
           </div>
+          <div />
         </div>
 
         <div className="grid grid-cols-3 gap-x-4 gap-y-1 text-xs mt-2">

--- a/frontend/src/components/features/calculator/DirectBossSelector.tsx
+++ b/frontend/src/components/features/calculator/DirectBossSelector.tsx
@@ -315,7 +315,7 @@ export function DirectBossSelector({ onSelectBoss, onSelectForm }: DirectBossSel
                   ))}
                 </SelectContent>
               </Select>
-                <Button variant="outline" size="sm" onClick={handleResetBoss}>
+                <Button variant="outline" size="sm" onClick={handleResetBoss} className="ml-auto">
                   <RotateCcw className="h-4 w-4 mr-2" />
                   Reset
                 </Button>

--- a/frontend/src/components/features/calculator/ImprovedDpsCalculator.tsx
+++ b/frontend/src/components/features/calculator/ImprovedDpsCalculator.tsx
@@ -93,7 +93,7 @@ export function ImprovedDpsCalculator() {
         </div>
 
         {/* Right column */}
-        <div className="space-y-6 flex flex-col">
+        <div className="space-y-6 flex flex-col flex-grow">
           {/* Target selection section */}
           <DirectBossSelector onSelectForm={handleBossUpdate} />
           
@@ -104,17 +104,13 @@ export function ImprovedDpsCalculator() {
             </CardContent>
           </Card>
 
-          {/* Preset selector */}
-          <PresetSelector
-            className="flex-grow"
-            onPresetLoad={() => toast.success("Preset loaded successfully!")}
-          />
-
         </div>
-        {/* Full-width comparison table at the bottom */}
-        <div className="lg:col-span-2">
-          <DpsComparison />
-        </div>
+        {/* Bottom row: DPS comparison and loadout presets */}
+        <DpsComparison />
+        <PresetSelector
+          className="flex-grow"
+          onPresetLoad={() => toast.success("Preset loaded successfully!")}
+        />
       </div>
       
     </div>

--- a/frontend/src/components/features/calculator/PresetSelector.tsx
+++ b/frontend/src/components/features/calculator/PresetSelector.tsx
@@ -120,48 +120,85 @@ export function PresetSelector({ onPresetLoad, className }: PresetSelectorProps)
         <CardDescription>Save and load your equipment setups</CardDescription>
       </CardHeader>
       <CardContent>
-        <div className="flex justify-end mb-4">
-          <Dialog open={saveDialogOpen} onOpenChange={setSaveDialogOpen}>
-            <DialogTrigger asChild>
-              <Button size="sm">
-                <Save className="h-4 w-4 mr-2" />
-                Add
-              </Button>
-            </DialogTrigger>
-            <DialogContent>
-              <DialogHeader>
-                <DialogTitle>Save Loadout Preset</DialogTitle>
-                <DialogDescription>
-                  Give your preset a name to save your current setup
-                </DialogDescription>
-              </DialogHeader>
-              <div className="space-y-4 py-4">
-                <Input
-                  placeholder="Preset name..."
-                  value={presetName}
-                  onChange={(e) => setPresetName(e.target.value)}
-                />
-                <div className="text-sm">
-                  <p>Combat Style: <Badge>{params.combat_style}</Badge></p>
-                </div>
-              </div>
-              <div className="flex justify-end gap-2">
-                <Button variant="outline" onClick={() => setSaveDialogOpen(false)}>
-                  Cancel
-                </Button>
-                <Button onClick={savePreset} disabled={!presetName.trim()}>
-                  Save Preset
-                </Button>
-              </div>
-            </DialogContent>
-          </Dialog>
-        </div>
         {presets.length === 0 ? (
           <div className="text-center py-8 text-muted-foreground">
             <p>You haven&apos;t saved any presets yet.</p>
             <p className="text-sm">Save your current setup to create a preset.</p>
+            <div className="mt-4 flex justify-center">
+              <Dialog open={saveDialogOpen} onOpenChange={setSaveDialogOpen}>
+                <DialogTrigger asChild>
+                  <Button size="sm">
+                    <Save className="h-4 w-4 mr-2" />
+                    Add
+                  </Button>
+                </DialogTrigger>
+                <DialogContent>
+                  <DialogHeader>
+                    <DialogTitle>Save Loadout Preset</DialogTitle>
+                    <DialogDescription>
+                      Give your preset a name to save your current setup
+                    </DialogDescription>
+                  </DialogHeader>
+                  <div className="space-y-4 py-4">
+                    <Input
+                      placeholder="Preset name..."
+                      value={presetName}
+                      onChange={(e) => setPresetName(e.target.value)}
+                    />
+                    <div className="text-sm">
+                      <p>Combat Style: <Badge>{params.combat_style}</Badge></p>
+                    </div>
+                  </div>
+                  <div className="flex justify-end gap-2">
+                    <Button variant="outline" onClick={() => setSaveDialogOpen(false)}>
+                      Cancel
+                    </Button>
+                    <Button onClick={savePreset} disabled={!presetName.trim()}>
+                      Save Preset
+                    </Button>
+                  </div>
+                </DialogContent>
+              </Dialog>
+            </div>
           </div>
         ) : (
+          <>
+            <div className="flex justify-end mb-4">
+              <Dialog open={saveDialogOpen} onOpenChange={setSaveDialogOpen}>
+                <DialogTrigger asChild>
+                  <Button size="sm">
+                    <Save className="h-4 w-4 mr-2" />
+                    Add
+                  </Button>
+                </DialogTrigger>
+                <DialogContent>
+                  <DialogHeader>
+                    <DialogTitle>Save Loadout Preset</DialogTitle>
+                    <DialogDescription>
+                      Give your preset a name to save your current setup
+                    </DialogDescription>
+                  </DialogHeader>
+                  <div className="space-y-4 py-4">
+                    <Input
+                      placeholder="Preset name..."
+                      value={presetName}
+                      onChange={(e) => setPresetName(e.target.value)}
+                    />
+                    <div className="text-sm">
+                      <p>Combat Style: <Badge>{params.combat_style}</Badge></p>
+                    </div>
+                  </div>
+                  <div className="flex justify-end gap-2">
+                    <Button variant="outline" onClick={() => setSaveDialogOpen(false)}>
+                      Cancel
+                    </Button>
+                    <Button onClick={savePreset} disabled={!presetName.trim()}>
+                      Save Preset
+                    </Button>
+                  </div>
+                </DialogContent>
+              </Dialog>
+            </div>
           <Tabs defaultValue="all">
             <TabsList className="grid grid-cols-4 mb-4 align-middle w-auto">
               <TabsTrigger value="all">All</TabsTrigger>


### PR DESCRIPTION
## Summary
- reposition Add preset button so it appears under the empty-state message
- align attack bonuses grid with defence totals
- place Target Defence Type next to Style Bonus
- align reset button to the right in boss selector
- move PresetSelector next to DPS comparison and let boss selector fill space

## Testing
- `npm test` *(fails: Jest encountered unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_684589a26904832e86d5c028a6f2beec