### PR TITLE
Auto-populate raid bosses in simulation

### DIFF
--- a/frontend/src/components/features/simulation/MultiBossSimulation.tsx
+++ b/frontend/src/components/features/simulation/MultiBossSimulation.tsx
@@ -90,8 +90,14 @@ export function MultiBossSimulation() {
   });
 
   useEffect(() => {
-    setSelectedBosses([]);
-  }, [selectedRaid]);
+    if (!selectedRaid) {
+      setSelectedBosses([]);
+      return;
+    }
+    const raidName = RAID_NAME_MAP[selectedRaid];
+    const bossesForRaid = storeBosses.filter((b) => b.raid_group === raidName);
+    setSelectedBosses(bossesForRaid);
+  }, [selectedRaid, storeBosses]);
 
   const filteredBosses = (searchTerm.length > 0 ? searchResults ?? [] : storeBosses).filter(
     (b) => !selectedRaid || b.raid_group === RAID_NAME_MAP[selectedRaid]


### PR DESCRIPTION
## Summary
- when selecting a raid, automatically fill the boss list with bosses from that raid

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6847b9f6ac5c832e8935c51c638d98f3