### PR TITLE
Add dotenv support for Azure config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Example environment variables for OSRS Simulator
+# Rename this file to .env and provide your own values.
+
+# Connection string for Azure Blob Storage containing the SQLite databases
+AZURE_STORAGE_CONNECTION_STRING="DefaultEndpointsProtocol=https;AccountName=your_account;AccountKey=your_key;EndpointSuffix=core.windows.net"
+
+# Optional: container name if different from the default 'databases'
+AZURE_STORAGE_CONTAINER_NAME="databases"

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,6 +3,10 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from typing import Dict, Any, List
 import os
+from dotenv import load_dotenv
+
+# Load environment variables from a .env file if present
+load_dotenv()
 
 from .repositories import item_repository, boss_repository
 from .models import (

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,3 +7,4 @@ python-multipart==0.0.6
 httpx<0.28
 azure-functions
 azure-storage-blob==12.19.0
+python-dotenv==1.0.1


### PR DESCRIPTION
## Summary
- provide `.env.example` to document Azure storage settings
- load environment variables from `.env` on startup
- add `python-dotenv` to backend requirements

## Testing
- `python app/testing/UnitTest.py`

------
https://chatgpt.com/codex/tasks/task_e_6845a4823034832eae6b660713b17624