### PR TITLE
Add raid scaling panel to simulator

### DIFF
--- a/frontend/src/components/features/calculator/ImprovedDpsCalculator.tsx
+++ b/frontend/src/components/features/calculator/ImprovedDpsCalculator.tsx
@@ -2,7 +2,7 @@
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Info } from 'lucide-react';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useReferenceDataStore } from '@/store/reference-data-store';
 import { BossSelector } from './BossSelector';
 import { CombinedEquipmentDisplay } from './CombinedEquipmentDisplay';
@@ -16,6 +16,8 @@ import { CombatStyleTabs } from './CombatStyleTabs';
 import { DpsResultDisplay } from './DpsResultDisplay';
 import { useDpsCalculator } from '@/hooks/useDpsCalculator';
 import { useToast } from '@/hooks/use-toast';
+import RaidScalingPanel, { Raid, RaidScalingConfig } from '../simulation/RaidScalingPanel';
+import { useCalculatorStore } from '@/store/calculator-store';
 
 /**
  * ImprovedDpsCalculator - A redesigned OSRS DPS Calculator with better UI flow
@@ -41,6 +43,18 @@ export function ImprovedDpsCalculator() {
     currentBossForm,
   } = useDpsCalculator();
   const initData = useReferenceDataStore((s) => s.initData);
+  const selectedBoss = useCalculatorStore((s) => s.selectedBoss);
+  const [raidConfig, setRaidConfig] = useState<RaidScalingConfig>({ teamSize: 1 });
+
+  const RAID_NAME_TO_ID: Record<string, Raid> = {
+    'Chambers of Xeric': 'cox',
+    'Theatre of Blood': 'tob',
+    'Tombs of Amascut': 'toa',
+  };
+
+  const selectedRaid = selectedBoss?.raid_group
+    ? RAID_NAME_TO_ID[selectedBoss.raid_group]
+    : undefined;
 
   useEffect(() => {
     initData();
@@ -107,6 +121,13 @@ export function ImprovedDpsCalculator() {
         <div className="space-y-6 flex flex-col flex-grow">
           {/* Target selection section */}
           <BossSelector onSelectForm={handleBossUpdate} />
+          {selectedRaid && (
+            <RaidScalingPanel
+              raid={selectedRaid}
+              config={raidConfig}
+              onChange={setRaidConfig}
+            />
+          )}
           
           {/* Defensive reductions panel - with contained height */}
           <Card className="w-full border">

--- a/frontend/src/components/features/calculator/ImprovedDpsCalculator.tsx
+++ b/frontend/src/components/features/calculator/ImprovedDpsCalculator.tsx
@@ -16,7 +16,8 @@ import { CombatStyleTabs } from './CombatStyleTabs';
 import { DpsResultDisplay } from './DpsResultDisplay';
 import { useDpsCalculator } from '@/hooks/useDpsCalculator';
 import { useToast } from '@/hooks/use-toast';
