### PR TITLE
Disable pagination for search

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,17 @@ Query Parameters:
 - `page` – Page number (default `1`)
 - `page_size` – Results per page (default `50`)
 
+Search Endpoints
+----------------
+
+GET `/search/bosses` - Search for bosses by name
+GET `/search/items` - Search for items by name
+
+Query Parameters:
+
+- `query` – Search term (required)
+- `limit` – Maximum results to return. If omitted, all matches are returned.
+
 List Items
 ----------
 

--- a/api/SearchBosses/__init__.py
+++ b/api/SearchBosses/__init__.py
@@ -7,9 +7,14 @@ async def main(req: func.HttpRequest) -> func.HttpResponse:
     query = req.params.get('query')
     if not query:
         return func.HttpResponse("Missing query", status_code=400)
-    try:
-        limit = int(req.params.get('limit', 10))
-    except ValueError:
-        return func.HttpResponse("Invalid limit", status_code=400)
+    limit_param = req.params.get('limit')
+    if limit_param is not None:
+        try:
+            limit = int(limit_param)
+        except ValueError:
+            return func.HttpResponse("Invalid limit", status_code=400)
+    else:
+        limit = None
+
     results = boss_repository.search_bosses(query, limit=limit)
     return json_response(results)

--- a/api/SearchItems/__init__.py
+++ b/api/SearchItems/__init__.py
@@ -7,9 +7,13 @@ async def main(req: func.HttpRequest) -> func.HttpResponse:
     query = req.params.get('query')
     if not query:
         return func.HttpResponse("Missing query", status_code=400)
-    try:
-        limit = int(req.params.get('limit', 10))
-    except ValueError:
-        return func.HttpResponse("Invalid limit", status_code=400)
+    limit_param = req.params.get('limit')
+    if limit_param is not None:
+        try:
+            limit = int(limit_param)
+        except ValueError:
+            return func.HttpResponse("Invalid limit", status_code=400)
+    else:
+        limit = None
     results = item_repository.search_items(query, limit=limit)
     return json_response(results)

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -317,18 +317,29 @@ class AzureSQLDatabaseService:
             print(f"Error getting item {item_id}: {e}")
             return None
 
-    def search_bosses(self, query: str, limit: int = 10) -> List[Dict[str, Any]]:
+    def search_bosses(self, query: str, limit: int | None = None) -> List[Dict[str, Any]]:
         """Search bosses by name."""
         try:
             conn = self._get_connection()
             cursor = conn.cursor()
-            
-            cursor.execute("""
-                SELECT TOP (?) id, name, raid_group, location
-                FROM bosses
-                WHERE name LIKE ?
-                ORDER BY name
-            """, (limit, f"%{query}%"))
+
+            sql = (
+                "SELECT id, name, raid_group, location\n"
+                "FROM bosses\n"
+                "WHERE name LIKE ?\n"
+                "ORDER BY name"
+            )
+            params: list[Any] = [f"%{query}%"]
+            if limit is not None:
+                sql = (
+                    "SELECT TOP (?) id, name, raid_group, location\n"
+                    "FROM bosses\n"
+                    "WHERE name LIKE ?\n"
+                    "ORDER BY name"
+                )
+                params.insert(0, limit)
+
+            cursor.execute(sql, params)
             
             bosses = []
             for row in cursor.fetchall():
@@ -346,19 +357,31 @@ class AzureSQLDatabaseService:
             print(f"Error searching bosses: {e}")
             return []
 
-    def search_items(self, query: str, limit: int = 10) -> List[Dict[str, Any]]:
+    def search_items(self, query: str, limit: int | None = None) -> List[Dict[str, Any]]:
         """Search items by name."""
         try:
             conn = self._get_connection()
             cursor = conn.cursor()
-            
-            cursor.execute("""
-                SELECT TOP (?) id, name, has_special_attack, has_passive_effect,
-                       has_combat_stats, is_tradeable, slot, icons
-                FROM items
-                WHERE name LIKE ?
-                ORDER BY name
-            """, (limit, f"%{query}%"))
+
+            sql = (
+                "SELECT id, name, has_special_attack, has_passive_effect,\n"
+                "       has_combat_stats, is_tradeable, slot, icons\n"
+                "FROM items\n"
+                "WHERE name LIKE ?\n"
+                "ORDER BY name"
+            )
+            params: list[Any] = [f"%{query}%"]
+            if limit is not None:
+                sql = (
+                    "SELECT TOP (?) id, name, has_special_attack, has_passive_effect,\n"
+                    "       has_combat_stats, is_tradeable, slot, icons\n"
+                    "FROM items\n"
+                    "WHERE name LIKE ?\n"
+                    "ORDER BY name"
+                )
+                params.insert(0, limit)
+
+            cursor.execute(sql, params)
             
             items = []
             for row in cursor.fetchall():
@@ -386,6 +409,9 @@ class AzureSQLDatabaseService:
         except Exception as e:
             print(f"Error searching items: {e}")
             return []
+
+# Provide legacy name for unit tests
+DatabaseService = AzureSQLDatabaseService
 
 # Create a singleton instance
 azure_sql_service = AzureSQLDatabaseService()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -431,7 +431,7 @@ async def get_item(item_id: int, response: Response):
         raise HTTPException(status_code=500, detail=f"Failed to retrieve item: {str(e)}")
 
 @app.get("/search/bosses", response_model=List[BossSummary], tags=["Search"])
-async def search_bosses(query: str, limit: int = 10):
+async def search_bosses(query: str, limit: int | None = None):
     """
     Search for bosses by name.
     
@@ -444,7 +444,7 @@ async def search_bosses(query: str, limit: int = 10):
         raise HTTPException(status_code=500, detail=f"Search failed: {str(e)}")
 
 @app.get("/search/items", response_model=List[ItemSummary], tags=["Search"])
-async def search_items(query: str, limit: int = 10):
+async def search_items(query: str, limit: int | None = None):
     """
     Search for items by name.
     

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -193,4 +193,4 @@ class SearchQuery(BaseModel):
     """Query parameters for search endpoints."""
 
     query: str
-    limit: int = 10
+    limit: int | None = None

--- a/backend/app/repositories/boss_repository.py
+++ b/backend/app/repositories/boss_repository.py
@@ -18,5 +18,5 @@ def get_boss(boss_id: int) -> Optional[Dict[str, Any]]:
     return db_service.get_boss(boss_id)
 
 
-def search_bosses(query: str, limit: int = 10) -> List[Dict[str, Any]]:
+def search_bosses(query: str, limit: int | None = None) -> List[Dict[str, Any]]:
     return db_service.search_bosses(query, limit=limit)

--- a/backend/app/repositories/item_repository.py
+++ b/backend/app/repositories/item_repository.py
@@ -30,5 +30,5 @@ def get_item(item_id: int) -> Optional[Dict[str, Any]]:
     return db_service.get_item(item_id)
 
 
-def search_items(query: str, limit: int = 10) -> List[Dict[str, Any]]:
+def search_items(query: str, limit: int | None = None) -> List[Dict[str, Any]]:
     return db_service.search_items(query, limit=limit)


### PR DESCRIPTION
## Summary
- disable pagination for search endpoints so they query the full DB unless an optional `limit` is passed
- update azure functions to use optional limit
- document search endpoints
- expose legacy `DatabaseService` alias for tests

## Testing
- `pytest -q` *(fails: Client.__init__ got unexpected keyword argument 'app')*

------
https://chatgpt.com/codex/tasks/task_e_6846cd155d24832ebb274187f4388641