### PR TITLE
Fix boss size display

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -150,7 +150,8 @@ class AzureSQLDatabaseService:
             cursor.execute("""
                 SELECT id, boss_id, form_name, form_order, combat_level, hitpoints,
                        defence_level, magic_level, ranged_level, defence_stab, defence_slash,
-                       defence_crush, defence_magic, defence_ranged_standard, icons, image_url
+                       defence_crush, defence_magic, defence_ranged_standard, icons, image_url,
+                       size
                 FROM boss_forms
                 WHERE boss_id = ?
                 ORDER BY form_order
@@ -181,7 +182,8 @@ class AzureSQLDatabaseService:
                     "defence_magic": form_row[12],
                     "defence_ranged_standard": form_row[13],
                     "icons": icons,
-                    "image_url": form_row[15]
+                    "image_url": form_row[15],
+                    "size": form_row[16]
                 }
                 boss_data["forms"].append(form_data)
             

--- a/backend/app/testing/test_database.py
+++ b/backend/app/testing/test_database.py
@@ -29,7 +29,7 @@ class SQLiteDatabaseService:
 
         boss = {"id": row["id"], "name": row["name"], "forms": []}
         cursor.execute(
-            "SELECT id, boss_id, form_name, form_order FROM boss_forms WHERE boss_id = ? ORDER BY form_order",
+            "SELECT id, boss_id, form_name, form_order, size FROM boss_forms WHERE boss_id = ? ORDER BY form_order",
             (boss_id,),
         )
         for form_row in cursor.fetchall():
@@ -39,6 +39,7 @@ class SQLiteDatabaseService:
                     "boss_id": form_row["boss_id"],
                     "form_name": form_row["form_name"],
                     "form_order": form_row["form_order"],
+                    "size": form_row["size"],
                 }
             )
         conn.close()

--- a/frontend/src/components/features/calculator/BossSelector.tsx
+++ b/frontend/src/components/features/calculator/BossSelector.tsx
@@ -500,7 +500,7 @@ export function BossSelector({ onSelectBoss, onSelectForm }: BossSelectorProps) 
                   <div>
                     <span className="text-xs text-muted-foreground">Size:</span>{' '}
                     <span className="text-xs font-medium">
-                      {selectedForm.size ? `${selectedForm.size}x${selectedForm.size}` : 'Unknown'}
+                      {selectedForm.size ?? 'Unknown'}
                     </span>
                   </div>
                 </div>

--- a/frontend/src/components/features/calculator/DirectBossSelector.tsx
+++ b/frontend/src/components/features/calculator/DirectBossSelector.tsx
@@ -397,9 +397,7 @@ export function DirectBossSelector({ onSelectBoss, onSelectForm, className }: Di
                   </div>
                   <div>
                     <span className="text-xs text-muted-foreground">Size:</span>{' '}
-                    <span className="text-xs font-medium">
-                      {selectedForm.size ? `${selectedForm.size}x${selectedForm.size}` : 'Unknown'}
-                    </span>
+                    <span className="text-xs font-medium">{selectedForm.size ?? 'Unknown'}</span>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- include `size` when fetching boss forms from the database
- expose size in SQLite test service
- show raw size value in boss selector components

## Testing
- `npm --prefix frontend test` *(fails: jest not found)*
- `python -m unittest discover backend/app/testing` *(fails: ModuleNotFoundError: httpx)*

------
https://chatgpt.com/codex/tasks/task_e_6846f8ca5008832e952e852750efcbeb