### PR TITLE
Implement raid-level scaling in DPS calculator

### DIFF
--- a/backend/app/calculators/__init__.py
+++ b/backend/app/calculators/__init__.py
@@ -1,6 +1,7 @@
 from .melee import MeleeCalculator
 from .ranged import RangedCalculator
 from .magic import MagicCalculator
+from .raid_scaling import apply_raid_scaling
 from typing import Dict, Any
 
 
@@ -12,6 +13,7 @@ class DpsCalculator:
         """
         Dispatch DPS calculation based on combat style.
         """
+        params = apply_raid_scaling(params)
         combat_style = params.get("combat_style", "melee").lower()
 
         if combat_style == "melee":

--- a/backend/app/calculators/raid_scaling.py
+++ b/backend/app/calculators/raid_scaling.py
@@ -1,0 +1,69 @@
+"""Utility functions for adjusting target stats based on raid settings."""
+
+from typing import Dict, Any
+
+
+def apply_raid_scaling(params: Dict[str, Any]) -> Dict[str, Any]:
+    """Adjust defensive stats based on raid type and raid level."""
+
+    raid = params.get("raid")
+    if not raid:
+        return params
+
+    raid = str(raid).lower()
+    party_size = int(params.get("party_size", 1) or 1)
+    raid_level = int(params.get("raid_level", 0) or 0)
+    path_level = int(params.get("path_level", 0) or 0)
+
+    defence_mult = 1.0
+
+    if raid in {"toa", "tombs of amascut"}:
+        # Only raid level affects defence/accuracy. Party size and path level
+        # modify hitpoints/damage which are not currently modelled.
+        defence_mult = 1 + raid_level * 0.004
+    elif raid in {"tob", "theatre of blood"}:
+        # Theatre of Blood only scales boss hitpoints based on party size.
+        # Defensive stats remain unchanged.
+        defence_mult = 1.0
+    elif raid in {"cox", "chambers of xeric"}:
+        # Chambers of Xeric enemy stats vary with party size and scaling
+        # from infiltration. A precise formula is complex, so we
+        # approximate increased defence by 40% per extra player.
+        defence_mult = 1 + 0.4 * max(0, party_size - 1)
+    else:
+        return params
+
+    params = params.copy()
+    params["target_defence_level"] = int(params.get("target_defence_level", 1) * defence_mult)
+    params["target_defence_bonus"] = int(params.get("target_defence_bonus", 0) * defence_mult)
+    if "target_magic_level" in params:
+        params["target_magic_level"] = int(params.get("target_magic_level", 1) * defence_mult)
+    if "target_magic_defence" in params:
+        params["target_magic_defence"] = int(params.get("target_magic_defence", 0) * defence_mult)
+
+    # Store multipliers for potential future use (e.g. hitpoint scaling)
+    params["raid_defence_multiplier"] = defence_mult
+
+    hp_mult = 1.0
+    if raid in {"toa", "tombs of amascut"}:
+        hp_mult = 1.0
+        if party_size > 1:
+            hp_mult += 0.9 * min(2, party_size - 1)
+        if party_size > 3:
+            hp_mult += 0.6 * (party_size - 3)
+        hp_mult *= 1 + raid_level * 0.004
+        if path_level:
+            hp_mult *= 1 + 0.08 + 0.05 * max(0, path_level - 1)
+    elif raid in {"tob", "theatre of blood"}:
+        if party_size <= 3:
+            hp_mult = 0.75
+        elif party_size == 4:
+            hp_mult = 0.875
+        else:
+            hp_mult = 1.0
+    elif raid in {"cox", "chambers of xeric"}:
+        hp_mult = 1 + 0.4 * max(0, party_size - 1)
+
+    params["raid_hp_multiplier"] = hp_mult
+
+    return params

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -178,6 +178,12 @@ class DpsParameters(BaseModel):
     elemental_weakness: Optional[float] = None
     salve_bonus: Optional[float] = None
 
+    # Raid parameters
+    raid: Optional[str] = None
+    raid_level: Optional[int] = None
+    party_size: Optional[int] = None
+    path_level: Optional[int] = None
+
     # Target parameters
     target_defence_level: int = 1
     target_defence_bonus: int = 0


### PR DESCRIPTION
## Summary
- refine raid scaling logic and keep track of both defence and HP multipliers
- extend `DpsParameters` with a `path_level` field for Tombs of Amascut

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847cdc7ee7c832eb99f15bcd9d31958