### PR TITLE
Fix backend URL

### DIFF
--- a/.github/workflows/deploy-backend-function-app.yml
+++ b/.github/workflows/deploy-backend-function-app.yml
@@ -11,6 +11,7 @@ on:
 
 env:
   AZURE_WEBAPP_NAME: 'ScapeLab-API'  # Your full app name
+  AZURE_WEBAPP_URL: 'scapelab-api-dvawaebtdze3brf0.canadacentral-01.azurewebsites.net'
   AZURE_WEBAPP_PACKAGE_PATH: './backend'
   PYTHON_VERSION: '3.12'
 
@@ -54,10 +55,10 @@ jobs:
         sleep 30
         
         # Test root endpoint
-        curl -f https://${{ env.AZURE_WEBAPP_NAME }}.azurewebsites.net/ || echo "Root endpoint failed"
-        
+        curl -f https://${{ env.AZURE_WEBAPP_URL }}/ || echo "Root endpoint failed"
+
         # Test health/docs endpoint
-        curl -f https://${{ env.AZURE_WEBAPP_NAME }}.azurewebsites.net/docs || echo "Docs endpoint failed"
-        
+        curl -f https://${{ env.AZURE_WEBAPP_URL }}/docs || echo "Docs endpoint failed"
+
         # Test bosses endpoint
-        curl -f https://${{ env.AZURE_WEBAPP_NAME }}.azurewebsites.net/bosses || echo "Bosses endpoint failed"
+        curl -f https://${{ env.AZURE_WEBAPP_URL }}/bosses || echo "Bosses endpoint failed"

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ For production, set this to your deployed API URL. The deployment workflows
 expect a repository secret named `BACKEND_URL` which will be exposed as
 `NEXT_PUBLIC_API_URL` during the frontend build.
 Ensure this secret contains the URL of your deployed FastAPI service, for example
-`https://scapelab-api.azurewebsites.net`.
+`https://scapelab-api-dvawaebtdze3brf0.canadacentral-01.azurewebsites.net`.
 
 When deploying the frontend, the workflow also requires a secret named
 `AZURE_STATIC_WEB_APPS_API_TOKEN_YELLOW_STONE_0DAF36A0F` containing the


### PR DESCRIPTION
## Summary
- fix docs to reference scapelab API with the full Azure URL
- update backend workflow to test using the correct API host

## Testing
- `python -m unittest discover backend/app/testing`
- `npm test --ci`

------
https://chatgpt.com/codex/tasks/task_e_6847a1e6c528832eafbd9bc9d586a817