### PR TITLE
Remove 50-result limit from search

### DIFF
--- a/frontend/src/components/features/calculator/BossSelector.tsx
+++ b/frontend/src/components/features/calculator/BossSelector.tsx
@@ -65,7 +65,7 @@ export function BossSelector({ onSelectBoss, onSelectForm }: BossSelectorProps) 
     isLoading,
   } = useQuery({
     queryKey: ['boss-search', searchTerm],
-    queryFn: () => bossesApi.searchBosses(searchTerm, 50),
+    queryFn: () => bossesApi.searchBosses(searchTerm),
     enabled: searchTerm.length > 0,
     staleTime: Infinity,
     onSuccess: (d) => addBosses(d),

--- a/frontend/src/components/features/calculator/DirectBossSelector.tsx
+++ b/frontend/src/components/features/calculator/DirectBossSelector.tsx
@@ -58,7 +58,7 @@ export function DirectBossSelector({ onSelectBoss, onSelectForm, className }: Di
     isLoading,
   } = useQuery({
     queryKey: ['boss-search', searchQuery],
-    queryFn: () => bossesApi.searchBosses(searchQuery, 50),
+    queryFn: () => bossesApi.searchBosses(searchQuery),
     enabled: searchQuery.length > 0,
     staleTime: Infinity,
     onSuccess: (d) => addBosses(d),

--- a/frontend/src/components/features/calculator/ItemSelector.tsx
+++ b/frontend/src/components/features/calculator/ItemSelector.tsx
@@ -50,7 +50,7 @@ export function ItemSelector({ slot, onSelectItem }: ItemSelectorProps) {
     isLoading,
   } = useQuery({
     queryKey: ['item-search', searchTerm],
-    queryFn: () => itemsApi.searchItems(searchTerm, 50),
+    queryFn: () => itemsApi.searchItems(searchTerm),
     enabled: searchTerm.length > 0,
     staleTime: Infinity,
     onSuccess: (d) => addItems(d),

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -68,9 +68,11 @@ export const bossesApi = {
   },
 
   searchBosses: async (query: string, limit?: number): Promise<Boss[]> => {
-    const { data } = await apiClient.get('/search/bosses', {
-      params: { query, limit },
-    });
+    const params: Record<string, unknown> = { query };
+    if (limit !== undefined) {
+      params.limit = limit;
+    }
+    const { data } = await apiClient.get('/search/bosses', { params });
     return data;
   },
 };
@@ -97,9 +99,11 @@ export const itemsApi = {
   },
 
   searchItems: async (query: string, limit?: number): Promise<Item[]> => {
-    const { data } = await apiClient.get('/search/items', {
-      params: { query, limit },
-    });
+    const params: Record<string, unknown> = { query };
+    if (limit !== undefined) {
+      params.limit = limit;
+    }
+    const { data } = await apiClient.get('/search/items', { params });
     return data;
   },
 };


### PR DESCRIPTION
## Summary
- remove hard-coded 50 result limit from boss/item searches in the frontend
- only include `limit` param when a value is provided

## Testing
- `python -m unittest discover backend/app/testing`

------
https://chatgpt.com/codex/tasks/task_e_6847a9d82328832eb570f3d4a4b6c49c