### PR TITLE
Update database docs for Azure SQL

### DIFF
--- a/backend/app/README.md
+++ b/backend/app/README.md
@@ -14,7 +14,7 @@ Python 3.8+
 FastAPI
 Uvicorn
 Pydantic
-SQLite (for database)
+Azure SQL Database
 
 Installation
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -8,20 +8,20 @@ This document illustrates the high level layout of the project and the flow betw
 flowchart LR
     User["Browser"] --> Frontend
     Frontend["Next.js App"] -->|REST API| Backend
-    Backend["FastAPI Service"] --> Database[(SQLite)]
+    Backend["FastAPI Service"] --> Database[(Azure SQL)]
     Backend --> Webscraper["Scraper Scripts"]
 ```
 
 * **Frontend** – Next.js application housed in `frontend/`.
 * **Backend** – FastAPI service inside `backend/` that provides calculation endpoints.
-* **Database** – SQLite databases populated by scrapers.
+* **Database** – Azure SQL database populated via scraper imports.
 * **Webscraper** – Python scripts under `backend/webscraper` used to refresh game data.
 
 ## Data Flow
 
 1. Users interact with the React frontend.
 2. The frontend communicates with the FastAPI backend.
-3. The backend queries the SQLite databases and performs DPS calculations.
+3. The backend queries the Azure SQL database and performs DPS calculations.
 4. Results are returned to the frontend for display.
 
 For more information see `docs/DEVELOPER_GUIDE.md`.

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -13,7 +13,7 @@ Additional documentation lives inside the `docs` folder.
 
 ## Database Schema
 
-The backend stores scraped game data in SQLite databases. An Entity Relationship Diagram (ERD) can be generated from the `database_schema.dot` file using Graphviz:
+The backend stores scraped game data in an Azure SQL Database. An Entity Relationship Diagram (ERD) can be generated from the `database_schema.dot` file using Graphviz:
 
 ```bash
 dot -Tpng docs/database_schema.dot -o database_schema.png
@@ -40,7 +40,7 @@ digraph ERD {
 - **Calculators** (`backend/app/calculators`) contain the core algorithms for melee, ranged and magic DPS.
 - **Services** (`backend/app/services`) provide thin wrappers used by the FastAPI endpoints.
 - **Repositories** (`backend/app/repositories`) interact with the database layer using `database.py`.
-- **Webscraper** (`backend/webscraper`) contains scripts that populate the SQLite databases from the Old School RuneScape Wiki.
+- **Webscraper** (`backend/webscraper`) contains scripts that scrape the Old School RuneScape Wiki and can populate SQLite databases for import into Azure SQL.
 
 The separation allows the same calculation logic to be reused across the application.
 


### PR DESCRIPTION
## Summary
- update README to document Azure SQL usage and env vars
- update backend README to list Azure SQL as requirement
- update architecture diagram references to Azure SQL
- refresh developer guide to mention Azure SQL instead of SQLite

## Testing
- `python -m unittest discover backend/app/testing` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6847a1309c7c832e9eef8935952dd4ab