### PR TITLE
Add async DB connection pooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,14 @@ request the server loads and caches the full boss and item lists, and all
 subsequent search requests are served from this in-memory cache so the
 database is only queried when a specific record is requested.
 
+Database connections are pooled. Tune pool behaviour with the following
+environment variables:
+
+- `DB_POOL_SIZE` – Maximum number of open connections (default `5`).
+- `DB_CONNECTION_TIMEOUT` – Connection timeout in seconds (default `30`).
+- `DB_MAX_RETRIES` – Number of connection retries for transient failures
+  (default `3`).
+
 🔄 API Reference
 Calculate DPS
 

--- a/backend/app/config/settings.py
+++ b/backend/app/config/settings.py
@@ -2,3 +2,8 @@ import os
 
 # TTL for in-memory caches (in seconds)
 CACHE_TTL_SECONDS = int(os.getenv("CACHE_TTL_SECONDS", "3600"))
+
+# Database connection pool settings
+DB_POOL_SIZE = int(os.getenv("DB_POOL_SIZE", "5"))
+DB_CONNECTION_TIMEOUT = int(os.getenv("DB_CONNECTION_TIMEOUT", "30"))
+DB_MAX_RETRIES = int(os.getenv("DB_MAX_RETRIES", "3"))

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,7 +1,51 @@
 import pyodbc
 import os
 import json
+import time
+import asyncio
+from contextlib import contextmanager, asynccontextmanager
+from queue import Queue, Empty
 from typing import Dict, List, Optional, Any
+from .config.settings import (
+    DB_POOL_SIZE,
+    DB_CONNECTION_TIMEOUT,
+    DB_MAX_RETRIES,
+)
+
+# Connection pool configuration via environment variables
+POOL_SIZE = DB_POOL_SIZE
+CONNECTION_TIMEOUT = DB_CONNECTION_TIMEOUT
+MAX_RETRIES = DB_MAX_RETRIES
+
+
+class _ConnectionPool:
+    """Simple thread-based connection pool for pyodbc."""
+
+    def __init__(self, conn_str: str, size: int, timeout: int) -> None:
+        self.conn_str = conn_str
+        self.timeout = timeout
+        self.pool: Queue[pyodbc.Connection] = Queue(maxsize=size)
+
+    def _create(self) -> pyodbc.Connection:
+        return pyodbc.connect(self.conn_str, timeout=self.timeout)
+
+    def acquire(self) -> pyodbc.Connection:
+        try:
+            return self.pool.get_nowait()
+        except Empty:
+            return self._create()
+
+    def release(self, conn: pyodbc.Connection) -> None:
+        try:
+            self.pool.put_nowait(conn)
+        except Exception:
+            conn.close()
+
+    async def acquire_async(self) -> pyodbc.Connection:
+        return await asyncio.to_thread(self.acquire)
+
+    async def release_async(self, conn: pyodbc.Connection) -> None:
+        await asyncio.to_thread(self.release, conn)
 
 class AzureSQLDatabaseService:
     """Service for handling database operations using Azure SQL Database."""
@@ -49,13 +93,52 @@ class AzureSQLDatabaseService:
                     f"Connection Timeout=30;"
                 )
 
-    def _get_connection(self):
-        """Get a connection to Azure SQL Database."""
-        try:
-            return pyodbc.connect(self.connection_string)
-        except Exception as e:
-            print(f"Failed to connect to Azure SQL Database: {e}")
-            raise
+        # Initialize connection pool
+        self.pool = _ConnectionPool(
+            self.connection_string,
+            size=POOL_SIZE,
+            timeout=CONNECTION_TIMEOUT,
+        )
+
+    def _get_connection(self) -> pyodbc.Connection:
+        """Get a connection from the pool."""
+        return self.pool.acquire()
+
+    async def _get_connection_async(self) -> pyodbc.Connection:
+        """Asynchronously get a connection from the pool."""
+        return await self.pool.acquire_async()
+
+    @contextmanager
+    def connection(self):
+        """Context manager with retry logic for DB connections."""
+        for attempt in range(MAX_RETRIES):
+            try:
+                conn = self._get_connection()
+                try:
+                    yield conn
+                finally:
+                    self.pool.release(conn)
+                break
+            except Exception as e:
+                if attempt == MAX_RETRIES - 1:
+                    raise
+                time.sleep(2**attempt)
+
+    @asynccontextmanager
+    async def connection_async(self):
+        """Async context manager with retry logic for DB connections."""
+        for attempt in range(MAX_RETRIES):
+            try:
+                conn = await self._get_connection_async()
+                try:
+                    yield conn
+                finally:
+                    await self.pool.release_async(conn)
+                break
+            except Exception:
+                if attempt == MAX_RETRIES - 1:
+                    raise
+                await asyncio.sleep(2**attempt)
 
     def get_all_bosses(
         self,
@@ -64,55 +147,59 @@ class AzureSQLDatabaseService:
     ) -> List[Dict[str, Any]]:
         """Get all bosses from the database with optional pagination."""
         try:
