### PR TITLE
Add raid scaling panel to calc page

### DIFF
--- a/frontend/src/__tests__/reference-data-store.test.ts
+++ b/frontend/src/__tests__/reference-data-store.test.ts
@@ -14,9 +14,10 @@ function getStore() {
 describe('reference data store', () => {
   beforeEach(() => {
     act(() => {
-      useReferenceDataStore.setState({ bosses: [], items: [], initialized: false });
+      useReferenceDataStore.setState({ bosses: [], bossForms: {}, items: [], initialized: false });
     });
     mockedBossApi.getAllBosses.mockReset();
+    mockedBossApi.getBossForms.mockReset();
     mockedItemsApi.getAllItems.mockReset();
   });
 
@@ -24,6 +25,8 @@ describe('reference data store', () => {
     mockedBossApi.getAllBosses
       .mockResolvedValueOnce([{ id: 1, name: 'Boss' } as any])
       .mockResolvedValueOnce([]);
+
+    mockedBossApi.getBossForms.mockResolvedValueOnce([{ id: 10, boss_id: 1 } as any]);
 
     mockedItemsApi.getAllItems
       .mockResolvedValueOnce([{ id: 2, name: 'Item' } as any])
@@ -35,13 +38,16 @@ describe('reference data store', () => {
 
     const state = getStore();
     expect(state.bosses).toHaveLength(1);
+    expect(state.bossForms[1]).toHaveLength(1);
     expect(state.items).toHaveLength(1);
     expect(mockedBossApi.getAllBosses).toHaveBeenCalledTimes(1);
+    expect(mockedBossApi.getBossForms).toHaveBeenCalledTimes(1);
     expect(mockedItemsApi.getAllItems).toHaveBeenCalledTimes(1);
   });
 
   it('does not load again when initialized', async () => {
     mockedBossApi.getAllBosses.mockResolvedValue([]);
+    mockedBossApi.getBossForms.mockResolvedValue([]);
     mockedItemsApi.getAllItems.mockResolvedValue([]);
 
     await act(async () => {
@@ -53,6 +59,7 @@ describe('reference data store', () => {
     });
 
     expect(mockedBossApi.getAllBosses).toHaveBeenCalledTimes(1);
+    expect(mockedBossApi.getBossForms).toHaveBeenCalledTimes(0);
     expect(mockedItemsApi.getAllItems).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/components/features/calculator/ImprovedDpsCalculator.tsx
+++ b/frontend/src/components/features/calculator/ImprovedDpsCalculator.tsx
@@ -2,7 +2,7 @@
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Info } from 'lucide-react';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useReferenceDataStore } from '@/store/reference-data-store';
 import { BossSelector } from './BossSelector';
 import { CombinedEquipmentDisplay } from './CombinedEquipmentDisplay';
@@ -16,6 +16,9 @@ import { CombatStyleTabs } from './CombatStyleTabs';
 import { DpsResultDisplay } from './DpsResultDisplay';
 import { useDpsCalculator } from '@/hooks/useDpsCalculator';
 import { useToast } from '@/hooks/use-toast';
+import RaidScalingPanel, { RaidScalingConfig } from '../simulation/RaidScalingPanel';
+import { Raid, RAID_NAME_TO_ID } from '@/types/raid';
+import { useCalculatorStore } from '@/store/calculator-store';
 
 /**
  * ImprovedDpsCalculator - A redesigned OSRS DPS Calculator with better UI flow
@@ -41,6 +44,12 @@ export function ImprovedDpsCalculator() {
     currentBossForm,
   } = useDpsCalculator();
   const initData = useReferenceDataStore((s) => s.initData);
+  const selectedBoss = useCalculatorStore((s) => s.selectedBoss);
+  const [raidConfig, setRaidConfig] = useState<RaidScalingConfig>({ teamSize: 1 });
+
+  const selectedRaid = selectedBoss?.raid_group
+    ? RAID_NAME_TO_ID[selectedBoss.raid_group]
+    : undefined;
 
   useEffect(() => {
     initData();
@@ -107,6 +116,13 @@ export function ImprovedDpsCalculator() {
         <div className="space-y-6 flex flex-col flex-grow">
           {/* Target selection section */}
           <BossSelector onSelectForm={handleBossUpdate} />
+          {selectedRaid && (
+            <RaidScalingPanel
+              raid={selectedRaid}
+              config={raidConfig}
+              onChange={setRaidConfig}
+            />
+          )}
           
           {/* Defensive reductions panel - with contained height */}
           <Card className="w-full border">

--- a/frontend/src/components/features/simulation/RaidScalingPanel.tsx
+++ b/frontend/src/components/features/simulation/RaidScalingPanel.tsx
@@ -1,0 +1,57 @@
+'use client';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Raid, RAID_NAME_MAP } from '@/types/raid';
+
+export interface RaidScalingConfig {
+  teamSize: number;
+  raidLevel?: number;
+}
+
+interface RaidScalingPanelProps {
+  raid: Raid;
+  config: RaidScalingConfig;
+  onChange: (config: RaidScalingConfig) => void;
+}
+
+export function RaidScalingPanel({ raid, config, onChange }: RaidScalingPanelProps) {
+  const handleChange = (key: keyof RaidScalingConfig, value: number) => {
+    onChange({ ...config, [key]: value });
+  };
+
+  return (
+    <Card className="w-full">
+      <CardHeader>
+        <CardTitle>{RAID_NAME_MAP[raid]} Scaling</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4 text-left">
+        <div className="flex items-center gap-2">
+          <Label className="w-28">Team Size</Label>
+          <Input
+            type="number"
+            min={1}
+            value={config.teamSize}
+            onChange={(e) => handleChange('teamSize', parseInt(e.target.value) || 1)}
+            className="w-24"
+          />
+        </div>
+        {raid === 'toa' && (
+          <div className="flex items-center gap-2">
+            <Label className="w-28">Raid Level</Label>
+            <Input
+              type="number"
+              min={0}
+              max={600}
+              value={config.raidLevel ?? 0}
+              onChange={(e) => handleChange('raidLevel', parseInt(e.target.value) || 0)}
+              className="w-24"
+            />
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+export default RaidScalingPanel;

--- a/frontend/src/store/reference-data-store.ts
+++ b/frontend/src/store/reference-data-store.ts
@@ -3,15 +3,17 @@
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 import { bossesApi, itemsApi } from '@/services/api';
-import { Boss, Item } from '@/types/calculator';
+import { Boss, BossForm, Item } from '@/types/calculator';
 
 interface ReferenceDataState {
   bosses: Boss[];
+  bossForms: Record<number, BossForm[]>;
   items: Item[];
   initialized: boolean;
   timestamp: number;
   initData: () => Promise<void>;
   addBosses: (b: Boss[]) => void;
+  addBossForms: (id: number, forms: BossForm[]) => void;
   addItems: (i: Item[]) => void;
 }
 
@@ -21,6 +23,7 @@ export const useReferenceDataStore = create<ReferenceDataState>()(
   persist(
     (set, get) => ({
       bosses: [],
+      bossForms: {},
       items: [],
       initialized: false,
       timestamp: 0,
@@ -34,6 +37,16 @@ export const useReferenceDataStore = create<ReferenceDataState>()(
             const data = await bossesApi.getAllBosses({ page, page_size: pageSize });
             if (!data.length) break;
             set((state) => ({ bosses: [...state.bosses, ...data] }));
+            for (const b of data) {
+              try {
+                const forms = await bossesApi.getBossForms(b.id);
+                if (forms.length) {
+                  set((state) => ({ bossForms: { ...state.bossForms, [b.id]: forms } }));
+                }
+              } catch {
+                /* ignore */
+              }
+            }
             if (data.length < pageSize) break;
             page += 1;
           } catch {
@@ -61,6 +74,9 @@ export const useReferenceDataStore = create<ReferenceDataState>()(
       addBosses(b) {
         set((state) => ({ bosses: [...state.bosses, ...b] }));
       },
+      addBossForms(id, forms) {
+        set((state) => ({ bossForms: { ...state.bossForms, [id]: forms } }));
+      },
       addItems(i) {
         set((state) => ({ items: [...state.items, ...i] }));
       },
@@ -70,6 +86,7 @@ export const useReferenceDataStore = create<ReferenceDataState>()(
       storage: createJSONStorage(() => localStorage),
       partialize: (state) => ({
         bosses: state.bosses,
+        bossForms: state.bossForms,
         items: state.items,
         timestamp: state.timestamp,
       }),
@@ -77,7 +94,7 @@ export const useReferenceDataStore = create<ReferenceDataState>()(
         if (!stored) return;
         const expired = Date.now() - stored.timestamp > REFERENCE_TTL_MS;
         if (expired) {
-          state.setState({ bosses: [], items: [], initialized: false, timestamp: Date.now() });
+          state.setState({ bosses: [], bossForms: {}, items: [], initialized: false, timestamp: Date.now() });
         } else {
           state.setState({ initialized: true });
         }

--- a/frontend/src/types/raid.ts
+++ b/frontend/src/types/raid.ts
@@ -1,0 +1,17 @@
+export type Raid = 'cox' | 'tob' | 'toa';
+
+export const RAID_OPTIONS: { id: Raid; name: string }[] = [
+  { id: 'cox', name: 'Chambers of Xeric' },
+  { id: 'tob', name: 'Theatre of Blood' },
+  { id: 'toa', name: 'Tombs of Amascut' },
+];
+
+export const RAID_NAME_MAP = RAID_OPTIONS.reduce<Record<Raid, string>>((acc, r) => {
+  acc[r.id] = r.name;
+  return acc;
+}, {} as Record<Raid, string>);
+
+export const RAID_NAME_TO_ID = RAID_OPTIONS.reduce<Record<string, Raid>>((acc, r) => {
+  acc[r.name] = r.id;
+  return acc;
+}, {} as Record<string, Raid>);


### PR DESCRIPTION
## Summary
- allow selecting raid groups in multi-boss simulator
- show raid scaling inputs for team size (and raid level for ToA)
- display raid scaling panel on calculator page when a raid boss is chosen
- refactor raid constant mappings into a shared file
- cache boss form data in the reference data store

## Testing
- `npm run lint` *(fails: many lint errors)*
- `npm test`
- `python -m unittest discover backend/app/testing` *(fails: ModuleNotFoundError: httpx/cachetools)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6847adf6f234832eb81ac7ff80c3a2c7