### PR TITLE
Fix active highlight for attack style buttons

### DIFF
--- a/frontend/src/components/features/calculator/AttackStyleSelector.tsx
+++ b/frontend/src/components/features/calculator/AttackStyleSelector.tsx
@@ -143,14 +143,16 @@ export function AttackStyleSelector({
               <TooltipProvider key={style}>
                 <Tooltip>
                   <TooltipTrigger asChild>
-                    <TabsTrigger
-                      value={style}
-                      onClick={() => onSelectAttackStyle(style)}
-                      className="capitalize text-xs"
-                    >
-                      {styleInfo.name}
-                      {combatStyle !== "melee" && ` (${styleInfo.attackType})`}
-                    </TabsTrigger>
+                    <span className="contents">
+                      <TabsTrigger
+                        value={style}
+                        onClick={() => onSelectAttackStyle(style)}
+                        className="capitalize text-xs"
+                      >
+                        {styleInfo.name}
+                        {combatStyle !== "melee" && ` (${styleInfo.attackType})`}
+                      </TabsTrigger>
+                    </span>
                   </TooltipTrigger>
                   <TooltipContent>
                     <p>{styleInfo.description}</p>


### PR DESCRIPTION
## Summary
- prevent tooltip state from overriding Tabs state in AttackStyleSelector

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847c4367924832e913a93eb4b2ea2ea