### PR TITLE
Cache boss and item lists for faster search

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,10 @@ in the first writable search directory so subsequent requests are fast.
 
 The API also caches boss and item lookups in memory. Set the
 `CACHE_TTL_SECONDS` environment variable to control how long (in seconds)
-these results remain cached. The default is `3600` seconds.
+these results remain cached. The default is `3600` seconds. On the first
+request the server loads and caches the full boss and item lists, and all
+subsequent search requests are served from this in-memory cache so the
+database is only queried when a specific record is requested.
 
 🔄 API Reference
 Calculate DPS

--- a/backend/app/repositories/boss_repository.py
+++ b/backend/app/repositories/boss_repository.py
@@ -5,12 +5,30 @@ from cachetools import TTLCache, cached
 from ..database import azure_sql_service as db_service
 from ..config.settings import CACHE_TTL_SECONDS
 
-_all_bosses_cache = TTLCache(maxsize=8, ttl=CACHE_TTL_SECONDS)
+_all_bosses_cache = TTLCache(maxsize=1, ttl=CACHE_TTL_SECONDS)
 _boss_cache = TTLCache(maxsize=256, ttl=CACHE_TTL_SECONDS)
 
-def get_all_bosses(limit: int | None = None, offset: int | None = None) -> List[Dict[str, Any]]:
-    """Return bosses with optional pagination."""
-    return db_service.get_all_bosses(limit=limit, offset=offset)
+
+def _load_all_bosses() -> List[Dict[str, Any]]:
+    """Load all bosses from the database and cache them."""
+    bosses = _all_bosses_cache.get("all")
+    if bosses is None:
+        bosses = db_service.get_all_bosses()
+        _all_bosses_cache["all"] = bosses
+    return bosses
+
+
+def get_all_bosses(
+    limit: int | None = None, offset: int | None = None
+) -> List[Dict[str, Any]]:
+    """Return bosses with optional pagination using cached data."""
+    bosses = _load_all_bosses()
+    if limit is not None or offset is not None:
+        off = offset or 0
+        if limit is None:
+            return bosses[off:]
+        return bosses[off : off + limit]
+    return bosses
 
 @cached(_boss_cache)
 def get_boss(boss_id: int) -> Optional[Dict[str, Any]]:
@@ -19,4 +37,10 @@ def get_boss(boss_id: int) -> Optional[Dict[str, Any]]:
 
 
 def search_bosses(query: str, limit: int | None = None) -> List[Dict[str, Any]]:
-    return db_service.search_bosses(query, limit=limit)
+    """Search the cached boss list."""
+    bosses = _load_all_bosses()
+    q = query.lower()
+    results = [b for b in bosses if q in b["name"].lower()]
+    if limit is not None:
+        return results[:limit]
+    return results

--- a/backend/app/repositories/item_repository.py
+++ b/backend/app/repositories/item_repository.py
@@ -5,8 +5,17 @@ from cachetools import TTLCache, cached
 from ..database import azure_sql_service as db_service
 from ..config.settings import CACHE_TTL_SECONDS
 
-_all_items_cache = TTLCache(maxsize=32, ttl=CACHE_TTL_SECONDS)
+_all_items_cache = TTLCache(maxsize=1, ttl=CACHE_TTL_SECONDS)
 _item_cache = TTLCache(maxsize=512, ttl=CACHE_TTL_SECONDS)
+
+
+def _load_all_items() -> List[Dict[str, Any]]:
+    """Load all items from the database and cache them."""
+    items = _all_items_cache.get("all")
+    if items is None:
+        items = db_service.get_all_items(combat_only=False)
+        _all_items_cache["all"] = items
+    return items
 
 
 def get_all_items(
@@ -15,13 +24,20 @@ def get_all_items(
     limit: int | None = None,
     offset: int | None = None,
 ) -> List[Dict[str, Any]]:
-    """Return items with optional pagination."""
-    return db_service.get_all_items(
-        combat_only=combat_only,
-        tradeable_only=tradeable_only,
-        limit=limit,
-        offset=offset,
-    )
+    """Return items with optional pagination using cached data."""
+    items = _load_all_items()
+    # Apply filters locally for the cached list
+    if combat_only:
+        items = [i for i in items if i.get("has_combat_stats")]
+    if tradeable_only:
+        items = [i for i in items if i.get("is_tradeable")]
+
+    if limit is not None or offset is not None:
+        off = offset or 0
+        if limit is None:
+            return items[off:]
+        return items[off : off + limit]
+    return items
 
 
 @cached(_item_cache)
@@ -31,4 +47,10 @@ def get_item(item_id: int) -> Optional[Dict[str, Any]]:
 
 
 def search_items(query: str, limit: int | None = None) -> List[Dict[str, Any]]:
-    return db_service.search_items(query, limit=limit)
+    """Search the cached item list."""
+    items = _load_all_items()
+    q = query.lower()
+    results = [i for i in items if q in i["name"].lower()]
+    if limit is not None:
+        return results[:limit]
+    return results


### PR DESCRIPTION
## Summary
- cache the complete boss and item lists on first load
- serve search results from memory
- document the search cache

## Testing
- `python backend/app/testing/UnitTest.py`

------
https://chatgpt.com/codex/tasks/task_e_6846d17465b0832e80a5e7c4db3ec74e