### PR TITLE
Add architecture and wireframe docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,11 @@ Usage Guide
     Calculate: View your expected DPS and other stats
     Compare: Save setups to compare different loadouts
 
+Additional documentation can be found in the `docs/` folder:
+
+    docs/ARCHITECTURE.md - High level component diagram
+    docs/WIREFRAME.md    - Basic UI wireframe
+
 Technical Documentation
 Frontend Architecture
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,30 @@
+# Architecture Overview
+
+This document illustrates the high level layout of the project and the flow between components.
+
+## Component Diagram
+
+```mermaid
+flowchart LR
+    User["Browser"] --> Frontend
+    Frontend["Next.js App"] -->|REST API| Backend
+    Backend["FastAPI Service"] --> Database[(SQLite)]
+    Backend --> Webscraper["Scraper Scripts"]
+    Frontend --> AzureFunctions["Azure Functions"]
+    AzureFunctions -->|wraps| Backend
+```
+
+* **Frontend** – Next.js application housed in `frontend/`.
+* **Backend** – FastAPI service inside `backend/` that provides calculation endpoints.
+* **Azure Functions** – Serverless wrappers in `api/` for cloud deployment.
+* **Database** – SQLite databases populated by scrapers.
+* **Webscraper** – Python scripts under `backend/webscraper` used to refresh game data.
+
+## Data Flow
+
+1. Users interact with the React frontend.
+2. The frontend communicates with the FastAPI backend or Azure Functions.
+3. The backend queries the SQLite databases and performs DPS calculations.
+4. Results are returned to the frontend for display.
+
+For more information see `docs/DEVELOPER_GUIDE.md`.

--- a/docs/WIREFRAME.md
+++ b/docs/WIREFRAME.md
@@ -1,0 +1,23 @@
+# UI Wireframe
+
+The following diagram sketches the layout of the main calculator page.
+
+```mermaid
+flowchart TB
+    header["Header / Navigation"]
+    sidebar["Left Panel\nEquipment & Stats"]
+    results["Right Panel\nResults"]
+    footer["Footer"]
+
+    header --> main
+    main --> sidebar
+    main --> results
+    results --> footer
+```
+
+* **Header** – contains navigation links and project title.
+* **Left Panel** – forms for selecting equipment, combat style and boss.
+* **Right Panel** – displays max hit, hit chance and DPS graphs.
+* **Footer** – credits and external links.
+
+This wireframe is a general guide; actual components live under `frontend/src`.


### PR DESCRIPTION
## Summary
- include high level architecture diagram
- sketch a simple UI wireframe
- reference new docs from README

## Testing
- `python -m unittest discover backend/app/testing`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846f7b5e928832e896905d19db5ffd4