### PR TITLE
Add BIS upgrade suggestions endpoint

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -118,6 +118,16 @@ async def get_best_in_slot(params: DpsParameters):
     except Exception as e:
         raise HTTPException(status_code=400, detail=str(e))
 
+
+@app.post("/bis/upgrades", tags=["BIS"])
+async def get_upgrade_suggestions(boss_id: int, params: DpsParameters):
+    """Return DPS improvements for each slot compared to best-in-slot items."""
+    try:
+        result = bis_service.suggest_upgrades(params.model_dump(exclude_none=True), boss_id)
+        return result
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
 @app.get("/bosses", response_model=List[BossSummary], tags=["Bosses"])
 async def get_bosses():
     """

--- a/backend/app/services/bis_service.py
+++ b/backend/app/services/bis_service.py
@@ -43,3 +43,52 @@ def suggest_bis(params: Dict[str, Any]) -> Dict[str, Any]:
             best_per_slot[slot] = {"item": item, "dps": dps}
 
     return {slot: info["item"] for slot, info in best_per_slot.items()}
+
+
+def suggest_upgrades(params: Dict[str, Any], boss_id: int) -> Dict[str, Any]:
+    """Suggest gear upgrades and DPS improvements for the given parameters."""
+
+    # DPS with the current setup
+    current_result = calculation_service.calculate_dps(params)
+    current_dps = current_result.get("dps", 0.0)
+
+    bis_setup = suggest_bis(params)
+    style = params.get("combat_style", "melee")
+
+    upgrades: Dict[str, Any] = {}
+
+    for slot, item in bis_setup.items():
+        stats = item.get("combat_stats") or {}
+        attack_bonuses = stats.get("attack_bonuses", {})
+        other_bonuses = stats.get("other_bonuses", {})
+
+        test_params = params.copy()
+
+        if style == "melee":
+            test_params["melee_strength_bonus"] = other_bonuses.get("strength", 0)
+            atk_type = params.get("attack_type", "slash").lower()
+            test_params["melee_attack_bonus"] = attack_bonuses.get(atk_type, 0)
+        elif style == "ranged":
+            test_params["ranged_strength_bonus"] = other_bonuses.get("ranged strength", 0)
+            test_params["ranged_attack_bonus"] = attack_bonuses.get("ranged", 0)
+        else:  # magic
+            dmg_bonus = other_bonuses.get("magic damage", "0")
+            if isinstance(dmg_bonus, str) and dmg_bonus.endswith("%"):
+                dmg_bonus = float(dmg_bonus.strip("%")) / 100
+            test_params["magic_damage_bonus"] = float(dmg_bonus or 0)
+            test_params["magic_attack_bonus"] = attack_bonuses.get("magic", 0)
+
+        new_result = calculation_service.calculate_dps(test_params)
+        new_dps = new_result.get("dps", 0.0)
+
+        upgrades[slot] = {
+            "best_item": item,
+            "current_dps": current_dps,
+            "upgraded_dps": new_dps,
+            "improvement": new_dps - current_dps,
+        }
+
+    return {
+        "current_dps": current_dps,
+        "upgrades": upgrades,
+    }

--- a/backend/app/testing/test_api.py
+++ b/backend/app/testing/test_api.py
@@ -143,5 +143,25 @@ class TestApiRoutes(unittest.TestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertIsInstance(resp.json(), dict)
 
+    def test_bis_upgrades(self):
+        params = {
+            'combat_style': 'melee',
+            'strength_level': 99,
+            'attack_level': 99,
+            'melee_strength_bonus': 80,
+            'melee_attack_bonus': 80,
+            'attack_style_bonus_strength': 3,
+            'attack_style_bonus_attack': 0,
+            'target_defence_level': 100,
+            'target_defence_bonus': 50,
+            'attack_speed': 2.4
+        }
+        with self.client_ctx as client:
+            resp = client.post('/bis/upgrades?boss_id=1', json=params)
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertIn('current_dps', data)
+        self.assertIn('upgrades', data)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- add `suggest_upgrades` helper to compute DPS gains from BIS items
- expose new `POST /bis/upgrades` endpoint
- test new endpoint in API unit tests

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684629deefd0832e8d639be2e559ee4a