### PR TITLE
Separate Azure deployments

### DIFF
--- a/.github/workflows/azure-static-web-apps-yellow-stone-0daf36a0f.yml
+++ b/.github/workflows/azure-static-web-apps-yellow-stone-0daf36a0f.yml
@@ -23,8 +23,6 @@ jobs:
         with:
           submodules: true
           lfs: false
-      - name: Include backend in API package
-        run: cp -r backend api/
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
@@ -39,16 +37,6 @@ jobs:
         run: |
           cd frontend
           npm test --ci
-      - name: Install OIDC Client from Core Package
-        run: npm install @actions/core@1.6.0 @actions/http-client
-      - name: Get Id Token
-        uses: actions/github-script@v6
-        id: idtoken
-        with:
-           script: |
-               const coredemo = require('@actions/core')
-               return await coredemo.getIDToken()
-           result-encoding: string
       - name: Build And Deploy
         id: builddeploy
         uses: Azure/static-web-apps-deploy@v1
@@ -58,9 +46,7 @@ jobs:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_YELLOW_STONE_0DAF36A0F }}
           action: "upload"
           app_location: "./frontend"
-          api_location: "./api"
-          output_location: "out"
-          github_id_token: ${{ steps.idtoken.outputs.result }}
+          output_location: "out"  # No API functions; backend deployed separately
 
   close_pull_request_job:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'

--- a/.github/workflows/deploy-backend-function-app.yml
+++ b/.github/workflows/deploy-backend-function-app.yml
@@ -3,15 +3,15 @@ name: Deploy Backend to Azure Function App
 on:
   push:
     branches: [ main ]
-    paths: [ 'backend/**', 'api/**' ]  # Trigger when backend changes
+    paths: [ 'backend/**' ]  # Trigger when backend changes
   pull_request:
     branches: [ main ]
-    paths: [ 'backend/**', 'api/**' ]
+    paths: [ 'backend/**' ]
   workflow_dispatch:  # Allow manual deployment
 
 env:
   AZURE_FUNCTIONAPP_NAME: 'OSRS-Simulator-API'
-  AZURE_FUNCTIONAPP_PACKAGE_PATH: './api'
+  AZURE_FUNCTIONAPP_PACKAGE_PATH: './backend'
   PYTHON_VERSION: '3.11'
 
 jobs:
@@ -22,8 +22,6 @@ jobs:
     - name: 'Checkout GitHub Action'
       uses: actions/checkout@v4
 
-    - name: Include backend in API package
-      run: cp -r backend api/
 
     - name: Setup Python
       uses: actions/setup-python@v4
@@ -48,7 +46,7 @@ jobs:
       run: |
         cd ${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}
         source venv/bin/activate
-        python backend/app/testing/UnitTest.py
+        python app/testing/UnitTest.py
 
     - name: 'Login to Azure'
       uses: azure/login@v1


### PR DESCRIPTION
## Summary
- remove backend copy step from Static Web Apps workflow
- deploy backend directly from the backend folder
- clarify frontend workflow does not deploy API functions

## Testing
- `python -m pytest` *(fails: ModuleNotFoundError httpx/app)*
- `npm test --ci` *(fails: jest not found)*


------
https://chatgpt.com/codex/tasks/task_e_68461c92dccc832e9f4e53c397972ddc