### PR TITLE
Async SQL Server pool and startup cache warm-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ source venv/bin/activate  # On Windows: venv\Scripts\activate
 # Install dependencies
 pip install -r requirements.txt
 
+The backend relies on `aioodbc` for asynchronous SQL Server access. Ensure the
+system has the Microsoft ODBC driver installed.
+
 # Run development server
 uvicorn app.main:app --reload
 
@@ -182,6 +185,10 @@ environment variables:
 - `DB_CONNECTION_TIMEOUT` – Connection timeout in seconds (default `30`).
 - `DB_MAX_RETRIES` – Number of connection retries for transient failures
   (default `3`).
+
+The async database layer uses `aioodbc`, so the appropriate ODBC driver must be
+installed on the host system. Ensure these environment variables are set before
+starting the API so the connection pool can connect successfully.
 
 🔄 API Reference
 Calculate DPS

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,10 +1,10 @@
 import pyodbc
+import aioodbc
 import os
 import json
 import time
 import asyncio
 from contextlib import contextmanager, asynccontextmanager
-from queue import Queue, Empty
 from typing import Dict, List, Optional, Any
 from .config.settings import (
     DB_POOL_SIZE,
@@ -18,34 +18,6 @@ CONNECTION_TIMEOUT = DB_CONNECTION_TIMEOUT
 MAX_RETRIES = DB_MAX_RETRIES
 
 
-class _ConnectionPool:
-    """Simple thread-based connection pool for pyodbc."""
-
-    def __init__(self, conn_str: str, size: int, timeout: int) -> None:
-        self.conn_str = conn_str
-        self.timeout = timeout
-        self.pool: Queue[pyodbc.Connection] = Queue(maxsize=size)
-
-    def _create(self) -> pyodbc.Connection:
-        return pyodbc.connect(self.conn_str, timeout=self.timeout)
-
-    def acquire(self) -> pyodbc.Connection:
-        try:
-            return self.pool.get_nowait()
-        except Empty:
-            return self._create()
-
-    def release(self, conn: pyodbc.Connection) -> None:
-        try:
-            self.pool.put_nowait(conn)
-        except Exception:
-            conn.close()
-
-    async def acquire_async(self) -> pyodbc.Connection:
-        return await asyncio.to_thread(self.acquire)
-
-    async def release_async(self, conn: pyodbc.Connection) -> None:
-        await asyncio.to_thread(self.release, conn)
 
 class AzureSQLDatabaseService:
     """Service for handling database operations using Azure SQL Database."""
@@ -93,20 +65,25 @@ class AzureSQLDatabaseService:
                     f"Connection Timeout=30;"
                 )
 
-        # Initialize connection pool
-        self.pool = _ConnectionPool(
-            self.connection_string,
-            size=POOL_SIZE,
-            timeout=CONNECTION_TIMEOUT,
-        )
+        # Async connection pool will be created lazily
+        self._async_pool: aioodbc.pool.Pool | None = None
 
     def _get_connection(self) -> pyodbc.Connection:
-        """Get a connection from the pool."""
-        return self.pool.acquire()
+        """Create a synchronous connection (no pooling)."""
+        return pyodbc.connect(self.connection_string, timeout=CONNECTION_TIMEOUT)
 
-    async def _get_connection_async(self) -> pyodbc.Connection:
-        """Asynchronously get a connection from the pool."""
-        return await self.pool.acquire_async()
+    async def _get_async_pool(self) -> aioodbc.pool.Pool:
+        if self._async_pool is None:
+            self._async_pool = await aioodbc.create_pool(
+                dsn=self.connection_string,
+                maxsize=POOL_SIZE,
+                timeout=CONNECTION_TIMEOUT,
+            )
+        return self._async_pool
+
+    async def _get_connection_async(self) -> aioodbc.Connection:
+        pool = await self._get_async_pool()
+        return await pool.acquire()
 
     @contextmanager
     def connection(self):
@@ -119,7 +96,7 @@ class AzureSQLDatabaseService:
             except Exception:
                 if conn:
                     try:
