### PR TITLE
Clarify .env setup and log API URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,9 +122,12 @@ DPS = Hit Chance × ((Max Hit + 1) / 2) / Attack Speed
 ⚙️ Configuration
 Environment Variables
 
-Create a .env.local file in the root directory:
+Create a `.env.local` file inside the `frontend` directory:
 
-NEXT_PUBLIC_API_URL=http://localhost:8000
+```bash
+cd frontend
+echo "NEXT_PUBLIC_API_URL=http://localhost:8000" > .env.local
+```
 
 For production, set this to your deployed API URL. The deployment workflows
 expect a repository secret named `BACKEND_URL` which will be exposed as

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -8,6 +8,8 @@ import {
 } from '@/types/calculator';
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+// Log the resolved API URL to help debug environment issues
+console.log('API_URL:', API_URL);
 
 // Create axios instance with base configuration
 const apiClient = axios.create({


### PR DESCRIPTION
## Summary
- clarify that `.env.local` belongs in the `frontend` directory
- log the resolved API URL in the frontend API service to help debug env issues

## Testing
- `npm test`
- `pytest app/testing/test_api.py app/testing/test_database.py` *(fails: ImportError: cannot import name 'DatabaseService')*

------
https://chatgpt.com/codex/tasks/task_e_6846abc47d40832eba62e12c04b9acfa