### PR TITLE
Integrate new raid components

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Key Features
     DPS Comparison: Save and compare multiple equipment setups
     Passive Effects: Automatic detection of relevant passive effects for your setup
     Prayer & Potions: Account for all combat boosting prayers and potions
+    Multi-Boss Simulation: Analyze DPS across multiple bosses at once
+    Upgrade Suggestions: Discover gear improvements for specific bosses
 
 🚀 Getting Started
 Prerequisites

--- a/frontend/src/components/features/calculator/ImprovedDpsCalculator.tsx
+++ b/frontend/src/components/features/calculator/ImprovedDpsCalculator.tsx
@@ -12,6 +12,8 @@ import { PresetSelector } from './PresetSelector';
 import { CalculatorForms } from './CalculatorForms';
 import { CombatStyleTabs } from './CombatStyleTabs';
 import { DpsResultDisplay } from './DpsResultDisplay';
+import { BossDpsTable } from './BossDpsTable';
+import { UpgradeList } from './UpgradeList';
 import { useDpsCalculator } from '@/hooks/useDpsCalculator';
 import { useToast } from '@/hooks/use-toast';
 
@@ -70,11 +72,17 @@ export function ImprovedDpsCalculator() {
           />
 
           {results && (
-            <DpsResultDisplay
-              params={params}
-              results={results}
-              appliedPassiveEffects={appliedPassiveEffects}
-            />
+            <>
+              <DpsResultDisplay
+                params={params}
+                results={results}
+                appliedPassiveEffects={appliedPassiveEffects}
+              />
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-6">
+                <BossDpsTable />
+                <UpgradeList />
+              </div>
+            </>
           )}
         </CardContent>
       </Card>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -35,12 +35,21 @@ export const calculatorApi = {
     const { data } = await apiClient.post('/bis', params);
     return data;
   },
-  simulateBosses: async (params: CalculatorParams): Promise<any> => {
-    const { data } = await apiClient.post('/simulate/bosses', params);
+  simulateBosses: async (
+    params: CalculatorParams,
+    bossIds: number[]
+  ): Promise<Record<number, DpsResult>> => {
+    const { data } = await apiClient.post('/simulate/bosses', {
+      params,
+      boss_ids: bossIds,
+    });
     return data;
   },
-  getUpgradeSuggestions: async (params: CalculatorParams): Promise<any> => {
-    const { data } = await apiClient.post('/upgrade-suggestions', params);
+  getUpgradeSuggestions: async (
+    bossId: number,
+    params: CalculatorParams
+  ): Promise<any> => {
+    const { data } = await apiClient.post(`/bis/upgrades?boss_id=${bossId}`, params);
     return data;
   },
 };


### PR DESCRIPTION
## Summary
- update API client to match new endpoints
- call multi-boss simulation and upgrade APIs
- render BossDpsTable and UpgradeList in calculator
- document new multi-boss and upgrade features

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68462fac1a28832eb8b907a6dd7afb64