### PR TITLE
Add pagination for items and bosses

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,28 @@ Request Body: `DpsParameters`
 
 Response: A mapping of gear slot to item details.
 
+List Bosses
+-----------
+
+GET `/bosses`
+
+Query Parameters:
+
+- `page` – Page number (default `1`)
+- `page_size` – Results per page (default `50`)
+
+List Items
+----------
+
+GET `/items`
+
+Query Parameters:
+
+- `combat_only` – Only items with combat stats (default `true`)
+- `tradeable_only` – Only tradeable items (default `false`)
+- `page` – Page number (default `1`)
+- `page_size` – Results per page (default `50`)
+
 See the API documentation at /docs for more endpoints.
 📊 Data Sources
 

--- a/api/GetBosses/__init__.py
+++ b/api/GetBosses/__init__.py
@@ -4,5 +4,7 @@ from ..common import json_response
 from app.repositories import boss_repository
 
 async def main(req: func.HttpRequest) -> func.HttpResponse:
-    bosses = boss_repository.get_all_bosses()
+    page = int(req.params.get('page', '1'))
+    page_size = int(req.params.get('page_size', '50'))
+    bosses = boss_repository.get_all_bosses(limit=page_size, offset=(page - 1) * page_size)
     return json_response(bosses)

--- a/api/GetItems/__init__.py
+++ b/api/GetItems/__init__.py
@@ -6,5 +6,12 @@ from app.repositories import item_repository
 async def main(req: func.HttpRequest) -> func.HttpResponse:
     combat_only = req.params.get('combat_only', 'true').lower() == 'true'
     tradeable_only = req.params.get('tradeable_only', 'false').lower() == 'true'
-    items = item_repository.get_all_items(combat_only=combat_only, tradeable_only=tradeable_only)
+    page = int(req.params.get('page', '1'))
+    page_size = int(req.params.get('page_size', '50'))
+    items = item_repository.get_all_items(
+        combat_only=combat_only,
+        tradeable_only=tradeable_only,
+        limit=page_size,
+        offset=(page - 1) * page_size,
+    )
     return json_response(items)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -119,14 +119,17 @@ async def get_best_in_slot(params: DpsParameters):
         raise HTTPException(status_code=400, detail=str(e))
 
 @app.get("/bosses", response_model=List[BossSummary], tags=["Bosses"])
-async def get_bosses():
+async def get_bosses(
+    page: int = Query(1, ge=1, description="Page number"),
+    page_size: int = Query(50, ge=1, le=100, description="Results per page"),
+):
     """
     Get a list of all bosses.
     
     Returns a list of boss summaries with basic information.
     """
     try:
-        bosses = boss_repository.get_all_bosses()
+        bosses = boss_repository.get_all_bosses(limit=page_size, offset=(page - 1) * page_size)
         
         # If no bosses are found in the database, return mock data
         if not bosses:
@@ -237,7 +240,9 @@ async def get_boss(boss_id: int):
 @app.get("/items", response_model=List[ItemSummary], tags=["Items"])
 async def get_items(
     combat_only: bool = Query(True, description="Filter to only show items with combat stats"),
-    tradeable_only: bool = Query(False, description="Filter to only show tradeable items")
+    tradeable_only: bool = Query(False, description="Filter to only show tradeable items"),
+    page: int = Query(1, ge=1, description="Page number"),
+    page_size: int = Query(50, ge=1, le=100, description="Results per page")
 ):
     """
     Get a list of all items with optional filters.
@@ -245,7 +250,12 @@ async def get_items(
     Returns a list of item summaries with basic information.
     """
     try:
-        items = item_repository.get_all_items(combat_only=combat_only, tradeable_only=tradeable_only)
+        items = item_repository.get_all_items(
+            combat_only=combat_only,
+            tradeable_only=tradeable_only,
+            limit=page_size,
+            offset=(page - 1) * page_size,
+        )
         
         # If no items are found in the database, return mock data
         if not items:

--- a/backend/app/repositories/boss_repository.py
+++ b/backend/app/repositories/boss_repository.py
@@ -3,8 +3,9 @@ from typing import Any, Dict, List, Optional
 from ..database import azure_sql_service as db_service
 
 
-def get_all_bosses() -> List[Dict[str, Any]]:
-    return db_service.get_all_bosses()
+def get_all_bosses(limit: int | None = None, offset: int | None = None) -> List[Dict[str, Any]]:
+    """Return bosses with optional pagination."""
+    return db_service.get_all_bosses(limit=limit, offset=offset)
 
 
 def get_boss(boss_id: int) -> Optional[Dict[str, Any]]:

--- a/backend/app/repositories/item_repository.py
+++ b/backend/app/repositories/item_repository.py
@@ -3,8 +3,19 @@ from typing import Any, Dict, List, Optional
 from ..database import azure_sql_service as db_service
 
 