-                        self.pool.release(conn)
+                        conn.close()
                     except Exception:
                         pass
                 if attempt == MAX_RETRIES - 1:
@@ -127,7 +104,7 @@ class AzureSQLDatabaseService:
                 time.sleep(2**attempt)
             else:
                 if conn:
-                    self.pool.release(conn)
+                    conn.close()
                 break
 
     @asynccontextmanager
@@ -141,7 +118,8 @@ class AzureSQLDatabaseService:
             except Exception:
                 if conn:
                     try:
-                        await self.pool.release_async(conn)
+                        pool = await self._get_async_pool()
+                        await pool.release(conn)
                     except Exception:
                         pass
                 if attempt == MAX_RETRIES - 1:
@@ -149,7 +127,8 @@ class AzureSQLDatabaseService:
                 await asyncio.sleep(2**attempt)
             else:
                 if conn:
-                    await self.pool.release_async(conn)
+                    pool = await self._get_async_pool()
+                    await pool.release(conn)
                 break
 
     def get_all_bosses(
@@ -533,21 +512,164 @@ class AzureSQLDatabaseService:
             print(f"Error searching items: {e}")
             return []
 
-    # Async wrappers -----------------------------------------------------
+    # Async implementations -----------------------------------------------------
 
     async def get_all_bosses_async(
         self, limit: int | None = None, offset: int | None = None
     ) -> List[Dict[str, Any]]:
-        return await asyncio.to_thread(self.get_all_bosses, limit=limit, offset=offset)
+        try:
+            async with self.connection_async() as conn:
+                async with conn.cursor() as cursor:
+                    query = (
+                        "SELECT id, name, raid_group, location, has_multiple_forms\n"
+                        "FROM bosses\n"
+                        "ORDER BY name"
+                    )
+                    params: list[Any] = []
+                    if limit is not None:
+                        off = offset or 0
+                        query += " OFFSET ? ROWS FETCH NEXT ? ROWS ONLY"
+                        params.extend([off, limit])
+
+                    await cursor.execute(query, params)
+                    rows = await cursor.fetchall()
+                    bosses = []
+                    for row in rows:
+                        icon_url = None
+                        await cursor.execute(
+                            """
+                        SELECT TOP 1 icons, image_url
+                        FROM boss_forms
+                        WHERE boss_id = ?
+                        """,
+                            (row[0],),
+                        )
+                        form_row = await cursor.fetchone()
+                        if form_row:
+                            if form_row[0]:
+                                try:
+                                    icons = json.loads(form_row[0])
+                                    if icons:
+                                        icon_url = icons[0]
+                                except Exception:
+                                    pass
+                            if not icon_url and form_row[1]:
+                                icon_url = form_row[1]
+                        bosses.append(
+                            {
+                                "id": row[0],
+                                "name": row[1],
+                                "raid_group": row[2],
+                                "location": row[3],
+                                "has_multiple_forms": bool(row[4]),
+                                "icon_url": icon_url,
+                            }
+                        )
+                    return bosses
+        except Exception as e:
+            print(f"Error getting bosses: {e}")
+            return []
 
     async def get_boss_async(self, boss_id: int) -> Optional[Dict[str, Any]]:
-        return await asyncio.to_thread(self.get_boss, boss_id)
+        try:
+            async with self.connection_async() as conn:
+                async with conn.cursor() as cursor:
+                    await cursor.execute(
+                        """
+                    SELECT id, name, raid_group, location, examine, has_multiple_forms
+                    FROM bosses
+                    WHERE id = ?
+                    """,
+                        (boss_id,),
+                    )
+                    boss_row = await cursor.fetchone()
+                    if not boss_row:
+                        return None
+
+                    boss_data = {
+                        "id": boss_row[0],
+                        "name": boss_row[1],
+                        "raid_group": boss_row[2],
+                        "location": boss_row[3],
+                        "examine": boss_row[4],
+                        "has_multiple_forms": bool(boss_row[5]),
+                        "forms": [],
+                    }
+
+                    await cursor.execute(
+                        """
+                    SELECT id, boss_id, form_name, form_order, combat_level, hitpoints,
+                           defence_level, magic_level, ranged_level, defence_stab, defence_slash,
+                           defence_crush, defence_magic, defence_ranged_standard, icons, image_url,
+                           size
+                    FROM boss_forms
+                    WHERE boss_id = ?
+                    ORDER BY form_order
+                    """,
+                        (boss_id,),
+                    )
+                    form_rows = await cursor.fetchall()
+                    for form_row in form_rows:
+                        icons = []
+                        if form_row[14]:
+                            try:
+                                icons = json.loads(form_row[14])
+                            except Exception:
+                                pass
+                        form_data = {
+                            "id": form_row[0],
+                            "boss_id": form_row[1],
+                            "form_name": form_row[2],
+                            "form_order": form_row[3],
+                            "combat_level": form_row[4],
+                            "hitpoints": form_row[5],
+                            "defence_level": form_row[6],
+                            "magic_level": form_row[7],
+                            "ranged_level": form_row[8],
+                            "defence_stab": form_row[9],
+                            "defence_slash": form_row[10],
+                            "defence_crush": form_row[11],
+                            "defence_magic": form_row[12],
+                            "defence_ranged_standard": form_row[13],
+                            "icons": icons,
+                            "image_url": form_row[15],
+                            "size": form_row[16],
+                        }
+                        boss_data["forms"].append(form_data)
+
+                    if boss_data["forms"]:
+                        first_form = boss_data["forms"][0]
+                        if first_form.get("icons"):
+                            boss_data["icon_url"] = first_form["icons"][0]
+                        elif first_form.get("image_url"):
+                            boss_data["icon_url"] = first_form["image_url"]
+
+                    return boss_data
+        except Exception as e:
+            print(f"Error getting boss {boss_id}: {e}")
+            return None
 
     async def get_boss_id_by_form_async(self, form_id: int) -> Optional[int]:
-        return await asyncio.to_thread(self.get_boss_id_by_form, form_id)
+        try:
+            async with self.connection_async() as conn:
+                async with conn.cursor() as cursor:
+                    await cursor.execute(
+                        "SELECT boss_id FROM boss_forms WHERE id = ?",
+                        (form_id,),
+                    )
+                    row = await cursor.fetchone()
+                    if row:
+                        return row[0]
+                    return None
+        except Exception as e:
+            print(f"Error getting boss id from form {form_id}: {e}")
+            return None
 
     async def get_boss_by_form_async(self, form_id: int) -> Optional[Dict[str, Any]]:
-        return await asyncio.to_thread(self.get_boss_by_form, form_id)
+        boss_id = await self.get_boss_id_by_form_async(form_id)
+        if boss_id is None:
+            return None
+        return await self.get_boss_async(boss_id)
 
     async def get_all_items_async(
         self,
@@ -556,26 +678,201 @@ class AzureSQLDatabaseService:
         limit: int | None = None,
         offset: int | None = None,
     ) -> List[Dict[str, Any]]:
-        return await asyncio.to_thread(
-            self.get_all_items,
-            combat_only,
-            tradeable_only,
-            limit,
-            offset,
-        )
+        try:
+            async with self.connection_async() as conn:
+                async with conn.cursor() as cursor:
+                    query = """
+                        SELECT id, name, has_special_attack, has_passive_effect,
+                               has_combat_stats, is_tradeable, slot, icons
+                        FROM items
+                        WHERE 1=1
+                    """
+                    params = []
+
+                    if combat_only:
+                        query += " AND has_combat_stats = 1"
+                    if tradeable_only:
+                        query += " AND is_tradeable = 1"
+
+                    query += " ORDER BY name"
+
+                    if limit is not None:
+                        off = offset or 0
+                        query += " OFFSET ? ROWS FETCH NEXT ? ROWS ONLY"
+                        params.extend([off, limit])
+
+                    await cursor.execute(query, params)
+                    rows = await cursor.fetchall()
+
+                    items = []
+                    for row in rows:
+                        icons = []
+                        if row[7]:
+                            try:
+                                icons = json.loads(row[7])
+                            except Exception:
+                                pass
+                        items.append(
+                            {
+                                "id": row[0],
+                                "name": row[1],
+                                "has_special_attack": bool(row[2]),
+                                "has_passive_effect": bool(row[3]),
+                                "has_combat_stats": bool(row[4]),
+                                "is_tradeable": bool(row[5]),
+                                "slot": row[6],
+                                "icons": icons,
+                            }
+                        )
+
+                    return items
+        except Exception as e:
+            print(f"Error getting items: {e}")
+            return []
 
     async def get_item_async(self, item_id: int) -> Optional[Dict[str, Any]]:
-        return await asyncio.to_thread(self.get_item, item_id)
+        try:
+            async with self.connection_async() as conn:
+                async with conn.cursor() as cursor:
+                    await cursor.execute(
+                        """
+                    SELECT id, name, has_special_attack, special_attack_text,
+                           has_passive_effect, passive_effect_text, has_combat_stats,
+                           is_tradeable, slot, combat_stats, icons
+                    FROM items
+                    WHERE id = ?
+                    """,
+                        (item_id,),
+                    )
+
+                    row = await cursor.fetchone()
+                    if not row:
+                        return None
+
+                    combat_stats = {}
+                    if row[9]:
+                        try:
+                            combat_stats = json.loads(row[9])
+                        except Exception:
+                            pass
+
+                    icons = []
+                    if row[10]:
+                        try:
+                            icons = json.loads(row[10])
+                        except Exception:
+                            pass
+
+                    item_data = {
+                        "id": row[0],
+                        "name": row[1],
+                        "has_special_attack": bool(row[2]),
+                        "special_attack_text": row[3],
+                        "has_passive_effect": bool(row[4]),
+                        "passive_effect_text": row[5],
+                        "has_combat_stats": bool(row[6]),
+                        "is_tradeable": bool(row[7]),
+                        "slot": row[8],
+                        "combat_stats": combat_stats,
+                        "icons": icons,
+                    }
+
+                    return item_data
+        except Exception as e:
+            print(f"Error getting item {item_id}: {e}")
+            return None
 
     async def search_bosses_async(
         self, query: str, limit: int | None = None
     ) -> List[Dict[str, Any]]:
-        return await asyncio.to_thread(self.search_bosses, query, limit)
+        try:
+            async with self.connection_async() as conn:
+                async with conn.cursor() as cursor:
+                    sql = (
+                        "SELECT id, name, raid_group, location\n"
+                        "FROM bosses\n"
+                        "WHERE name LIKE ?\n"
+                        "ORDER BY name"
+                    )
+                    params: list[Any] = [f"%{query}%"]
+                    if limit is not None:
+                        sql = (
+                            "SELECT TOP (?) id, name, raid_group, location\n"
+                            "FROM bosses\n"
+                            "WHERE name LIKE ?\n"
+                            "ORDER BY name"
+                        )
+                        params.insert(0, limit)
+
+                    await cursor.execute(sql, params)
+                    rows = await cursor.fetchall()
+                    bosses = []
+                    for row in rows:
+                        bosses.append(
+                            {
+                                "id": row[0],
+                                "name": row[1],
+                                "raid_group": row[2],
+                                "location": row[3],
+                            }
+                        )
+
+                    return bosses
+        except Exception as e:
+            print(f"Error searching bosses: {e}")
+            return []
 
     async def search_items_async(
         self, query: str, limit: int | None = None
     ) -> List[Dict[str, Any]]:
-        return await asyncio.to_thread(self.search_items, query, limit)
+        try:
+            async with self.connection_async() as conn:
+                async with conn.cursor() as cursor:
+                    sql = (
+                        "SELECT id, name, has_special_attack, has_passive_effect,\n"
+                        "       has_combat_stats, is_tradeable, slot, icons\n"
+                        "FROM items\n"
+                        "WHERE name LIKE ?\n"
+                        "ORDER BY name"
+                    )
+                    params: list[Any] = [f"%{query}%"]
+                    if limit is not None:
+                        sql = (
+                            "SELECT TOP (?) id, name, has_special_attack, has_passive_effect,\n"
+                            "       has_combat_stats, is_tradeable, slot, icons\n"
+                            "FROM items\n"
+                            "WHERE name LIKE ?\n"
+                            "ORDER BY name"
+                        )
+                        params.insert(0, limit)
+
+                    await cursor.execute(sql, params)
+                    rows = await cursor.fetchall()
+                    items = []
+                    for row in rows:
+                        icons = []
+                        if row[7]:
+                            try:
+                                icons = json.loads(row[7])
+                            except Exception:
+                                pass
+                        items.append(
+                            {
+                                "id": row[0],
+                                "name": row[1],
+                                "has_special_attack": bool(row[2]),
+                                "has_passive_effect": bool(row[3]),
+                                "has_combat_stats": bool(row[4]),
+                                "is_tradeable": bool(row[5]),
+                                "slot": row[6],
+                                "icons": icons,
+                            }
+                        )
+
+                    return items
+        except Exception as e:
+            print(f"Error searching items: {e}")
+            return []
 
 # Provide legacy name for unit tests
 DatabaseService = AzureSQLDatabaseService

--- a/backend/app/services/bis_service.py
+++ b/backend/app/services/bis_service.py
@@ -43,3 +43,44 @@ def suggest_bis(params: Dict[str, Any]) -> Dict[str, Any]:
             best_per_slot[slot] = {"item": item, "dps": dps}
 
     return {slot: info["item"] for slot, info in best_per_slot.items()}
+
+
+async def suggest_bis_async(params: Dict[str, Any]) -> Dict[str, Any]:
+    """Async version using the item repository async API."""
+    items = await item_repository.get_all_items_async(combat_only=True, tradeable_only=False)
+    best_per_slot: Dict[str, Dict[str, Any]] = {}
+
+    for item in items:
+        slot = item.get("slot")
+        if not slot:
+            continue
+
+        stats = item.get("combat_stats") or {}
+        attack_bonuses = stats.get("attack_bonuses", {})
+        other_bonuses = stats.get("other_bonuses", {})
+
+        test_params = params.copy()
+
+        style = params.get("combat_style", "melee")
+        if style == "melee":
+            test_params["melee_strength_bonus"] = other_bonuses.get("strength", 0)
+            atk_type = params.get("attack_type", "slash").lower()
+            test_params["melee_attack_bonus"] = attack_bonuses.get(atk_type, 0)
+        elif style == "ranged":
+            test_params["ranged_strength_bonus"] = other_bonuses.get("ranged strength", 0)
+            test_params["ranged_attack_bonus"] = attack_bonuses.get("ranged", 0)
+        else:
+            dmg_bonus = other_bonuses.get("magic damage", "0")
+            if isinstance(dmg_bonus, str) and dmg_bonus.endswith("%"):
+                dmg_bonus = float(dmg_bonus.strip("%")) / 100
+            test_params["magic_damage_bonus"] = float(dmg_bonus or 0)
+            test_params["magic_attack_bonus"] = attack_bonuses.get("magic", 0)
+
+        result = calculation_service.calculate_dps(test_params)
+        dps = result.get("dps", 0)
+
+        current_best = best_per_slot.get(slot)
+        if not current_best or dps > current_best["dps"]:
+            best_per_slot[slot] = {"item": item, "dps": dps}
+
+    return {slot: info["item"] for slot, info in best_per_slot.items()}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,3 +9,4 @@ azure-storage-blob==12.19.0
 python-dotenv==1.0.1
 pyodbc>=5.0.0
 cachetools==5.3.2
+aioodbc==0.5.0


### PR DESCRIPTION
## Summary
- add `aioodbc` requirement
- implement async connection pool for SQL Server
- add startup event to warm boss/item caches
- support async best-in-slot service
- adjust unit tests for async DB and startup cache
- document new async requirement in README

## Testing
- `PYTHONPATH=backend pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847ce1adcb4832ea435ce68d2b79a92