### PR TITLE
Improve state persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,13 @@ The frontend is built with Next.js and uses:
     shadcn/ui and Tailwind CSS for styling
     TypeScript for type safety
 
+State Persistence
+
+The calculator remembers your last selected boss, locked gear, and loadout across
+page reloads using Zustand's `persist` middleware. Boss and item lists are cached
+locally for 12 hours so returning to the app doesn't require refetching all
+reference data.
+
 Backend Architecture
 
 The backend is built with FastAPI and uses:

--- a/frontend/src/components/features/calculator/BossSelector.tsx
+++ b/frontend/src/components/features/calculator/BossSelector.tsx
@@ -41,8 +41,10 @@ interface BossSelectorProps {
 
 export function BossSelector({ onSelectBoss, onSelectForm }: BossSelectorProps) {
   const [open, setOpen] = useState(false);
-  const [selectedBoss, setSelectedBoss] = useState<Boss | null>(null);
-  const [selectedForm, setSelectedForm] = useState<BossForm | null>(null);
+  const selectedBoss = useCalculatorStore((s) => s.selectedBoss);
+  const setSelectedBoss = useCalculatorStore((s) => s.setSelectedBoss);
+  const selectedForm = useCalculatorStore((s) => s.selectedBossForm);
+  const setSelectedForm = useCalculatorStore((s) => s.setSelectedBossForm);
   const [bossIcons, setBossIcons] = useState<Record<number, string>>({});
   const storeBosses = useReferenceDataStore((s) => s.bosses);
   const initData = useReferenceDataStore((s) => s.initData);

--- a/frontend/src/hooks/useDpsCalculator.ts
+++ b/frontend/src/hooks/useDpsCalculator.ts
@@ -19,8 +19,14 @@ export function useDpsCalculator() {
 
   const [activeTab, setActiveTab] = useState<CombatStyle>(params.combat_style);
   const [currentLoadout, setCurrentLoadout] = useState<Record<string, Item | null>>(storeLoadout);
-  const [currentBossForm, setCurrentBossForm] = useState<BossForm | null>(null);
+  const storeBossForm = useCalculatorStore((s) => s.selectedBossForm);
+  const setStoreBossForm = useCalculatorStore((s) => s.setSelectedBossForm);
+  const [currentBossForm, setCurrentBossForm] = useState<BossForm | null>(storeBossForm);
   const [appliedPassiveEffects, setAppliedPassiveEffects] = useState<any>(null);
+
+  useEffect(() => {
+    setCurrentBossForm(storeBossForm);
+  }, [storeBossForm]);
 
   useEffect(() => {
     setCurrentLoadout(storeLoadout);
@@ -141,6 +147,7 @@ export function useDpsCalculator() {
 
   const handleBossUpdate = (bossForm: BossForm | null) => {
     setCurrentBossForm(bossForm);
+    setStoreBossForm(bossForm);
   };
 
   return {

--- a/frontend/src/store/calculator-store.ts
+++ b/frontend/src/store/calculator-store.ts
@@ -6,7 +6,9 @@ import {
   MeleeCalculatorParams,
   RangedCalculatorParams,
   MagicCalculatorParams,
-  Item
+  Item,
+  Boss,
+  BossForm
 } from '@/types/calculator';
 
 interface CalculatorState {
@@ -20,6 +22,8 @@ interface CalculatorState {
   gearLocked: boolean;
   bossLocked: boolean;
   loadout: Record<string, Item | null>;
+  selectedBoss: Boss | null;
+  selectedBossForm: BossForm | null;
 
   setParams: (params: Partial<CalculatorParams>) => void;
   switchCombatStyle: (style: 'melee' | 'ranged' | 'magic') => void;
@@ -34,6 +38,8 @@ interface CalculatorState {
   unlockBoss: () => void;
   resetLocks: () => void;
   setLoadout: (loadout: Record<string, Item | null>) => void;
+  setSelectedBoss: (boss: Boss | null) => void;
+  setSelectedBossForm: (form: BossForm | null) => void;
 }
 
 const defaultMeleeParams: MeleeCalculatorParams = {
@@ -113,6 +119,8 @@ export const useCalculatorStore = create<CalculatorState>()(
       gearLocked: false,
       bossLocked: false,
       loadout: {},
+      selectedBoss: null,
+      selectedBossForm: null,
 
       setParams: (newParams: Partial<CalculatorParams>) => set((state): Partial<CalculatorState> => {
         const currentStyle = state.params.combat_style;
@@ -200,7 +208,9 @@ export const useCalculatorStore = create<CalculatorState>()(
       lockBoss: () => set({ bossLocked: true }),
       unlockBoss: () => set({ bossLocked: false }),
       resetLocks: () => set({ gearLocked: false, bossLocked: false }),
-      setLoadout: (loadout) => set({ loadout })
+      setLoadout: (loadout) => set({ loadout }),
+      setSelectedBoss: (boss) => set({ selectedBoss: boss }),
+      setSelectedBossForm: (form) => set({ selectedBossForm: form })
     }),
     {
       name: 'osrs-calculator-storage',
@@ -208,7 +218,9 @@ export const useCalculatorStore = create<CalculatorState>()(
         params: state.params,
         gearLocked: state.gearLocked,
         bossLocked: state.bossLocked,
-        loadout: state.loadout
+        loadout: state.loadout,
+        selectedBoss: state.selectedBoss,
+        selectedBossForm: state.selectedBossForm
       })
     }
   )

--- a/frontend/src/store/reference-data-store.ts
+++ b/frontend/src/store/reference-data-store.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
 import { bossesApi, itemsApi } from '@/services/api';
 import { Boss, Item } from '@/types/calculator';
 
@@ -8,55 +9,79 @@ interface ReferenceDataState {
   bosses: Boss[];
   items: Item[];
   initialized: boolean;
+  timestamp: number;
   initData: () => Promise<void>;
   addBosses: (b: Boss[]) => void;
   addItems: (i: Item[]) => void;
 }
 
-export const useReferenceDataStore = create<ReferenceDataState>((set, get) => ({
-  bosses: [],
-  items: [],
-  initialized: false,
-  async initData() {
-    if (get().initialized) return;
-    set({ initialized: true });
-    const pageSize = 50;
-    let page = 1;
-    // Fetch bosses
-    while (true) {
-      try {
-        const data = await bossesApi.getAllBosses({ page, page_size: pageSize });
-        if (!data.length) break;
-        set(state => ({ bosses: [...state.bosses, ...data] }));
-        if (data.length < pageSize) break;
-        page += 1;
-      } catch {
-        break;
-      }
+const REFERENCE_TTL_MS = 12 * 60 * 60 * 1000; // 12 hours
+
+export const useReferenceDataStore = create<ReferenceDataState>()(
+  persist(
+    (set, get) => ({
+      bosses: [],
+      items: [],
+      initialized: false,
+      timestamp: 0,
+      async initData() {
+        if (get().initialized) return;
+        set({ initialized: true, timestamp: Date.now() });
+        const pageSize = 50;
+        let page = 1;
+        while (true) {
+          try {
+            const data = await bossesApi.getAllBosses({ page, page_size: pageSize });
+            if (!data.length) break;
+            set((state) => ({ bosses: [...state.bosses, ...data] }));
+            if (data.length < pageSize) break;
+            page += 1;
+          } catch {
+            break;
+          }
+        }
+        page = 1;
+        while (true) {
+          try {
+            const data = await itemsApi.getAllItems({
+              page,
+              page_size: pageSize,
+              combat_only: true,
+              tradeable_only: false,
+            });
+            if (!data.length) break;
+            set((state) => ({ items: [...state.items, ...data] }));
+            if (data.length < pageSize) break;
+            page += 1;
+          } catch {
+            break;
+          }
+        }
+      },
+      addBosses(b) {
+        set((state) => ({ bosses: [...state.bosses, ...b] }));
+      },
+      addItems(i) {
+        set((state) => ({ items: [...state.items, ...i] }));
+      },
+    }),
+    {
+      name: 'osrs-reference-data',
+      storage: createJSONStorage(() => localStorage),
+      partialize: (state) => ({
+        bosses: state.bosses,
+        items: state.items,
+        timestamp: state.timestamp,
+      }),
+      onRehydrateStorage: (state) => (stored) => {
+        if (!stored) return;
+        const expired = Date.now() - stored.timestamp > REFERENCE_TTL_MS;
+        if (expired) {
+          state.setState({ bosses: [], items: [], initialized: false, timestamp: Date.now() });
+        } else {
+          state.setState({ initialized: true });
+        }
+      },
     }
-    page = 1;
-    // Fetch items (combat only for dropdowns)
-    while (true) {
-      try {
-        const data = await itemsApi.getAllItems({
-          page,
-          page_size: pageSize,
-          combat_only: true,
-          tradeable_only: false,
-        });
-        if (!data.length) break;
-        set(state => ({ items: [...state.items, ...data] }));
-        if (data.length < pageSize) break;
-        page += 1;
-      } catch {
-        break;
-      }
-    }
-  },
-  addBosses(b) {
-    set(state => ({ bosses: [...state.bosses, ...b] }));
-  },
-  addItems(i) {
-    set(state => ({ items: [...state.items, ...i] }));
-  },
-}));
+  )
+);


### PR DESCRIPTION
## Summary
- persist selected boss and form in calculator store
- cache reference data with TTL using Zustand
- reflect persistence in BossSelector component
- sync boss form with the store in `useDpsCalculator`
- document frontend state persistence

## Testing
- `npm --prefix frontend test`
- `python3 -m unittest discover backend/app/testing` *(fails: test_bis, test_calculate_dps, test_calculate_seed, test_import_seed)*

------
https://chatgpt.com/codex/tasks/task_e_6846f76222f8832e9b1e2d46919b3156