### PR TITLE
Expand backend test suite

### DIFF
--- a/backend/app/testing/test_repositories.py
+++ b/backend/app/testing/test_repositories.py
@@ -1,0 +1,84 @@
+import unittest
+from unittest.mock import MagicMock
+
+from app.repositories import item_repository, boss_repository
+
+
+class TestItemRepositoryCaching(unittest.TestCase):
+    def setUp(self):
+        self.mock_items = [
+            {'id': 1, 'name': 'Dragon scimitar', 'has_combat_stats': True, 'is_tradeable': True},
+            {'id': 2, 'name': 'Bronze dagger', 'has_combat_stats': True, 'is_tradeable': False},
+        ]
+        self.item_service = MagicMock()
+        self.item_service.get_all_items.return_value = self.mock_items
+        self.item_service.get_item.return_value = self.mock_items[0]
+
+        # Clear caches and patch the db service
+        item_repository._all_items_cache.clear()
+        item_repository._item_cache.clear()
+        self.orig_service = item_repository.db_service
+        item_repository.db_service = self.item_service
+
+    def tearDown(self):
+        item_repository.db_service = self.orig_service
+
+    def test_get_all_items_cached(self):
+        first = item_repository.get_all_items()
+        second = item_repository.get_all_items()
+        self.assertEqual(first, self.mock_items)
+        self.assertEqual(second, self.mock_items)
+        # Should call underlying service only once due to caching
+        self.assertEqual(self.item_service.get_all_items.call_count, 1)
+
+    def test_get_item_cached(self):
+        item_repository.get_item(1)
+        item_repository.get_item(1)
+        # Underlying service called only once
+        self.assertEqual(self.item_service.get_item.call_count, 1)
+
+    def test_search_items(self):
+        item_repository._all_items_cache['all'] = self.mock_items
+        results = item_repository.search_items('dragon')
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]['id'], 1)
+
+
+class TestBossRepositoryCaching(unittest.TestCase):
+    def setUp(self):
+        self.mock_bosses = [
+            {'id': 1, 'name': 'Zulrah', 'raid_group': None, 'location': 'Zul-Andra', 'has_multiple_forms': True},
+        ]
+        self.boss_service = MagicMock()
+        self.boss_service.get_all_bosses.return_value = self.mock_bosses
+        self.boss_service.get_boss.return_value = self.mock_bosses[0]
+
+        boss_repository._all_bosses_cache.clear()
+        boss_repository._boss_cache.clear()
+        self.orig_service = boss_repository.db_service
+        boss_repository.db_service = self.boss_service
+
+    def tearDown(self):
+        boss_repository.db_service = self.orig_service
+
+    def test_get_all_bosses_cached(self):
+        first = boss_repository.get_all_bosses()
+        second = boss_repository.get_all_bosses()
+        self.assertEqual(first, self.mock_bosses)
+        self.assertEqual(second, self.mock_bosses)
+        self.assertEqual(self.boss_service.get_all_bosses.call_count, 1)
+
+    def test_get_boss_cached(self):
+        boss_repository.get_boss(1)
+        boss_repository.get_boss(1)
+        self.assertEqual(self.boss_service.get_boss.call_count, 1)
+
+    def test_search_bosses(self):
+        boss_repository._all_bosses_cache['all'] = self.mock_bosses
+        results = boss_repository.search_bosses('zul')
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]['id'], 1)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/backend/app/testing/test_services.py
+++ b/backend/app/testing/test_services.py
@@ -1,0 +1,89 @@
+import unittest
+from unittest.mock import patch
+
+from app.services import seed_service, bis_service, calculation_service
+from app.repositories import item_repository
+from app.models import DpsParameters
+
+
+class TestSeedService(unittest.TestCase):
+    def test_encode_decode_roundtrip(self):
+        params = DpsParameters(
+            combat_style="melee",
+            strength_level=1,
+            attack_level=1,
+            melee_strength_bonus=0,
+            melee_attack_bonus=0,
+            attack_style_bonus_strength=0,
+            attack_style_bonus_attack=0,
+            target_defence_level=1,
+            target_defence_bonus=0,
+            attack_speed=2.4,
+        )
+        seed = seed_service.encode_seed(params)
+        decoded = seed_service.decode_seed(seed)
+        self.assertEqual(decoded.combat_style, params.combat_style)
+        self.assertEqual(decoded.attack_speed, params.attack_speed)
+        self.assertEqual(decoded.strength_level, params.strength_level)
+
+
+class TestBisService(unittest.TestCase):
+    def test_suggest_bis_selects_highest_dps_per_slot(self):
+        items = [
+            {
+                'id': 1,
+                'name': 'Bronze sword',
+                'slot': 'weapon',
+                'combat_stats': {
+                    'attack_bonuses': {'slash': 10},
+                    'other_bonuses': {'strength': 5},
+                },
+            },
+            {
+                'id': 2,
+                'name': 'Iron sword',
+                'slot': 'weapon',
+                'combat_stats': {
+                    'attack_bonuses': {'slash': 5},
+                    'other_bonuses': {'strength': 10},
+                },
+            },
+            {
+                'id': 3,
+                'name': 'Basic helm',
+                'slot': 'head',
+                'combat_stats': {
+                    'attack_bonuses': {},
+                    'other_bonuses': {'strength': 2},
+                },
+            },
+        ]
+
+        with patch.object(item_repository, 'get_all_items', return_value=items):
+            # Mock calculation_service to score based on melee_strength_bonus
+            with patch.object(calculation_service, 'calculate_dps', side_effect=lambda p: {'dps': p.get('melee_strength_bonus', 0)}):
+                result = bis_service.suggest_bis({'combat_style': 'melee'})
+
+        self.assertEqual(result['weapon']['id'], 2)
+        self.assertEqual(result['head']['id'], 3)
+
+
+class TestCalculationService(unittest.TestCase):
+    def test_calculate_dps_delegates(self):
+        params = {'combat_style': 'melee'}
+        with patch('app.services.calculation_service.DpsCalculator.calculate_dps', return_value={'dps': 1}) as mock_calc:
+            result = calculation_service.calculate_dps(params)
+            mock_calc.assert_called_once_with(params)
+            self.assertEqual(result, {'dps': 1})
+
+
+class TestSettings(unittest.TestCase):
+    def test_cache_ttl_env_override(self):
+        import importlib, os
+        os.environ['CACHE_TTL_SECONDS'] = '123'
+        settings = importlib.reload(importlib.import_module('app.config.settings'))
+        self.assertEqual(settings.CACHE_TTL_SECONDS, 123)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add repository caching tests
- add service layer tests and env var behavior

## Testing
- `python -m unittest discover backend/app/testing -v`

------
https://chatgpt.com/codex/tasks/task_e_6846f505ae08832eaac5e90a3026825c