### PR TITLE
Fix simulation to handle boss forms

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -11,12 +11,13 @@ load_dotenv()
 
 from .repositories import item_repository, boss_repository
 from .models import (
-    DpsResult, 
-    Boss, 
-    BossSummary, 
-    Item, 
+    DpsResult,
+    Boss,
+    BossSummary,
+    Item,
     ItemSummary,
-    DpsParameters
+    DpsParameters,
+    BossFormSelection,
 )
 from .services import calculation_service
 from .services import seed_service
@@ -470,17 +471,17 @@ async def calculate_item_effect(params: Dict[str, Any]):
 
 class BossSimulationRequest(BaseModel):
     params: DpsParameters
-    boss_ids: List[int]
+    selections: List[BossFormSelection]
 
 
 @app.post("/simulate/bosses", tags=["Simulation"])
 async def simulate_bosses_endpoint(request: BossSimulationRequest):
-    """Return DPS results for each boss id using its defence stats."""
+    """Return DPS results for each selected boss form."""
     try:
         results = simulation_service.simulate_bosses(
-            request.params.model_dump(exclude_none=True), request.boss_ids
+            request.params.model_dump(exclude_none=True), request.selections
         )
-        return {bid: res.model_dump() for bid, res in results.items()}
+        return {fid: res.model_dump() for fid, res in results.items()}
     except Exception as e:
         raise HTTPException(status_code=400, detail=str(e))
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -67,6 +67,13 @@ class BossForm(BaseModel):
     assigned_by: Optional[str] = None
 
 
+class BossFormSelection(BaseModel):
+    """Request selection of a specific boss form."""
+
+    boss_id: int
+    form_id: int
+
+
 class Boss(BaseModel):
     """Represents a boss with metadata."""
 

--- a/backend/app/services/simulation_service.py
+++ b/backend/app/services/simulation_service.py
@@ -22,11 +22,14 @@ def _defence_bonus_for_form(form: Dict[str, Any], params: Dict[str, Any]) -> int
     return form.get("defence_magic", 0)
 
 
-def simulate_bosses(params: Dict[str, Any], boss_ids: List[int]) -> Dict[int, DpsResult]:
-    """Simulate DPS against each boss ID using its defence stats."""
+def simulate_bosses(params: Dict[str, Any], selections: List[Dict[str, int]]) -> Dict[int, DpsResult]:
+    """Simulate DPS against each selected boss form."""
     results: Dict[int, DpsResult] = {}
 
-    for boss_id in boss_ids:
+    for sel in selections:
+        boss_id = sel.get("boss_id")
+        form_id = sel.get("form_id")
+
         boss = boss_repository.get_boss(boss_id)
         if not boss:
             continue
@@ -35,8 +38,7 @@ def simulate_bosses(params: Dict[str, Any], boss_ids: List[int]) -> Dict[int, Dp
         if not forms:
             continue
 
-        # Only use the first form for now
-        form = forms[0]
+        form = next((f for f in forms if f.get("id") == form_id), forms[0])
         form_params = params.copy()
         form_params["target_defence_level"] = form.get(
             "defence_level", form_params.get("target_defence_level", 1)
@@ -50,6 +52,6 @@ def simulate_bosses(params: Dict[str, Any], boss_ids: List[int]) -> Dict[int, Dp
         form_params["target_defence_bonus"] = _defence_bonus_for_form(form, form_params)
 
         calc = calculation_service.calculate_dps(form_params)
-        results[boss_id] = DpsResult(**calc)
+        results[form.get("id")] = DpsResult(**calc)
 
     return results

--- a/backend/app/testing/UnitTest.py
+++ b/backend/app/testing/UnitTest.py
@@ -461,7 +461,7 @@ class TestSimulationService(unittest.TestCase):
             }
 
             from app.services import simulation_service
-            result = simulation_service.simulate_bosses(params, [1])
+            result = simulation_service.simulate_bosses(params, [{"boss_id": 1, "form_id": 1}])
 
             self.assertIn(1, result)
             self.assertEqual(result[1].dps, 5.0)
@@ -477,7 +477,7 @@ class TestSimulationService(unittest.TestCase):
 
         with patch.dict(sys.modules, {"app.repositories.boss_repository": dummy_repo}):
             from app.services import simulation_service
-            result = simulation_service.simulate_bosses(params, [99])
+            result = simulation_service.simulate_bosses(params, [{"boss_id": 99, "form_id": 1}])
             self.assertEqual(result, {})
 
 if __name__ == "__main__":

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,10 +1,11 @@
 import axios from 'axios';
-import { 
-  CalculatorParams, 
-  DpsResult, 
-  Boss, 
-  Item, 
-  BossForm 
+import {
+  CalculatorParams,
+  DpsResult,
+  Boss,
+  Item,
+  BossForm,
+  BossFormSelection,
 } from '@/types/calculator';
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
@@ -37,11 +38,11 @@ export const calculatorApi = {
   },
   simulateBosses: async (
     params: CalculatorParams,
-    bossIds: number[]
+    forms: BossFormSelection[]
   ): Promise<Record<number, DpsResult>> => {
     const { data } = await apiClient.post('/simulate/bosses', {
       params,
-      boss_ids: bossIds,
+      selections: forms,
     });
     return data;
   },

--- a/frontend/src/types/calculator.ts
+++ b/frontend/src/types/calculator.ts
@@ -209,6 +209,11 @@ export interface BossForm {
   size?: number;
 }
 
+export interface BossFormSelection {
+  boss_id: number;
+  form_id: number;
+}
+
 export interface Item {
   id: number;
   name: string;


### PR DESCRIPTION
## Summary
- add `BossFormSelection` model for referencing specific boss forms
- update simulation service and API to accept selections
- send form ids from the frontend when running simulations
- adjust unit tests for new API

## Testing
- `python -m unittest discover backend/app/testing`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684640d7e840832e941bdae7ed9e9c37