### PR TITLE
Expand frontend test coverage

### DIFF
--- a/frontend/src/__tests__/passive-effects-utils.test.ts
+++ b/frontend/src/__tests__/passive-effects-utils.test.ts
@@ -1,0 +1,35 @@
+import {
+  isTargetDraconic,
+  isTargetDemonic,
+  hasVoidKnightSet,
+  countInquisitorPieces,
+} from '../utils/passiveEffectsUtils';
+
+const dragonBoss = { boss_id: 50, form_name: 'King Black Dragon' } as any;
+const demonBoss = { form_name: "K'ril Tsutsaroth", weakness: 'demon' } as any;
+
+const equipment = {
+  body: { name: 'Void knight top' },
+  legs: { name: 'Void knight robe' },
+  hands: { name: 'Void knight gloves' },
+  head: null,
+  mainhand: { name: "Inquisitor's mace" },
+};
+
+const inquisitorEquip = {
+  head: { name: 'Inquisitor helm' },
+  body: { name: 'Inquisitor body' },
+  legs: { name: 'Inquisitor legs' },
+};
+
+describe('passiveEffectsUtils', () => {
+  it('detects target types', () => {
+    expect(isTargetDraconic(dragonBoss)).toBe(true);
+    expect(isTargetDemonic(demonBoss)).toBe(true);
+  });
+
+  it('detects void set and inquisitor pieces', () => {
+    expect(hasVoidKnightSet(equipment)).toBe(true);
+    expect(countInquisitorPieces(inquisitorEquip)).toBe(3);
+  });
+});

--- a/frontend/src/__tests__/reference-data-store.test.ts
+++ b/frontend/src/__tests__/reference-data-store.test.ts
@@ -1,0 +1,58 @@
+import { act } from '@testing-library/react';
+import { useReferenceDataStore } from '../store/reference-data-store';
+import { bossesApi, itemsApi } from '../services/api';
+
+jest.mock('../services/api');
+
+const mockedBossApi = bossesApi as jest.Mocked<typeof bossesApi>;
+const mockedItemsApi = itemsApi as jest.Mocked<typeof itemsApi>;
+
+function getStore() {
+  return useReferenceDataStore.getState();
+}
+
+describe('reference data store', () => {
+  beforeEach(() => {
+    act(() => {
+      useReferenceDataStore.setState({ bosses: [], items: [], initialized: false });
+    });
+    mockedBossApi.getAllBosses.mockReset();
+    mockedItemsApi.getAllItems.mockReset();
+  });
+
+  it('loads data from APIs', async () => {
+    mockedBossApi.getAllBosses
+      .mockResolvedValueOnce([{ id: 1, name: 'Boss' } as any])
+      .mockResolvedValueOnce([]);
+
+    mockedItemsApi.getAllItems
+      .mockResolvedValueOnce([{ id: 2, name: 'Item' } as any])
+      .mockResolvedValueOnce([]);
+
+    await act(async () => {
+      await getStore().initData();
+    });
+
+    const state = getStore();
+    expect(state.bosses).toHaveLength(1);
+    expect(state.items).toHaveLength(1);
+    expect(mockedBossApi.getAllBosses).toHaveBeenCalledTimes(1);
+    expect(mockedItemsApi.getAllItems).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not load again when initialized', async () => {
+    mockedBossApi.getAllBosses.mockResolvedValue([]);
+    mockedItemsApi.getAllItems.mockResolvedValue([]);
+
+    await act(async () => {
+      await getStore().initData();
+    });
+
+    await act(async () => {
+      await getStore().initData();
+    });
+
+    expect(mockedBossApi.getAllBosses).toHaveBeenCalledTimes(1);
+    expect(mockedItemsApi.getAllItems).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/__tests__/use-combat-form.test.ts
+++ b/frontend/src/__tests__/use-combat-form.test.ts
@@ -1,0 +1,84 @@
+import React from 'react';
+import { renderHook, act } from '@testing-library/react';
+import { z } from 'zod';
+import { useCombatForm } from '../hooks/useCombatForm';
+import { useCalculatorStore } from '../store/calculator-store';
+
+type FormValues = {
+  magic_attack_bonus: number;
+  target_magic_level: number;
+};
+
+const schema = z.object({
+  magic_attack_bonus: z.number(),
+  target_magic_level: z.number(),
+});
+
+const defaultValues: FormValues = {
+  magic_attack_bonus: 0,
+  target_magic_level: 0,
+};
+
+describe('useCombatForm hook', () => {
+  beforeEach(() => {
+    act(() => {
+      useCalculatorStore.getState().switchCombatStyle('magic');
+      useCalculatorStore.getState().resetLocks();
+      useCalculatorStore.getState().setParams({
+        magic_attack_bonus: 0,
+        target_magic_level: 0,
+      } as any);
+    });
+  });
+
+  it('updates store values when not locked', () => {
+    const { result } = renderHook(() =>
+      useCombatForm<FormValues>({
+        combatStyle: 'magic',
+        formSchema: schema,
+        defaultValues,
+        gearLockedFields: ['magic_attack_bonus'],
+        bossLockedFields: ['target_magic_level'],
+      })
+    );
+
+    act(() => {
+      result.current.onValueChange({
+        magic_attack_bonus: 50,
+        target_magic_level: 75,
+      });
+    });
+
+    const state = useCalculatorStore.getState().params as any;
+    expect(state.magic_attack_bonus).toBe(50);
+    expect(state.target_magic_level).toBe(75);
+  });
+
+  it('respects gear and boss locks', () => {
+    const { result } = renderHook(() =>
+      useCombatForm<FormValues>({
+        combatStyle: 'magic',
+        formSchema: schema,
+        defaultValues,
+        gearLockedFields: ['magic_attack_bonus'],
+        bossLockedFields: ['target_magic_level'],
+      })
+    );
+
+    act(() => {
+      useCalculatorStore.getState().lockGear();
+      useCalculatorStore.getState().lockBoss();
+    });
+
+    act(() => {
+      result.current.onValueChange({
+        magic_attack_bonus: 60,
+        target_magic_level: 80,
+      });
+    });
+
+    const state = useCalculatorStore.getState().params as any;
+    expect(state.magic_attack_bonus).toBe(0);
+    expect(state.target_magic_level).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for `useCombatForm` hook logic
- add tests for `useReferenceDataStore`
- add tests for passive effects utilities

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846f3846b70832ea00911ff2597f1f3