### PR TITLE
Add paginated boss forms API and client updates

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -146,6 +146,24 @@ async def get_bosses(
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to retrieve bosses: {str(e)}")
 
+
+@app.get("/bosses/full", response_model=List[Boss], tags=["Bosses"])
+async def get_bosses_full(
+    page: int = Query(1, ge=1, description="Page number"),
+    page_size: int = Query(50, ge=1, le=100, description="Results per page"),
+):
+    """Get a paginated list of bosses including their forms."""
+    try:
+        bosses = await boss_repository.get_bosses_with_forms_async(
+            limit=page_size,
+            offset=(page - 1) * page_size,
+        )
+        if not bosses:
+            return []
+        return bosses
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Failed to retrieve bosses: {str(e)}")
+
 @app.get("/boss/{boss_id}", response_model=Boss, tags=["Bosses"])
 async def get_boss(boss_id: int, response: Response):
     """

--- a/backend/app/repositories/boss_repository.py
+++ b/backend/app/repositories/boss_repository.py
@@ -94,3 +94,17 @@ async def get_boss_by_form_async(form_id: int) -> Optional[Dict[str, Any]]:
 
 async def search_bosses_async(query: str, limit: int | None = None) -> List[Dict[str, Any]]:
     return await db_service.search_bosses_async(query, limit)
+
+
+async def get_bosses_with_forms_async(
+    limit: int | None = None, offset: int | None = None
+) -> List[Dict[str, Any]]:
+    """Return multiple bosses with all forms included."""
+    bosses = await get_all_bosses_async(limit=limit, offset=offset)
+    if not bosses:
+        return []
+
+    results = await asyncio.gather(
+        *[get_boss_async(boss["id"]) for boss in bosses]
+    )
+    return [b for b in results if b is not None]

--- a/frontend/src/__tests__/reference-data-store.test.ts
+++ b/frontend/src/__tests__/reference-data-store.test.ts
@@ -16,17 +16,15 @@ describe('reference data store', () => {
     act(() => {
       useReferenceDataStore.setState({ bosses: [], bossForms: {}, items: [], initialized: false });
     });
-    mockedBossApi.getAllBosses.mockReset();
+    mockedBossApi.getBossesWithForms.mockReset();
     mockedBossApi.getBossForms.mockReset();
     mockedItemsApi.getAllItems.mockReset();
   });
 
   it('loads data from APIs', async () => {
-    mockedBossApi.getAllBosses
-      .mockResolvedValueOnce([{ id: 1, name: 'Boss' } as any])
+    mockedBossApi.getBossesWithForms
+      .mockResolvedValueOnce([{ id: 1, name: 'Boss', forms: [{ id: 10, boss_id: 1 }] } as any])
       .mockResolvedValueOnce([]);
-
-    mockedBossApi.getBossForms.mockResolvedValueOnce([{ id: 10, boss_id: 1 } as any]);
 
     mockedItemsApi.getAllItems
       .mockResolvedValueOnce([{ id: 2, name: 'Item' } as any])
@@ -40,13 +38,13 @@ describe('reference data store', () => {
     expect(state.bosses).toHaveLength(1);
     expect(state.bossForms[1]).toHaveLength(1);
     expect(state.items).toHaveLength(1);
-    expect(mockedBossApi.getAllBosses).toHaveBeenCalledTimes(1);
-    expect(mockedBossApi.getBossForms).toHaveBeenCalledTimes(1);
+    expect(mockedBossApi.getBossesWithForms).toHaveBeenCalledTimes(1);
+    expect(mockedBossApi.getBossForms).toHaveBeenCalledTimes(0);
     expect(mockedItemsApi.getAllItems).toHaveBeenCalledTimes(1);
   });
 
   it('does not load again when initialized', async () => {
-    mockedBossApi.getAllBosses.mockResolvedValue([]);
+    mockedBossApi.getBossesWithForms.mockResolvedValue([]);
     mockedBossApi.getBossForms.mockResolvedValue([]);
     mockedItemsApi.getAllItems.mockResolvedValue([]);
 
@@ -58,7 +56,7 @@ describe('reference data store', () => {
       await getStore().initData();
     });
 
-    expect(mockedBossApi.getAllBosses).toHaveBeenCalledTimes(1);
+    expect(mockedBossApi.getBossesWithForms).toHaveBeenCalledTimes(1);
     expect(mockedBossApi.getBossForms).toHaveBeenCalledTimes(0);
     expect(mockedItemsApi.getAllItems).toHaveBeenCalledTimes(1);
   });

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -52,6 +52,13 @@ export const bossesApi = {
     return data;
   },
 
+  getBossesWithForms: async (
+    params?: { page?: number; page_size?: number }
+  ): Promise<Boss[]> => {
+    const { data } = await apiClient.get('/bosses/full', { params });
+    return data;
+  },
+
   getBossById: async (id: number): Promise<Boss> => {
     try {
       const { data } = await apiClient.get(`/boss/${id}`);

--- a/frontend/src/store/reference-data-store.ts
+++ b/frontend/src/store/reference-data-store.ts
@@ -35,18 +35,17 @@ export const useReferenceDataStore = create<ReferenceDataState>()(
         let page = 1;
         while (true) {
           try {
-            const data = await bossesApi.getAllBosses({ page, page_size: pageSize });
+            const data = await bossesApi.getBossesWithForms({ page, page_size: pageSize });
             if (!data.length) break;
             set((state) => ({ bosses: [...state.bosses, ...data] }));
+            const formsMap: Record<number, BossForm[]> = {};
             for (const b of data) {
-              try {
-                const forms = await bossesApi.getBossForms(b.id);
-                if (forms.length) {
-                  set((state) => ({ bossForms: { ...state.bossForms, [b.id]: forms } }));
-                }
-              } catch {
-                /* ignore */
+              if (b.forms && b.forms.length) {
+                formsMap[b.id] = b.forms;
               }
+            }
+            if (Object.keys(formsMap).length) {
+              set((state) => ({ bossForms: { ...state.bossForms, ...formsMap } }));
             }
             if (data.length < pageSize) break;
             page += 1;


### PR DESCRIPTION
## Summary
- provide `/bosses/full` endpoint that returns full boss details
- add `getBossesWithForms` repository helper
- expose new API client method
- batch load bosses with forms in reference data store
- adjust unit tests for new workflow

## Testing
- `npm test`
- `pytest` *(fails: ModuleNotFoundError and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6847c99eb48c832e9b8d48b5563cc646