### PR TITLE
Fix layout of equipment totals and boss selector

### DIFF
--- a/frontend/src/components/features/calculator/CombatStatsSummary.tsx
+++ b/frontend/src/components/features/calculator/CombatStatsSummary.tsx
@@ -155,13 +155,13 @@ export function CombatStatsSummary({
                   {params.melee_attack_bonus || 0}
                 </span>
               </div>
+              <div />
               <div>
                 <span className="text-muted-foreground">Strength Bonus:</span>{' '}
                 <span className="font-medium">
                   {params.melee_strength_bonus || 0}
                 </span>
               </div>
-              <div />
             </>
           )}
           {combatStyle === 'ranged' && (
@@ -172,13 +172,13 @@ export function CombatStatsSummary({
                   {params.ranged_attack_bonus || 0}
                 </span>
               </div>
+              <div />
               <div>
                 <span className="text-muted-foreground">Ranged Strength Bonus:</span>{' '}
                 <span className="font-medium">
                   {params.ranged_strength_bonus || 0}
                 </span>
               </div>
-              <div />
             </>
           )}
           {combatStyle === 'magic' && (
@@ -189,13 +189,13 @@ export function CombatStatsSummary({
                   {params.magic_attack_bonus || 0}
                 </span>
               </div>
+              <div />
               <div>
                 <span className="text-muted-foreground">Magic Damage Bonus:</span>{' '}
                 <span className="font-medium">
                   {Math.round((params.magic_damage_bonus || 0) * 100)}%
                 </span>
               </div>
-              <div />
             </>
           )}
           <div>
@@ -204,13 +204,13 @@ export function CombatStatsSummary({
               +{params.attack_style_bonus_attack || 0}
             </span>
           </div>
+          <div />
           <div>
             <span className="text-muted-foreground">Style Strength Bonus:</span>{' '}
             <span className="font-medium">
               +{params.attack_style_bonus_strength || 0}
             </span>
           </div>
-          <div />
         </div>
 
         <div className="grid grid-cols-3 gap-x-4 gap-y-1 text-xs mt-2">

--- a/frontend/src/components/features/calculator/DirectBossSelector.tsx
+++ b/frontend/src/components/features/calculator/DirectBossSelector.tsx
@@ -26,13 +26,15 @@ import { bossesApi } from '@/services/api';
 import { Boss, BossForm } from '@/types/calculator';
 import { useCalculatorStore } from '@/store/calculator-store';
 import { Alert, AlertDescription } from '@/components/ui/alert';
+import { cn } from '@/lib/utils';
 
 interface DirectBossSelectorProps {
   onSelectBoss?: (boss: Boss) => void;
   onSelectForm?: (form: BossForm | null) => void;
+  className?: string;
 }
 
-export function DirectBossSelector({ onSelectBoss, onSelectForm }: DirectBossSelectorProps) {
+export function DirectBossSelector({ onSelectBoss, onSelectForm, className }: DirectBossSelectorProps) {
   const [searchOpen, setSearchOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedBoss, setSelectedBoss] = useState<Boss | null>(null);
@@ -211,7 +213,7 @@ export function DirectBossSelector({ onSelectBoss, onSelectForm }: DirectBossSel
   };
 
   return (
-    <Card>
+    <Card className={cn("flex flex-col h-full", className)}>
       <CardHeader>
         <CardTitle>Target Selection</CardTitle>
         <CardDescription>Select a boss to calculate DPS against</CardDescription>
@@ -294,7 +296,7 @@ export function DirectBossSelector({ onSelectBoss, onSelectForm }: DirectBossSel
                 <Loader2 className="mr-2 h-4 w-4 animate-spin" />
                 Loading boss details...
               </div>
-            ) : (<div className="flex items-center gap-2">
+            ) : (<div className="flex items-center gap-2 w-full justify-between">
               <Select
                 value={selectedForm?.id.toString() || ''}
                 onValueChange={(value: string) => {
@@ -304,7 +306,7 @@ export function DirectBossSelector({ onSelectBoss, onSelectForm }: DirectBossSel
                   }
                 }}
               >
-                <SelectTrigger>
+                <SelectTrigger className="w-full">
                   <SelectValue placeholder="Select a form/phase" />
                 </SelectTrigger>
                 <SelectContent>
@@ -315,7 +317,7 @@ export function DirectBossSelector({ onSelectBoss, onSelectForm }: DirectBossSel
                   ))}
                 </SelectContent>
               </Select>
-                <Button variant="outline" size="sm" onClick={handleResetBoss} className="ml-auto">
+                <Button variant="outline" size="sm" onClick={handleResetBoss}>
                   <RotateCcw className="h-4 w-4 mr-2" />
                   Reset
                 </Button>

--- a/frontend/src/components/features/calculator/ImprovedDpsCalculator.tsx
+++ b/frontend/src/components/features/calculator/ImprovedDpsCalculator.tsx
@@ -95,7 +95,7 @@ export function ImprovedDpsCalculator() {
         {/* Right column */}
         <div className="space-y-6 flex flex-col flex-grow">
           {/* Target selection section */}
-          <DirectBossSelector onSelectForm={handleBossUpdate} />
+          <DirectBossSelector onSelectForm={handleBossUpdate} className="flex-grow" />
           
           {/* Defensive reductions panel - with contained height */}
           <Card className="w-full border">


### PR DESCRIPTION
## Summary
- update Equipment Totals layout so the empty column sits between attack and strength values
- let DirectBossSelector stretch using `flex-grow` and customizable className
- align form selector left and reset button right
- allow DirectBossSelector to take available vertical space in ImprovedDpsCalculator

## Testing
- `npm test` *(fails: Jest unable to parse TSX files)*

------
https://chatgpt.com/codex/tasks/task_e_68458e60fd98832e92ccc5fb23e9cf54