### PR TITLE
Make boss form dropdown always visible

### DIFF
--- a/frontend/src/components/features/calculator/BossSelector.tsx
+++ b/frontend/src/components/features/calculator/BossSelector.tsx
@@ -401,8 +401,8 @@ export function BossSelector({ onSelectBoss, onSelectForm }: BossSelectorProps) 
           </Popover>
         </div>
 
-        {/* Form selector (if the boss has multiple forms) */}
-        {selectedBoss && bossDetails?.forms && bossDetails.forms.length > 0 && (
+        {/* Form selector */}
+        {selectedBoss && (
           <div className="space-y-2">
             <label className="text-sm font-medium">Select Form/Phase</label>
             {isLoadingDetails ? (
@@ -424,7 +424,7 @@ export function BossSelector({ onSelectBoss, onSelectForm }: BossSelectorProps) 
                   <SelectValue placeholder="Select a form/phase" />
                 </SelectTrigger>
                 <SelectContent>
-                  {bossDetails.forms.map((form) => (
+                  {(bossDetails?.forms ?? []).map((form) => (
                     <SelectItem key={form.id} value={form.id.toString()}>
                       <img
                         src={form.icons?.[0]}

--- a/frontend/src/components/features/calculator/DirectBossSelector.tsx
+++ b/frontend/src/components/features/calculator/DirectBossSelector.tsx
@@ -306,7 +306,7 @@ export function DirectBossSelector({ onSelectBoss, onSelectForm, className }: Di
         </div>
 
         {/* Form selector */}
-        {selectedBoss && bossDetails?.forms && bossDetails.forms.length > 0 && (
+        {selectedBoss && (
           <div className="space-y-2">
             <label className="text-sm font-medium">Select Form/Phase</label>
             {isLoadingDetails ? (
@@ -328,9 +328,9 @@ export function DirectBossSelector({ onSelectBoss, onSelectForm, className }: Di
                   <SelectValue placeholder="Select a form/phase" />
                 </SelectTrigger>
                 <SelectContent>
-                  {bossDetails.forms.map((form) => (
+                  {(bossDetails?.forms ?? []).map((form) => (
                     <SelectItem key={form.id} value={form.id.toString()}>
-                      {form.form_name || `${bossDetails.name} (${form.combat_level || 'Unknown'})`}
+                      {form.form_name || `${bossDetails?.name} (${form.combat_level || 'Unknown'})`}
                     </SelectItem>
                   ))}
                 </SelectContent>


### PR DESCRIPTION
## Summary
- remove guard so form dropdown is always rendered when a boss is selected

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846e6ad226c832e8b4769454eda0af1