### PR TITLE
Add pagination-aware query keys

### DIFF
--- a/frontend/src/components/features/calculator/BossSelector.tsx
+++ b/frontend/src/components/features/calculator/BossSelector.tsx
@@ -46,11 +46,16 @@ export function BossSelector({ onSelectBoss, onSelectForm }: BossSelectorProps) 
   const { params, setParams, lockBoss, unlockBoss, bossLocked } = useCalculatorStore();
   const { toast } = useToast();
   
+  // Pagination state (default to first page with 50 bosses)
+  const [page, setPage] = useState(1);
+  const [pageSize] = useState(50);
+
   // Fetch all bosses
   const { data: bosses, isLoading } = useQuery({
-    queryKey: ['bosses'],
-    queryFn: bossesApi.getAllBosses,
+    queryKey: ['bosses', page, pageSize],
+    queryFn: () => bossesApi.getAllBosses({ page, page_size: pageSize }),
     staleTime: Infinity,
+    keepPreviousData: true,
   });
 
   // Fetch specific boss details when a boss is selected

--- a/frontend/src/components/features/calculator/DirectBossSelector.tsx
+++ b/frontend/src/components/features/calculator/DirectBossSelector.tsx
@@ -44,11 +44,16 @@ export function DirectBossSelector({ onSelectBoss, onSelectForm, className }: Di
   const { toast } = useToast();
   const commandRef = useRef<HTMLDivElement>(null);
   
+  // Pagination state (default to first page with 50 bosses)
+  const [page, setPage] = useState(1);
+  const [pageSize] = useState(50);
+
   // Fetch all bosses
   const { data: bosses, isLoading } = useQuery({
-    queryKey: ['bosses'],
-    queryFn: bossesApi.getAllBosses,
+    queryKey: ['bosses', page, pageSize],
+    queryFn: () => bossesApi.getAllBosses({ page, page_size: pageSize }),
     staleTime: Infinity,
+    keepPreviousData: true,
   });
 
   // Fetch specific boss details when a boss is selected

--- a/frontend/src/components/features/calculator/ItemSelector.tsx
+++ b/frontend/src/components/features/calculator/ItemSelector.tsx
@@ -34,11 +34,22 @@ export function ItemSelector({ slot, onSelectItem }: ItemSelectorProps) {
   const { params, setParams } = useCalculatorStore();
   const combatStyle = params.combat_style;
   
+  // Pagination state (default to first page with 50 items)
+  const [page, setPage] = useState(1);
+  const [pageSize] = useState(50);
+
   // Fetch items (with combat stats only)
   const { data: items, isLoading } = useQuery({
-    queryKey: ['items', { combat_only: true, tradeable_only: false }],
-    queryFn: () => itemsApi.getAllItems({ combat_only: true, tradeable_only: false }),
+    queryKey: ['items', page, pageSize, { combat_only: true, tradeable_only: false }],
+    queryFn: () =>
+      itemsApi.getAllItems({
+        page,
+        page_size: pageSize,
+        combat_only: true,
+        tradeable_only: false,
+      }),
     staleTime: Infinity,
+    keepPreviousData: true,
   });
 
   // Fetch specific item details when an item is selected

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -41,8 +41,10 @@ export const calculatorApi = {
 
 // Bosses API
 export const bossesApi = {
-  getAllBosses: async (): Promise<Boss[]> => {
-    const { data } = await apiClient.get('/bosses');
+  getAllBosses: async (
+    params?: { page?: number; page_size?: number }
+  ): Promise<Boss[]> => {
+    const { data } = await apiClient.get('/bosses', { params });
     return data;
   },
 
@@ -59,7 +61,14 @@ export const bossesApi = {
 
 // Items API
 export const itemsApi = {
-  getAllItems: async (params?: { combat_only?: boolean; tradeable_only?: boolean }): Promise<Item[]> => {
+  getAllItems: async (
+    params?: {
+      page?: number;
+      page_size?: number;
+      combat_only?: boolean;
+      tradeable_only?: boolean;
+    }
+  ): Promise<Item[]> => {
     const { data } = await apiClient.get('/items', { params });
     return data;
   },


### PR DESCRIPTION
## Summary
- allow pagination params for `getAllItems` and `getAllBosses`
- cache items per page in `ItemSelector`
- cache bosses per page in `BossSelector` and `DirectBossSelector`

## Testing
- `npm test`
- `python -m pytest` *(fails: ImportError)*
- `python app/testing/UnitTest.py`
- `python app/testing/test_api.py`


------
https://chatgpt.com/codex/tasks/task_e_6846c671ac24832e8048c34f8ceb2478