-            conn = self._get_connection()
-            cursor = conn.cursor()
+            with self.connection() as conn:
+                cursor = conn.cursor()
 
-            query = (
-                "SELECT id, name, raid_group, location, has_multiple_forms\n"
-                "FROM bosses\n"
-                "ORDER BY name"
-            )
-            params: list[Any] = []
-            if limit is not None:
-                off = offset or 0
-                query += " OFFSET ? ROWS FETCH NEXT ? ROWS ONLY"
-                params.extend([off, limit])
+                query = (
+                    "SELECT id, name, raid_group, location, has_multiple_forms\n"
+                    "FROM bosses\n"
+                    "ORDER BY name"
+                )
+                params: list[Any] = []
+                if limit is not None:
+                    off = offset or 0
+                    query += " OFFSET ? ROWS FETCH NEXT ? ROWS ONLY"
+                    params.extend([off, limit])
 
-            cursor.execute(query, params)
-            
-            bosses = []
-            for row in cursor.fetchall():
-                icon_url = None
-                # Try to get icon from first boss form
-                cursor.execute("""
+                cursor.execute(query, params)
+
+                bosses = []
+                for row in cursor.fetchall():
+                    icon_url = None
+                    # Try to get icon from first boss form
+                    cursor.execute(
+                        """
                     SELECT TOP 1 icons, image_url
                     FROM boss_forms
                     WHERE boss_id = ?
-                """, (row[0],))
-                
-                form_row = cursor.fetchone()
-                if form_row:
-                    if form_row[0]:  # icons JSON
-                        try:
-                            icons = json.loads(form_row[0])
-                            if icons and len(icons) > 0:
-                                icon_url = icons[0]
-                        except:
-                            pass
-                    if not icon_url and form_row[1]:  # image_url
-                        icon_url = form_row[1]
-                
-                bosses.append({
-                    "id": row[0],
-                    "name": row[1],
-                    "raid_group": row[2],
-                    "location": row[3],
-                    "has_multiple_forms": bool(row[4]),
-                    "icon_url": icon_url
-                })
-            
-            conn.close()
-            return bosses
+                    """,
+                        (row[0],),
+                    )
+
+                    form_row = cursor.fetchone()
+                    if form_row:
+                        if form_row[0]:  # icons JSON
+                            try:
+                                icons = json.loads(form_row[0])
+                                if icons and len(icons) > 0:
+                                    icon_url = icons[0]
+                            except:
+                                pass
+                        if not icon_url and form_row[1]:  # image_url
+                            icon_url = form_row[1]
+
+                    bosses.append(
+                        {
+                            "id": row[0],
+                            "name": row[1],
+                            "raid_group": row[2],
+                            "location": row[3],
+                            "has_multiple_forms": bool(row[4]),
+                            "icon_url": icon_url,
+                        }
+                    )
+
+                return bosses
             
         except Exception as e:
             print(f"Error getting bosses: {e}")
@@ -121,33 +208,34 @@ class AzureSQLDatabaseService:
     def get_boss(self, boss_id: int) -> Optional[Dict[str, Any]]:
         """Get a specific boss with all its forms."""
         try:
