### PR TITLE
Add simulator and upgrade services

### DIFF
--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -35,6 +35,14 @@ export const calculatorApi = {
     const { data } = await apiClient.post('/bis', params);
     return data;
   },
+  simulateBosses: async (params: CalculatorParams): Promise<any> => {
+    const { data } = await apiClient.post('/simulate/bosses', params);
+    return data;
+  },
+  getUpgradeSuggestions: async (params: CalculatorParams): Promise<any> => {
+    const { data } = await apiClient.post('/upgrade-suggestions', params);
+    return data;
+  },
 };
 
 // Bosses API


### PR DESCRIPTION
## Summary
- expose new API helpers for boss simulation and upgrade suggestions

## Testing
- `npm test --prefix frontend`
- `python -m unittest discover backend/app/testing`

------
https://chatgpt.com/codex/tasks/task_e_684629e1552c832e8a6fab77e599f7a2