### PR TITLE
Fix item selector pagination state

### DIFF
--- a/frontend/src/components/features/calculator/ItemSelector.tsx
+++ b/frontend/src/components/features/calculator/ItemSelector.tsx
@@ -33,14 +33,15 @@ export function ItemSelector({ slot, onSelectItem }: ItemSelectorProps) {
   const [selectedItem, setSelectedItem] = useState<Item | null>(null);
   const { params, setParams } = useCalculatorStore();
   const combatStyle = params.combat_style;
-  
+
 
   // Pagination state (default to first page with 50 items)
   const [page, setPage] = useState(1);
   const [pageSize] = useState(50);
+  const [items, setItems] = useState<Item[]>([]);
 
   // Fetch items (with combat stats only)
-  const { data: items, isLoading } = useQuery({
+  const { data, isLoading } = useQuery({
     queryKey: ['items', page, pageSize, { combat_only: true, tradeable_only: false }],
     queryFn: () =>
       itemsApi.getAllItems({


### PR DESCRIPTION
## Summary
- add missing `items` state to `ItemSelector`
- update query variable names

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846d35b55fc832e96f4eec3cfd9ddf5