-            conn = self._get_connection()
-            cursor = conn.cursor()
-            
-            # Get boss info
-            cursor.execute("""
+            with self.connection() as conn:
+                cursor = conn.cursor()
+
+                cursor.execute(
+                    """
                 SELECT id, name, raid_group, location, examine, has_multiple_forms
                 FROM bosses
                 WHERE id = ?
-            """, (boss_id,))
-            
-            boss_row = cursor.fetchone()
-            if not boss_row:
-                conn.close()
-                return None
-            
-            boss_data = {
-                "id": boss_row[0],
-                "name": boss_row[1],
-                "raid_group": boss_row[2],
-                "location": boss_row[3],
-                "examine": boss_row[4],
-                "has_multiple_forms": bool(boss_row[5]),
-                "forms": []
-            }
-            
-            # Get boss forms
-            cursor.execute("""
+                """,
+                    (boss_id,),
+                )
+
+                boss_row = cursor.fetchone()
+                if not boss_row:
+                    return None
+
+                boss_data = {
+                    "id": boss_row[0],
+                    "name": boss_row[1],
+                    "raid_group": boss_row[2],
+                    "location": boss_row[3],
+                    "examine": boss_row[4],
+                    "has_multiple_forms": bool(boss_row[5]),
+                    "forms": [],
+                }
+
+                cursor.execute(
+                    """
                 SELECT id, boss_id, form_name, form_order, combat_level, hitpoints,
                        defence_level, magic_level, ranged_level, defence_stab, defence_slash,
                        defence_crush, defence_magic, defence_ranged_standard, icons, image_url,
@@ -155,48 +243,47 @@ class AzureSQLDatabaseService:
                 FROM boss_forms
                 WHERE boss_id = ?
                 ORDER BY form_order
-            """, (boss_id,))
-            
-            for form_row in cursor.fetchall():
-                # Parse icons JSON
-                icons = []
-                if form_row[14]:  # icons column
-                    try:
-                        icons = json.loads(form_row[14])
-                    except:
-                        pass
-                
-                form_data = {
-                    "id": form_row[0],
-                    "boss_id": form_row[1],
-                    "form_name": form_row[2],
-                    "form_order": form_row[3],
-                    "combat_level": form_row[4],
-                    "hitpoints": form_row[5],
-                    "defence_level": form_row[6],
-                    "magic_level": form_row[7],
-                    "ranged_level": form_row[8],
-                    "defence_stab": form_row[9],
-                    "defence_slash": form_row[10],
-                    "defence_crush": form_row[11],
-                    "defence_magic": form_row[12],
-                    "defence_ranged_standard": form_row[13],
-                    "icons": icons,
-                    "image_url": form_row[15],
-                    "size": form_row[16]
-                }
-                boss_data["forms"].append(form_data)
-            
-            # Set boss icon from first form
-            if boss_data["forms"]:
-                first_form = boss_data["forms"][0]
-                if first_form.get("icons"):
-                    boss_data["icon_url"] = first_form["icons"][0]
-                elif first_form.get("image_url"):
-                    boss_data["icon_url"] = first_form["image_url"]
-            
-            conn.close()
-            return boss_data
+                """,
+                    (boss_id,),
+                )
+
+                for form_row in cursor.fetchall():
+                    icons = []
+                    if form_row[14]:
+                        try:
+                            icons = json.loads(form_row[14])
+                        except Exception:
+                            pass
+
+                    form_data = {
+                        "id": form_row[0],
+                        "boss_id": form_row[1],
+                        "form_name": form_row[2],
+                        "form_order": form_row[3],
+                        "combat_level": form_row[4],
+                        "hitpoints": form_row[5],
+                        "defence_level": form_row[6],
+                        "magic_level": form_row[7],
+                        "ranged_level": form_row[8],
+                        "defence_stab": form_row[9],
+                        "defence_slash": form_row[10],
+                        "defence_crush": form_row[11],
+                        "defence_magic": form_row[12],
+                        "defence_ranged_standard": form_row[13],
+                        "icons": icons,
+                        "image_url": form_row[15],
+                        "size": form_row[16],
+                    }
+                    boss_data["forms"].append(form_data)
+
+                if boss_data["forms"]:
+                    first_form = boss_data["forms"][0]
+                    if first_form.get("icons"):
+                        boss_data["icon_url"] = first_form["icons"][0]
+                    elif first_form.get("image_url"):
+                        boss_data["icon_url"] = first_form["image_url"]
+
+                return boss_data
 
         except Exception as e:
             print(f"Error getting boss {boss_id}: {e}")
@@ -205,14 +292,13 @@ class AzureSQLDatabaseService:
     def get_boss_id_by_form(self, form_id: int) -> Optional[int]:
         """Return the boss_id associated with a boss form."""
         try:
