### PR TITLE
Improve combat style UX and auto-detection

### DIFF
--- a/frontend/src/components/features/calculator/AttackStyleSelector.tsx
+++ b/frontend/src/components/features/calculator/AttackStyleSelector.tsx
@@ -129,7 +129,7 @@ export function AttackStyleSelector({
       </div>
       <Tabs
         value={selectedAttackStyle}
-        onValueChange={(v) => v && onSelectAttackStyle(v)}
+        onValueChange={onSelectAttackStyle}
         className="w-full"
       >
         <TabsList

--- a/frontend/src/components/features/calculator/CalculatorForms.tsx
+++ b/frontend/src/components/features/calculator/CalculatorForms.tsx
@@ -1,10 +1,9 @@
 'use client';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Tabs, TabsContent } from '@/components/ui/tabs';
 import { Button } from '@/components/ui/button';
 import { ToggleBox } from '@/components/ui/toggle-box';
 import { Label } from '@/components/ui/label';
 import { useState } from 'react';
-import { RotateCcw, Sword, Target, Zap } from 'lucide-react';
 import { MeleeForm } from './MeleeForm';
 import { RangedForm } from './RangedForm';
 import { MagicForm } from './MagicForm';
@@ -14,7 +13,6 @@ interface CalculatorFormsProps {
   activeTab: CombatStyle;
   onTabChange: (style: CombatStyle) => void;
   onCalculate: () => void;
-  onReset: () => void;
   isCalculating: boolean;
 }
 
@@ -22,7 +20,6 @@ export function CalculatorForms({
   activeTab,
   onTabChange,
   onCalculate,
-  onReset,
   isCalculating,
 }: CalculatorFormsProps) {
   const [showManual, setShowManual] = useState(false);
@@ -44,24 +41,6 @@ export function CalculatorForms({
           onValueChange={(v) => onTabChange(v as CombatStyle)}
           className="w-full"
         >
-          <TabsList className="grid grid-cols-4 mb-6">
-            <TabsTrigger value="melee" className="flex items-center justify-center">
-              <Sword className="h-4 w-4 mr-2" />
-              Melee
-            </TabsTrigger>
-            <TabsTrigger value="ranged" className="flex items-center justify-center">
-              <Target className="h-4 w-4 mr-2" />
-              Ranged
-            </TabsTrigger>
-            <TabsTrigger value="magic" className="flex items-center justify-center">
-              <Zap className="h-4 w-4 mr-2" />
-              Magic
-            </TabsTrigger>
-            <Button variant="outline" className="flex items-center justify-center" onClick={onReset}>
-              <RotateCcw className="h-4 w-4 mr-2" />
-              Reset All
-            </Button>
-          </TabsList>
           <TabsContent value="melee">
             <MeleeForm />
           </TabsContent>

--- a/frontend/src/components/features/calculator/CombatStyleTabs.tsx
+++ b/frontend/src/components/features/calculator/CombatStyleTabs.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Button } from '@/components/ui/button';
+import { RotateCcw, Sword, Target, Zap } from 'lucide-react';
+import { CombatStyle } from '@/types/calculator';
+
+interface CombatStyleTabsProps {
+  activeTab: CombatStyle;
+  onTabChange: (style: CombatStyle) => void;
+  onReset: () => void;
+}
+
+export function CombatStyleTabs({ activeTab, onTabChange, onReset }: CombatStyleTabsProps) {
+  return (
+    <Tabs
+      value={activeTab}
+      onValueChange={(v) => onTabChange(v as CombatStyle)}
+      className="w-full"
+    >
+      <TabsList className="grid grid-cols-4 mb-6">
+        <TabsTrigger value="melee" className="flex items-center justify-center">
+          <Sword className="h-4 w-4 mr-2" />
+          Melee
+        </TabsTrigger>
+        <TabsTrigger value="ranged" className="flex items-center justify-center">
+          <Target className="h-4 w-4 mr-2" />
+          Ranged
+        </TabsTrigger>
+        <TabsTrigger value="magic" className="flex items-center justify-center">
+          <Zap className="h-4 w-4 mr-2" />
+          Magic
+        </TabsTrigger>
+        <Button variant="outline" className="flex items-center justify-center" onClick={onReset}>
+          <RotateCcw className="h-4 w-4 mr-2" />
+          Reset All
+        </Button>
+      </TabsList>
+    </Tabs>
+  );
+}
+
+export default CombatStyleTabs;

--- a/frontend/src/components/features/calculator/CombinedEquipmentDisplay.tsx
+++ b/frontend/src/components/features/calculator/CombinedEquipmentDisplay.tsx
@@ -50,7 +50,7 @@ interface CombinedEquipmentDisplayProps {
 }
 
 export function CombinedEquipmentDisplay({ onEquipmentUpdate, bossForm }: CombinedEquipmentDisplayProps) {
-  const { params, setParams, gearLocked, loadout, setLoadout, resetParams, resetLocks } = useCalculatorStore();
+  const { params, setParams, gearLocked, loadout, setLoadout, resetParams, resetLocks, switchCombatStyle } = useCalculatorStore();
   // Start with 1H + Shield by default
   const [show2hOption, setShow2hOption] = useState(false);
   const [availableAttackStyles, setAvailableAttackStyles] = useState<string[]>([]);
@@ -167,6 +167,20 @@ export function CombinedEquipmentDisplay({ onEquipmentUpdate, bossForm }: Combin
       console.log('[DEBUG] Processing weapon:', weapon.name);
     }
   }, [loadout]);
+
+  // Automatically switch combat style based on weapon attack types
+  useEffect(() => {
+    const styles = weaponStats.attackStyles;
+    if (!styles || Object.keys(styles).length === 0) return;
+    const attackTypes = Object.values(styles).map((s: any) => s.attackType);
+    let detected: 'melee' | 'ranged' | 'magic' | null = null;
+    if (attackTypes.some((t) => t === 'magic')) detected = 'magic';
+    else if (attackTypes.some((t) => t === 'ranged')) detected = 'ranged';
+    else if (attackTypes.some((t) => ['stab', 'slash', 'crush'].includes(t))) detected = 'melee';
+    if (detected && detected !== params.combat_style) {
+      switchCombatStyle(detected);
+    }
+  }, [weaponStats.attackStyles, params.combat_style, switchCombatStyle]);
 
   // Update available attack styles when weapon changes
   useEffect(() => {
@@ -348,7 +362,7 @@ export function CombinedEquipmentDisplay({ onEquipmentUpdate, bossForm }: Combin
                   baseAttackSpeed: 2.4,
                 });
               }}
-              className="mr-2"
+              className="mr-2 data-[state=unchecked]:bg-primary"
             />
             <Label htmlFor="use-2h" className="text-sm">
               {show2hOption ? 'Use 1H' : 'Use 2H'}

--- a/frontend/src/components/features/calculator/ImprovedDpsCalculator.tsx
+++ b/frontend/src/components/features/calculator/ImprovedDpsCalculator.tsx
@@ -10,6 +10,7 @@ import PassiveEffectsDisplay from './PassiveEffectsDisplay';
 import { DefenceReductionPanel } from './DefenceReductionPanel';
 import { PresetSelector } from './PresetSelector';
 import { CalculatorForms } from './CalculatorForms';
+import { CombatStyleTabs } from './CombatStyleTabs';
 import { DpsResultDisplay } from './DpsResultDisplay';
 import { useDpsCalculator } from '@/hooks/useDpsCalculator';
 import { useToast } from '@/hooks/use-toast';
@@ -45,7 +46,11 @@ export function ImprovedDpsCalculator() {
       {/* Main calculator header card */}
       <Card className="w-full bg-card border border-border shadow-md">
         <CardHeader className="border-b border-border pb-4 flex flex-row justify-between items-center">
-
+          <CombatStyleTabs
+            activeTab={activeTab}
+            onTabChange={handleTabChange}
+            onReset={handleReset}
+          />
         </CardHeader>
         
         <CardContent className="pt-6">
@@ -61,7 +66,6 @@ export function ImprovedDpsCalculator() {
             activeTab={activeTab}
             onTabChange={handleTabChange}
             onCalculate={handleCalculate}
-            onReset={handleReset}
             isCalculating={isCalculating}
           />
 

--- a/frontend/src/hooks/useDpsCalculator.ts
+++ b/frontend/src/hooks/useDpsCalculator.ts
@@ -26,6 +26,11 @@ export function useDpsCalculator() {
     setCurrentLoadout(storeLoadout);
   }, [storeLoadout]);
 
+  // keep local tab state in sync with store combat style
+  useEffect(() => {
+    setActiveTab(params.combat_style);
+  }, [params.combat_style]);
+
   const calculateEffects = useCallback(() => {
     return calculatePassiveEffectBonuses(params, currentLoadout, currentBossForm);
   }, [params, currentLoadout, currentBossForm]);


### PR DESCRIPTION
## Summary
- add `CombatStyleTabs` component for top-level combat style selection
- move combat style tabs outside manual forms
- auto-detect combat style from equipped weapon
- keep combat style switch yellow for both 1H and 2H
- sync tab state with store and update attack style selector handler

## Testing
- `npm test --silent` *(fails: Jest encountered unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68459c145b7c832ea94a9df414b693b4