-def get_all_items(combat_only: bool = True, tradeable_only: bool = False) -> List[Dict[str, Any]]:
-    return db_service.get_all_items(combat_only=combat_only, tradeable_only=tradeable_only)
+def get_all_items(
+    combat_only: bool = True,
+    tradeable_only: bool = False,
+    limit: int | None = None,
+    offset: int | None = None,
+) -> List[Dict[str, Any]]:
+    """Return items with optional pagination."""
+    return db_service.get_all_items(
+        combat_only=combat_only,
+        tradeable_only=tradeable_only,
+        limit=limit,
+        offset=offset,
+    )
 
 
 def get_item(item_id: int) -> Optional[Dict[str, Any]]:

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -65,3 +65,10 @@ The React frontend is found in `frontend/src` and relies on:
 
 A simple about page exists at `frontend/src/app/about/page.tsx` and describes the project, its data sources and technologies used. It links back to the main calculator page.
 
+## API Pagination
+
+The `/items` and `/bosses` endpoints accept optional `page` and `page_size` query parameters. These correspond to SQL `OFFSET`/`FETCH` clauses in the database service.
+
+- `page` defaults to `1`.
+- `page_size` defaults to `50`.
+

--- a/frontend/src/components/features/calculator/BossSelector.tsx
+++ b/frontend/src/components/features/calculator/BossSelector.tsx
@@ -43,15 +43,27 @@ export function BossSelector({ onSelectBoss, onSelectForm }: BossSelectorProps) 
   const [selectedBoss, setSelectedBoss] = useState<Boss | null>(null);
   const [selectedForm, setSelectedForm] = useState<BossForm | null>(null);
   const [bossIcons, setBossIcons] = useState<Record<number, string>>({});
+  const [bosses, setBosses] = useState<Boss[]>([]);
+  const [page, setPage] = useState(1);
+  const pageSize = 50;
   const { params, setParams, lockBoss, unlockBoss, bossLocked } = useCalculatorStore();
   const { toast } = useToast();
   
-  // Fetch all bosses
-  const { data: bosses, isLoading } = useQuery({
-    queryKey: ['bosses'],
-    queryFn: bossesApi.getAllBosses,
+  // Fetch bosses with pagination
+  const { data, isLoading } = useQuery({
+    queryKey: ['bosses', page],
+    queryFn: () => bossesApi.getAllBosses({ page, page_size: pageSize }),
+    keepPreviousData: true,
     staleTime: Infinity,
   });
+
+  useEffect(() => {
+    if (data) {
+      setBosses((prev) => (page === 1 ? data : [...prev, ...data]));
+    }
+  }, [data, page]);
+
+  const loadMore = () => setPage((p) => p + 1);
 
   // Fetch specific boss details when a boss is selected
   const { data: bossDetails, isLoading: isLoadingDetails } = useQuery({
@@ -372,6 +384,13 @@ export function BossSelector({ onSelectBoss, onSelectForm }: BossSelectorProps) 
                       ))
                     )}
                   </CommandList>
+                  {data && data.length === pageSize && (
+                    <div className="flex justify-center p-2">
+                      <Button variant="ghost" size="sm" onClick={loadMore}>
+                        Load More
+                      </Button>
+                    </div>
+                  )}
                 </CommandGroup>
               </Command>
             </PopoverContent>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -41,8 +41,8 @@ export const calculatorApi = {
 
 // Bosses API
 export const bossesApi = {
-  getAllBosses: async (): Promise<Boss[]> => {
-    const { data } = await apiClient.get('/bosses');
+  getAllBosses: async (params?: { page?: number; page_size?: number }): Promise<Boss[]> => {
+    const { data } = await apiClient.get('/bosses', { params });
     return data;
   },
 
@@ -59,7 +59,9 @@ export const bossesApi = {
 
 // Items API
 export const itemsApi = {
-  getAllItems: async (params?: { combat_only?: boolean; tradeable_only?: boolean }): Promise<Item[]> => {
+  getAllItems: async (
+    params?: { combat_only?: boolean; tradeable_only?: boolean; page?: number; page_size?: number }
+  ): Promise<Item[]> => {
     const { data } = await apiClient.get('/items', { params });
     return data;
   },


### PR DESCRIPTION
## Summary
- support `page` and `page_size` on `/items` and `/bosses`
- forward pagination values through repositories and SQL service
- update Azure Functions to read pagination query params
- add pagination handling to API services and selectors
- document new query params in README and developer guide

## Testing
- `python -m unittest discover backend/app/testing` *(fails: ModuleNotFoundError)*
- `npm test --silent` in `frontend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846c66c89a4832e952b97ba9d10ca3a