-import RaidScalingPanel, { Raid, RaidScalingConfig } from '../simulation/RaidScalingPanel';
+import RaidScalingPanel, { RaidScalingConfig } from '../simulation/RaidScalingPanel';
+import { Raid, RAID_NAME_TO_ID } from '@/types/raid';
 import { useCalculatorStore } from '@/store/calculator-store';
 
 /**
@@ -45,12 +46,6 @@ export function ImprovedDpsCalculator() {
   const initData = useReferenceDataStore((s) => s.initData);
   const selectedBoss = useCalculatorStore((s) => s.selectedBoss);
   const [raidConfig, setRaidConfig] = useState<RaidScalingConfig>({ teamSize: 1 });
-
-  const RAID_NAME_TO_ID: Record<string, Raid> = {
-    'Chambers of Xeric': 'cox',
-    'Theatre of Blood': 'tob',
-    'Tombs of Amascut': 'toa',
-  };
 
   const selectedRaid = selectedBoss?.raid_group
     ? RAID_NAME_TO_ID[selectedBoss.raid_group]

--- a/frontend/src/components/features/simulation/MultiBossSimulation.tsx
+++ b/frontend/src/components/features/simulation/MultiBossSimulation.tsx
@@ -22,7 +22,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import RaidScalingPanel, { Raid, RaidScalingConfig } from './RaidScalingPanel';
+import RaidScalingPanel, { RaidScalingConfig } from './RaidScalingPanel';
+import { Raid, RAID_OPTIONS, RAID_NAME_MAP } from '@/types/raid';
 import {
   Table,
   TableBody,
@@ -49,16 +50,6 @@ interface SimulationEntry {
   result: DpsResult;
 }
 
-const RAID_OPTIONS: { id: Raid; name: string }[] = [
-  { id: 'cox', name: 'Chambers of Xeric' },
-  { id: 'tob', name: 'Theatre of Blood' },
-  { id: 'toa', name: 'Tombs of Amascut' },
-];
-
-const RAID_NAME_MAP = RAID_OPTIONS.reduce<Record<Raid, string>>((acc, r) => {
-  acc[r.id] = r.name;
-  return acc;
-}, {} as Record<Raid, string>);
 
 export function MultiBossSimulation() {
   const params = useCalculatorStore((s) => s.params);

--- a/frontend/src/components/features/simulation/RaidScalingPanel.tsx
+++ b/frontend/src/components/features/simulation/RaidScalingPanel.tsx
@@ -1,0 +1,64 @@
+'use client';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+export type Raid = 'cox' | 'tob' | 'toa';
+
+export interface RaidScalingConfig {
+  teamSize: number;
+  raidLevel?: number;
+}
+
+interface RaidScalingPanelProps {
+  raid: Raid;
+  config: RaidScalingConfig;
+  onChange: (config: RaidScalingConfig) => void;
+}
+
+const RAID_NAMES: Record<Raid, string> = {
+  cox: 'Chambers of Xeric',
+  tob: 'Theatre of Blood',
+  toa: 'Tombs of Amascut',
+};
+
+export function RaidScalingPanel({ raid, config, onChange }: RaidScalingPanelProps) {
+  const handleChange = (key: keyof RaidScalingConfig, value: number) => {
+    onChange({ ...config, [key]: value });
+  };
+
+  return (
+    <Card className="w-full">
+      <CardHeader>
+        <CardTitle>{RAID_NAMES[raid]} Scaling</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4 text-left">
+        <div className="flex items-center gap-2">
+          <Label className="w-28">Team Size</Label>
+          <Input
+            type="number"
+            min={1}
+            value={config.teamSize}
+            onChange={(e) => handleChange('teamSize', parseInt(e.target.value) || 1)}
+            className="w-24"
+          />
+        </div>
+        {raid === 'toa' && (
+          <div className="flex items-center gap-2">
+            <Label className="w-28">Raid Level</Label>
+            <Input
+              type="number"
+              min={0}
+              max={600}
+              value={config.raidLevel ?? 0}
+              onChange={(e) => handleChange('raidLevel', parseInt(e.target.value) || 0)}
+              className="w-24"
+            />
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+export default RaidScalingPanel;

--- a/frontend/src/components/features/simulation/RaidScalingPanel.tsx
+++ b/frontend/src/components/features/simulation/RaidScalingPanel.tsx
@@ -2,8 +2,7 @@
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-
-export type Raid = 'cox' | 'tob' | 'toa';
+import { Raid, RAID_NAME_MAP } from '@/types/raid';
 
 export interface RaidScalingConfig {
   teamSize: number;
@@ -16,12 +15,6 @@ interface RaidScalingPanelProps {
   onChange: (config: RaidScalingConfig) => void;
 }
 
-const RAID_NAMES: Record<Raid, string> = {
-  cox: 'Chambers of Xeric',
-  tob: 'Theatre of Blood',
-  toa: 'Tombs of Amascut',
-};
-
 export function RaidScalingPanel({ raid, config, onChange }: RaidScalingPanelProps) {
   const handleChange = (key: keyof RaidScalingConfig, value: number) => {
     onChange({ ...config, [key]: value });
@@ -30,7 +23,7 @@ export function RaidScalingPanel({ raid, config, onChange }: RaidScalingPanelPro
   return (
     <Card className="w-full">
       <CardHeader>
-        <CardTitle>{RAID_NAMES[raid]} Scaling</CardTitle>
+        <CardTitle>{RAID_NAME_MAP[raid]} Scaling</CardTitle>
       </CardHeader>
       <CardContent className="space-y-4 text-left">
         <div className="flex items-center gap-2">

--- a/frontend/src/types/raid.ts
+++ b/frontend/src/types/raid.ts
@@ -1,0 +1,17 @@
+export type Raid = 'cox' | 'tob' | 'toa';
+
+export const RAID_OPTIONS: { id: Raid; name: string }[] = [
+  { id: 'cox', name: 'Chambers of Xeric' },
+  { id: 'tob', name: 'Theatre of Blood' },
+  { id: 'toa', name: 'Tombs of Amascut' },
+];
+
+export const RAID_NAME_MAP = RAID_OPTIONS.reduce<Record<Raid, string>>((acc, r) => {
+  acc[r.id] = r.name;
+  return acc;
+}, {} as Record<Raid, string>);
+
+export const RAID_NAME_TO_ID = RAID_OPTIONS.reduce<Record<string, Raid>>((acc, r) => {
+  acc[r.name] = r.id;
+  return acc;
+}, {} as Record<string, Raid>);


### PR DESCRIPTION
## Summary
- allow selecting raid groups in multi-boss simulator
- show raid scaling inputs for team size (and raid level for ToA)

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*
- `python -m unittest discover backend/app/testing` *(fails: import error)*

------
https://chatgpt.com/codex/tasks/task_e_6847adf6f234832eb81ac7ff80c3a2c7