-            conn = self._get_connection()
-            cursor = conn.cursor()
-            cursor.execute("SELECT boss_id FROM boss_forms WHERE id = ?", (form_id,))
-            row = cursor.fetchone()
-            conn.close()
-            if row:
-                return row[0]
-            return None
+            with self.connection() as conn:
+                cursor = conn.cursor()
+                cursor.execute("SELECT boss_id FROM boss_forms WHERE id = ?", (form_id,))
+                row = cursor.fetchone()
+                if row:
+                    return row[0]
+                return None
         except Exception as e:
             print(f"Error getting boss id from form {form_id}: {e}")
             return None
@@ -233,8 +319,8 @@ class AzureSQLDatabaseService:
     ) -> List[Dict[str, Any]]:
         """Get all items from the database with optional filters and pagination."""
         try:
-            conn = self._get_connection()
-            cursor = conn.cursor()
+            with self.connection() as conn:
+                cursor = conn.cursor()
             
             query = """
                 SELECT id, name, has_special_attack, has_passive_effect,
@@ -256,31 +342,30 @@ class AzureSQLDatabaseService:
                 query += " OFFSET ? ROWS FETCH NEXT ? ROWS ONLY"
                 params.extend([off, limit])
 
-            cursor.execute(query, params)
-            
-            items = []
-            for row in cursor.fetchall():
-                # Parse icons JSON
-                icons = []
-                if row[7]:  # icons column
-                    try:
-                        icons = json.loads(row[7])
-                    except:
-                        pass
-                
-                items.append({
-                    "id": row[0],
-                    "name": row[1],
-                    "has_special_attack": bool(row[2]),
-                    "has_passive_effect": bool(row[3]),
-                    "has_combat_stats": bool(row[4]),
-                    "is_tradeable": bool(row[5]),
-                    "slot": row[6],
-                    "icons": icons
-                })
-            
-            conn.close()
-            return items
+                cursor.execute(query, params)
+
+                items = []
+                for row in cursor.fetchall():
+                    # Parse icons JSON
+                    icons = []
+                    if row[7]:  # icons column
+                        try:
+                            icons = json.loads(row[7])
+                        except:
+                            pass
+
+                    items.append({
+                        "id": row[0],
+                        "name": row[1],
+                        "has_special_attack": bool(row[2]),
+                        "has_passive_effect": bool(row[3]),
+                        "has_combat_stats": bool(row[4]),
+                        "is_tradeable": bool(row[5]),
+                        "slot": row[6],
+                        "icons": icons,
+                    })
+
+                return items
             
         except Exception as e:
             print(f"Error getting items: {e}")
@@ -289,8 +374,8 @@ class AzureSQLDatabaseService:
     def get_item(self, item_id: int) -> Optional[Dict[str, Any]]:
         """Get a specific item."""
         try:
-            conn = self._get_connection()
-            cursor = conn.cursor()
+            with self.connection() as conn:
+                cursor = conn.cursor()
             
             cursor.execute("""
                 SELECT id, name, has_special_attack, special_attack_text,
@@ -302,7 +387,6 @@ class AzureSQLDatabaseService:
             
             row = cursor.fetchone()
             if not row:
-                conn.close()
                 return None
             
             # Parse JSON fields
@@ -331,10 +415,9 @@ class AzureSQLDatabaseService:
                 "is_tradeable": bool(row[7]),
                 "slot": row[8],
                 "combat_stats": combat_stats,
-                "icons": icons
+                "icons": icons,
             }
-            
-            conn.close()
+
             return item_data
             
         except Exception as e:
@@ -344,8 +427,8 @@ class AzureSQLDatabaseService:
     def search_bosses(self, query: str, limit: int | None = None) -> List[Dict[str, Any]]:
         """Search bosses by name."""
         try:
