### PR TITLE
Improve boss API fallbacks

### DIFF
--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -53,8 +53,16 @@ export const bossesApi = {
   },
 
   getBossById: async (id: number): Promise<Boss> => {
-    const { data } = await apiClient.get(`/boss/${id}`);
-    return data;
+    try {
+      const { data } = await apiClient.get(`/boss/${id}`);
+      return data;
+    } catch (err: any) {
+      if (err.response?.status === 404) {
+        const { data } = await apiClient.get(`/boss/form/${id}`);
+        return data;
+      }
+      throw err;
+    }
   },
 
   getBossByFormId: async (formId: number): Promise<Boss> => {
@@ -63,8 +71,16 @@ export const bossesApi = {
   },
 
   getBossForms: async (bossId: number): Promise<BossForm[]> => {
-    const { data } = await apiClient.get(`/boss/${bossId}`);
-    return data.forms || [];
+    try {
+      const { data } = await apiClient.get(`/boss/${bossId}`);
+      return data.forms || [];
+    } catch (err: any) {
+      if (err.response?.status === 404) {
+        const { data } = await apiClient.get(`/boss/form/${bossId}`);
+        return data.forms || [];
+      }
+      throw err;
+    }
   },
 
   searchBosses: async (query: string, limit?: number): Promise<Boss[]> => {


### PR DESCRIPTION
## Summary
- add fallback to `getBossById` so form ids work
- extend `getBossForms` with similar 404 fallback

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6847b8a71f58832e92cb31e8def1a05f