### PR TITLE
Restore boss form preview in selector

### DIFF
--- a/frontend/src/components/features/calculator/BossSelector.tsx
+++ b/frontend/src/components/features/calculator/BossSelector.tsx
@@ -49,12 +49,8 @@ export function BossSelector({ onSelectBoss, onSelectForm }: BossSelectorProps) 
   const { params, setParams, lockBoss, unlockBoss, bossLocked } = useCalculatorStore();
   const { toast } = useToast();
   
-  // Pagination state (default to first page with 50 bosses)
-  const [page, setPage] = useState(1);
-  const [pageSize] = useState(50);
-
   // Fetch all bosses
-  const { data: bosses, isLoading } = useQuery({
+  const { data, isLoading } = useQuery({
     queryKey: ['bosses', page, pageSize],
     queryFn: () => bossesApi.getAllBosses({ page, page_size: pageSize }),
     staleTime: Infinity,

--- a/frontend/src/components/features/calculator/DirectBossSelector.tsx
+++ b/frontend/src/components/features/calculator/DirectBossSelector.tsx
@@ -48,15 +48,10 @@ export function DirectBossSelector({ onSelectBoss, onSelectForm, className }: Di
   const commandRef = useRef<HTMLDivElement>(null);
   
 
-  // Pagination state (default to first page with 50 bosses)
-  const [page, setPage] = useState(1);
-  const [pageSize] = useState(50);
-
   // Fetch all bosses
-  const { data: bosses, isLoading } = useQuery({
+  const { data, isLoading } = useQuery({
     queryKey: ['bosses', page, pageSize],
     queryFn: () => bossesApi.getAllBosses({ page, page_size: pageSize }),
-
     staleTime: Infinity,
     keepPreviousData: true,
   });


### PR DESCRIPTION
## Summary
- fix duplicated state in `BossSelector` and `DirectBossSelector`
- use query results correctly so boss forms render with image, stats, and size

## Testing
- `npm test` *(fails: jest not found)*
- `pytest -q` *(fails: ModuleNotFoundError: httpx)*

------
https://chatgpt.com/codex/tasks/task_e_6846cf898288832ea8b564a3347406ea