### PR TITLE
Add API caching docs and fix items endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,13 @@ Query Parameters:
 - `page` – Page number (default `1`)
 - `page_size` – Results per page (default `50`)
 
+Performance & API Best Practices
+-------------------------------
+
+- Use `page` and `page_size` on `/items` and `/bosses` to paginate responses and minimize payload size.
+- Item and boss detail endpoints utilise server-side in-memory caches. Responses include a `Cache-Control` header with a `max-age` matching the `CACHE_TTL_SECONDS` setting.
+- Adjust cache duration via the `CACHE_TTL_SECONDS` environment variable when launching the backend.
+
 See the API documentation at /docs for more endpoints.
 📊 Data Sources
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -254,16 +254,13 @@ async def get_items(
     Returns a list of item summaries with basic information.
     """
     try:
-
-        items = item_repository.get_all_items(combat_only=combat_only, tradeable_only=tradeable_only)
-        response.headers["Cache-Control"] = f"public, max-age={CACHE_TTL_SECONDS}"
-
         items = item_repository.get_all_items(
             combat_only=combat_only,
             tradeable_only=tradeable_only,
             limit=page_size,
             offset=(page - 1) * page_size,
         )
+        response.headers["Cache-Control"] = f"public, max-age={CACHE_TTL_SECONDS}"
 
         
         # If no items are found in the database, return mock data

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -72,3 +72,18 @@ The `/items` and `/bosses` endpoints accept optional `page` and `page_size` quer
 - `page` defaults to `1`.
 - `page_size` defaults to `50`.
 
+### Caching
+
+Item and boss detail lookups are cached using `cachetools.TTLCache`.
+The cache duration is controlled by the `CACHE_TTL_SECONDS` environment
+variable defined in `backend/app/config/settings.py`.
+
+To override the default 3600‑second TTL during development run:
+
+```bash
+export CACHE_TTL_SECONDS=600  # 10 minutes
+uvicorn app.main:app --reload
+```
+
+Caches automatically expire when the TTL elapses.
+


### PR DESCRIPTION
## Summary
- document server-side caching and pagination best practices
- explain cache TTL configuration in developer docs
- remove redundant database call in `/items` endpoint

## Testing
- `python -m unittest discover backend/app/testing` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6846c98a8814832eb6f9c5b0b5caff96