-            conn = self._get_connection()
-            cursor = conn.cursor()
+            with self.connection() as conn:
+                cursor = conn.cursor()
 
             sql = (
                 "SELECT id, name, raid_group, location\n"
@@ -367,14 +450,15 @@ class AzureSQLDatabaseService:
             
             bosses = []
             for row in cursor.fetchall():
-                bosses.append({
-                    "id": row[0],
-                    "name": row[1],
-                    "raid_group": row[2],
-                    "location": row[3]
-                })
-            
-            conn.close()
+                bosses.append(
+                    {
+                        "id": row[0],
+                        "name": row[1],
+                        "raid_group": row[2],
+                        "location": row[3],
+                    }
+                )
+
             return bosses
             
         except Exception as e:
@@ -384,8 +468,8 @@ class AzureSQLDatabaseService:
     def search_items(self, query: str, limit: int | None = None) -> List[Dict[str, Any]]:
         """Search items by name."""
         try:
-            conn = self._get_connection()
-            cursor = conn.cursor()
+            with self.connection() as conn:
+                cursor = conn.cursor()
 
             sql = (
                 "SELECT id, name, has_special_attack, has_passive_effect,\n"
@@ -413,26 +497,71 @@ class AzureSQLDatabaseService:
                 if row[7]:
                     try:
                         icons = json.loads(row[7])
-                    except:
+                    except Exception:
                         pass
-                
-                items.append({
-                    "id": row[0],
-                    "name": row[1],
-                    "has_special_attack": bool(row[2]),
-                    "has_passive_effect": bool(row[3]),
-                    "has_combat_stats": bool(row[4]),
-                    "is_tradeable": bool(row[5]),
-                    "slot": row[6],
-                    "icons": icons
-                })
-            
-            conn.close()
+
+                items.append(
+                    {
+                        "id": row[0],
+                        "name": row[1],
+                        "has_special_attack": bool(row[2]),
+                        "has_passive_effect": bool(row[3]),
+                        "has_combat_stats": bool(row[4]),
+                        "is_tradeable": bool(row[5]),
+                        "slot": row[6],
+                        "icons": icons,
+                    }
+                )
+
             return items
-            
+
         except Exception as e:
             print(f"Error searching items: {e}")
             return []
+
+    # Async wrappers -----------------------------------------------------
+
+    async def get_all_bosses_async(
+        self, limit: int | None = None, offset: int | None = None
+    ) -> List[Dict[str, Any]]:
+        return await asyncio.to_thread(self.get_all_bosses, limit=limit, offset=offset)
+
+    async def get_boss_async(self, boss_id: int) -> Optional[Dict[str, Any]]:
+        return await asyncio.to_thread(self.get_boss, boss_id)
+
+    async def get_boss_id_by_form_async(self, form_id: int) -> Optional[int]:
+        return await asyncio.to_thread(self.get_boss_id_by_form, form_id)
+
+    async def get_boss_by_form_async(self, form_id: int) -> Optional[Dict[str, Any]]:
+        return await asyncio.to_thread(self.get_boss_by_form, form_id)
+
+    async def get_all_items_async(
+        self,
+        combat_only: bool = True,
+        tradeable_only: bool = False,
+        limit: int | None = None,
+        offset: int | None = None,
+    ) -> List[Dict[str, Any]]:
+        return await asyncio.to_thread(
+            self.get_all_items,
+            combat_only,
+            tradeable_only,
+            limit,
+            offset,
+        )
+
+    async def get_item_async(self, item_id: int) -> Optional[Dict[str, Any]]:
+        return await asyncio.to_thread(self.get_item, item_id)
+
+    async def search_bosses_async(
+        self, query: str, limit: int | None = None
+    ) -> List[Dict[str, Any]]:
+        return await asyncio.to_thread(self.search_bosses, query, limit)
+
+    async def search_items_async(
+        self, query: str, limit: int | None = None
+    ) -> List[Dict[str, Any]]:
+        return await asyncio.to_thread(self.search_items, query, limit)
 
 # Provide legacy name for unit tests
 DatabaseService = AzureSQLDatabaseService

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -131,7 +131,7 @@ async def get_bosses(
     """
     try:
 
-        bosses = boss_repository.get_all_bosses(limit=page_size, offset=(page - 1) * page_size)
+        bosses = await boss_repository.get_all_bosses_async(limit=page_size, offset=(page - 1) * page_size)
         
         # If no bosses are found in the database, return mock data
         if not bosses:
@@ -154,7 +154,7 @@ async def get_boss(boss_id: int, response: Response):
     Returns detailed information about a boss, including all of its forms if it has multiple forms.
     """
     try:
-        boss = boss_repository.get_boss(boss_id)
+        boss = await boss_repository.get_boss_async(boss_id)
         response.headers["Cache-Control"] = f"public, max-age={CACHE_TTL_SECONDS}"
 
         # If boss not found in the database, return mock data or 404
@@ -245,7 +245,7 @@ async def get_boss(boss_id: int, response: Response):
 async def get_boss_by_form(form_id: int, response: Response):
     """Get boss details using a form id."""
     try:
-        boss = boss_repository.get_boss_by_form(form_id)
+        boss = await boss_repository.get_boss_by_form_async(form_id)
         if not boss:
             raise HTTPException(status_code=404, detail="Boss form not found")
         response.headers["Cache-Control"] = f"public, max-age={CACHE_TTL_SECONDS}"
@@ -269,7 +269,7 @@ async def get_items(
     Returns a list of item summaries with basic information.
     """
     try:
-        items = item_repository.get_all_items(
+        items = await item_repository.get_all_items_async(
             combat_only=combat_only,
             tradeable_only=tradeable_only,
             limit=page_size,
@@ -299,7 +299,7 @@ async def get_item(item_id: int, response: Response):
     Returns detailed information about an item, including its combat stats.
     """
     try:
-        item = item_repository.get_item(item_id)
+        item = await item_repository.get_item_async(item_id)
         response.headers["Cache-Control"] = f"public, max-age={CACHE_TTL_SECONDS}"
 
         # If item not found in the database, return mock data or 404
@@ -453,7 +453,7 @@ async def search_bosses(query: str, limit: int | None = None):
     Returns a list of bosses that match the search query.
     """
     try:
-        results = boss_repository.search_bosses(query, limit=limit)
+        results = await boss_repository.search_bosses_async(query, limit=limit)
         return results
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Search failed: {str(e)}")
@@ -466,7 +466,7 @@ async def search_items(query: str, limit: int | None = None):
     Returns a list of items that match the search query.
     """
     try:
-        results = item_repository.search_items(query, limit=limit)
+        results = await item_repository.search_items_async(query, limit=limit)
         return results
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Search failed: {str(e)}")

--- a/backend/app/repositories/boss_repository.py
+++ b/backend/app/repositories/boss_repository.py
@@ -1,4 +1,5 @@
 from typing import Any, Dict, List, Optional
+import asyncio
 
 from cachetools import TTLCache, cached
 
@@ -52,3 +53,24 @@ def search_bosses(query: str, limit: int | None = None) -> List[Dict[str, Any]]:
     if limit is not None:
         return results[:limit]
     return results
+
+
+async def get_all_bosses_async(
+    limit: int | None = None, offset: int | None = None
+) -> List[Dict[str, Any]]:
+    return await db_service.get_all_bosses_async(limit=limit, offset=offset)
+
+
+async def get_boss_async(boss_id: int) -> Optional[Dict[str, Any]]:
+    return await db_service.get_boss_async(boss_id)
+
+
+async def get_boss_by_form_async(form_id: int) -> Optional[Dict[str, Any]]:
+    boss_id = await db_service.get_boss_id_by_form_async(form_id)
+    if boss_id is None:
+        return None
+    return await get_boss_async(boss_id)
+
+
+async def search_bosses_async(query: str, limit: int | None = None) -> List[Dict[str, Any]]:
+    return await asyncio.to_thread(search_bosses, query, limit)

--- a/backend/app/repositories/item_repository.py
+++ b/backend/app/repositories/item_repository.py
@@ -1,4 +1,5 @@
 from typing import Any, Dict, List, Optional
+import asyncio
 
 from cachetools import TTLCache, cached
 
@@ -54,3 +55,25 @@ def search_items(query: str, limit: int | None = None) -> List[Dict[str, Any]]:
     if limit is not None:
         return results[:limit]
     return results
+
+
+async def get_all_items_async(
+    combat_only: bool = True,
+    tradeable_only: bool = False,
+    limit: int | None = None,
+    offset: int | None = None,
+) -> List[Dict[str, Any]]:
+    return await db_service.get_all_items_async(
+        combat_only=combat_only,
+        tradeable_only=tradeable_only,
+        limit=limit,
+        offset=offset,
+    )
+
+
+async def get_item_async(item_id: int) -> Optional[Dict[str, Any]]:
+    return await db_service.get_item_async(item_id)
+
+
+async def search_items_async(query: str, limit: int | None = None) -> List[Dict[str, Any]]:
+    return await asyncio.to_thread(search_items, query, limit)


### PR DESCRIPTION
## Summary
- add connection pool with retry logic and async wrappers
- expose DB pool settings
- switch API routes to async repository functions
- document new environment variables for pooling

## Testing
- `python app/testing/UnitTest.py`
- `pytest app/testing/test_api.py`

------
https://chatgpt.com/codex/tasks/task_e_68478f9df7a0832eb7efd572f7cdc8a8