### PR TITLE
Handle storage quota failures

### DIFF
--- a/frontend/src/store/calculator-store.ts
+++ b/frontend/src/store/calculator-store.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
-import { persist } from 'zustand/middleware';
+import { persist, createJSONStorage } from 'zustand/middleware';
+import { safeStorage } from '@/utils/safeStorage';
 import {
   CalculatorParams,
   DpsResult,
@@ -214,6 +215,7 @@ export const useCalculatorStore = create<CalculatorState>()(
     }),
     {
       name: 'osrs-calculator-storage',
+      storage: createJSONStorage(() => safeStorage),
       partialize: (state) => ({
         params: state.params,
         gearLocked: state.gearLocked,

--- a/frontend/src/store/reference-data-store.ts
+++ b/frontend/src/store/reference-data-store.ts
@@ -2,6 +2,7 @@
 
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
+import { safeStorage } from '@/utils/safeStorage';
 import { bossesApi, itemsApi } from '@/services/api';
 import { Boss, BossForm, Item } from '@/types/calculator';
 
@@ -83,7 +84,7 @@ export const useReferenceDataStore = create<ReferenceDataState>()(
     }),
     {
       name: 'osrs-reference-data',
-      storage: createJSONStorage(() => localStorage),
+      storage: createJSONStorage(() => safeStorage),
       partialize: (state) => ({
         bosses: state.bosses,
         bossForms: state.bossForms,

--- a/frontend/src/utils/safeStorage.ts
+++ b/frontend/src/utils/safeStorage.ts
@@ -1,0 +1,28 @@
+import { StateStorage } from 'zustand/middleware';
+
+/**
+ * A wrapper around browser localStorage that gracefully handles quota errors.
+ */
+export const safeStorage: StateStorage = {
+  getItem(name) {
+    try {
+      return localStorage.getItem(name);
+    } catch {
+      return null;
+    }
+  },
+  setItem(name, value) {
+    try {
+      localStorage.setItem(name, value);
+    } catch (err) {
+      console.warn('Failed to persist state', err);
+    }
+  },
+  removeItem(name) {
+    try {
+      localStorage.removeItem(name);
+    } catch {
+      /* ignore */
+    }
+  }
+};


### PR DESCRIPTION
## Summary
- catch errors when persisting store data
- use resilient local storage wrapper

## Testing
- `python -m unittest discover backend/app/testing` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6847c5a06780832eaf5675b39e1836cd