### PR TITLE
Align combat style toggle design

### DIFF
--- a/frontend/src/components/features/calculator/AttackStyleSelector.tsx
+++ b/frontend/src/components/features/calculator/AttackStyleSelector.tsx
@@ -1,9 +1,12 @@
-import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import {
-  Tooltip, TooltipContent, TooltipProvider, TooltipTrigger
-} from '@/components/ui/tooltip';
-import { Item } from '@/types/calculator';
-import { BossForm } from '@/types/calculator';
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { Item } from "@/types/calculator";
+import { BossForm } from "@/types/calculator";
 
 // Define attack styles with their bonuses
 export interface AttackStyleDefinition {
@@ -18,75 +21,78 @@ export interface AttackStyleDefinition {
 }
 
 export const ATTACK_TYPE_TO_DEFENCE_TYPE: Record<string, string> = {
-  stab: 'defence_stab',
-  slash: 'defence_slash',
-  crush: 'defence_crush',
-  magic: 'defence_magic',
-  ranged: 'defence_ranged_standard'
+  stab: "defence_stab",
+  slash: "defence_slash",
+  crush: "defence_crush",
+  magic: "defence_magic",
+  ranged: "defence_ranged_standard",
 };
 
 // Default attack styles if weapon doesn't provide them
-export const DEFAULT_ATTACK_STYLES: Record<string, Record<string, AttackStyleDefinition>> = {
+export const DEFAULT_ATTACK_STYLES: Record<
+  string,
+  Record<string, AttackStyleDefinition>
+> = {
   melee: {
-    'accurate': { 
-      name: 'Accurate', 
-      attackType: 'slash',
+    accurate: {
+      name: "Accurate",
+      attackType: "slash",
       bonus: { attack: 3, strength: 0, defence: 0 },
-      description: '+3 Attack'
+      description: "+3 Attack",
     },
-    'aggressive': { 
-      name: 'Aggressive', 
-      attackType: 'slash',
+    aggressive: {
+      name: "Aggressive",
+      attackType: "slash",
       bonus: { attack: 0, strength: 3, defence: 0 },
-      description: '+3 Strength'
+      description: "+3 Strength",
     },
-    'controlled': { 
-      name: 'Controlled', 
-      attackType: 'stab',
+    controlled: {
+      name: "Controlled",
+      attackType: "stab",
       bonus: { attack: 1, strength: 1, defence: 1 },
-      description: '+1 to all'
+      description: "+1 to all",
     },
-    'defensive': { 
-      name: 'Defensive', 
-      attackType: 'slash',
+    defensive: {
+      name: "Defensive",
+      attackType: "slash",
       bonus: { attack: 0, strength: 0, defence: 3 },
-      description: '+3 Defence'
-    }
+      description: "+3 Defence",
+    },
   },
   ranged: {
-    'accurate': { 
-      name: 'Accurate', 
-      attackType: 'ranged',
+    accurate: {
+      name: "Accurate",
+      attackType: "ranged",
       bonus: { attack: 3, strength: 0, defence: 0 },
-      description: '+3 Ranged'
+      description: "+3 Ranged",
     },
-    'rapid': { 
-      name: 'Rapid', 
-      attackType: 'ranged',
+    rapid: {
+      name: "Rapid",
+      attackType: "ranged",
       bonus: { attack: 0, strength: 0, defence: 0 },
-      description: 'Faster attack speed'
+      description: "Faster attack speed",
     },
-    'longrange': { 
-      name: 'Longrange', 
-      attackType: 'ranged',
+    longrange: {
+      name: "Longrange",
+      attackType: "ranged",
       bonus: { attack: 0, strength: 0, defence: 3 },
-      description: '+3 Defence, increased range'
-    }
+      description: "+3 Defence, increased range",
+    },
   },
   magic: {
-    'standard': { 
-      name: 'Standard', 
-      attackType: 'magic',
+    standard: {
+      name: "Standard",
+      attackType: "magic",
       bonus: { attack: 0, strength: 0, defence: 0 },
-      description: 'Regular casting'
+      description: "Regular casting",
     },
-    'defensive': { 
-      name: 'Defensive', 
-      attackType: 'magic',
+    defensive: {
+      name: "Defensive",
+      attackType: "magic",
       bonus: { attack: 0, strength: 0, defence: 3 },
-      description: '+3 Defence'
-    }
-  }
+      description: "+3 Defence",
+    },
+  },
 };
 
 interface AttackStyleSelectorProps {
@@ -106,24 +112,22 @@ export function AttackStyleSelector({
   attackStyles,
   availableAttackStyles,
   selectedAttackStyle,
-  onSelectAttackStyle
+  onSelectAttackStyle,
 }: AttackStyleSelectorProps) {
-
-
   return (
     <div className="p-3 text-center">
       <div className="mb-1 text-sm text-muted-foreground">
-        {combatStyle === 'melee' 
-          ? "Combat Style:" 
-          : combatStyle === 'ranged' 
-            ? "Ranged Style:" 
+        {combatStyle === "melee"
+          ? "Combat Style:"
+          : combatStyle === "ranged"
+            ? "Ranged Style:"
             : "Magic Style:"}
       </div>
       <ToggleGroup
         type="single"
         value={selectedAttackStyle}
         onValueChange={(v) => v && onSelectAttackStyle(v)}
-        className="flex flex-wrap gap-1 justify-center"
+        className="bg-muted text-muted-foreground inline-flex flex-wrap justify-center rounded-lg p-[3px]"
       >
         {availableAttackStyles.map((style) => {
           const styleInfo = attackStyles[style];
@@ -133,15 +137,17 @@ export function AttackStyleSelector({
             <TooltipProvider key={style}>
               <Tooltip>
                 <TooltipTrigger asChild>
-                  <ToggleGroupItem value={style} size="sm">
+                  <ToggleGroupItem value={style} size="sm" variant="outline">
                     {styleInfo.name}
-                    {combatStyle !== 'melee' && ` (${styleInfo.attackType})`}
+                    {combatStyle !== "melee" && ` (${styleInfo.attackType})`}
                   </ToggleGroupItem>
                 </TooltipTrigger>
                 <TooltipContent>
                   <p>{styleInfo.description}</p>
-                  {combatStyle === 'melee' && (
-                    <p className="text-xs">Attack type: {styleInfo.attackType}</p>
+                  {combatStyle === "melee" && (
+                    <p className="text-xs">
+                      Attack type: {styleInfo.attackType}
+                    </p>
                   )}
                 </TooltipContent>
               </Tooltip>


### PR DESCRIPTION
## Summary
- make AttackStyleSelector toggles use the same style as prayer/potion tabs

## Testing
- `npm --prefix frontend test` *(fails: jest not found)*
- `npm --prefix frontend run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684595c2129c832e8ce417cfde12352f