### PR TITLE
Add special attack DPS breakdown

### DIFF
--- a/backend/app/calculators/__init__.py
+++ b/backend/app/calculators/__init__.py
@@ -14,14 +14,67 @@ class DpsCalculator:
         """
         combat_style = params.get("combat_style", "melee").lower()
 
+        calculator = None
         if combat_style == "melee":
-            return MeleeCalculator.calculate_dps(params)
+            calculator = MeleeCalculator
         elif combat_style == "ranged":
-            return RangedCalculator.calculate_dps(params)
+            calculator = RangedCalculator
         elif combat_style == "magic":
-            return MagicCalculator.calculate_dps(params)
+            calculator = MagicCalculator
         else:
             raise ValueError(f"Invalid combat style: {combat_style}")
+
+        # If no special rotation requested, just return normal DPS
+        if params.get("special_attack_cost") is None or params.get("special_rotation") is None:
+            return calculator.calculate_dps(params)
+
+        # Calculate regular and special attack damage per hit
+        regular_params = params.copy()
+        regular_params["special_multiplier"] = 1.0
+        regular_result = calculator.calculate_dps(regular_params)
+        special_result = calculator.calculate_dps(params)
+
+        regular_damage = regular_result["average_hit"]
+        special_damage = special_result["average_hit"]
+        attack_speed = params.get("attack_speed", 2.4)
+
+        # Special energy regeneration
+        regen_rate = 10 / 30  # energy per second
+        regen_mult = 1.0
+        if params.get("lightbearer"):
+            regen_mult *= 2
+        if params.get("surge_potion"):
+            regen_mult *= 1.5
+        regen_rate *= regen_mult
+
+        cost = params.get("special_attack_cost", 0)
+        rotation = params.get("special_rotation", 0.0)
+        duration = params.get("duration", 60.0)
+
+        energy = 100.0
+        time = 0.0
+        special_count = 0
+        attack_count = 0
+        total_damage = 0.0
+
+        while time < duration - 1e-9:
+            if energy >= cost and special_count / (attack_count + 1e-9) < rotation:
+                total_damage += special_damage
+                energy = max(0.0, energy - cost)
+                special_count += 1
+            else:
+                total_damage += regular_damage
+
+            attack_count += 1
+            time += attack_speed
+            energy = min(100.0, energy + regen_rate * attack_speed)
+
+        result = regular_result.copy()
+        final_dps = total_damage / duration
+        result["special_attack_dps"] = final_dps - regular_result["dps"]
+        result["special_attacks"] = special_count
+        result["duration"] = duration
+        return result
 
     @staticmethod
     def calculate_item_effect(params: Dict[str, Any]) -> Dict[str, Any]:

--- a/backend/app/data/special_attacks.json
+++ b/backend/app/data/special_attacks.json
@@ -1,0 +1,37 @@
+{
+  "dragon_dagger": {
+    "special_name": "Puncture",
+    "cost": 25,
+    "effect": "Performs two quick slashes.",
+    "attack_roll_modifier": 0.15,
+    "damage_roll_modifier": 0.15
+  },
+  "dragon_claws": {
+    "special_name": "Slice and Dice",
+    "cost": 50,
+    "effect": "Hits four times in rapid succession.",
+    "attack_roll_modifier": 0.0,
+    "damage_roll_modifier": 0.0
+  },
+  "saradomin_godsword": {
+    "special_name": "Healing Blade",
+    "cost": 50,
+    "effect": "Restores Hitpoints and Prayer based on damage dealt.",
+    "attack_roll_modifier": 1.0,
+    "damage_roll_modifier": 0.10
+  },
+  "armadyl_godsword": {
+    "special_name": "The Judgement",
+    "cost": 50,
+    "effect": "Inflicts extra damage and increases accuracy.",
+    "attack_roll_modifier": 1.0,
+    "damage_roll_modifier": 0.375
+  },
+  "zamorak_godsword": {
+    "special_name": "Ice Cleave",
+    "cost": 50,
+    "effect": "Freezes the target if the attack hits.",
+    "attack_roll_modifier": 1.0,
+    "damage_roll_modifier": 0.10
+  }
+}

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -14,6 +14,9 @@ class DpsResult(BaseModel):
     effective_str: Optional[int] = None
     effective_atk: Optional[int] = None
     damage_multiplier: Optional[float] = None
+    special_attacks: Optional[int] = None
+    duration: Optional[float] = None
+    special_attack_dps: Optional[float] = None
 
 
 class BossForm(BaseModel):
@@ -143,6 +146,11 @@ class DpsParameters(BaseModel):
     gear_multiplier: float = 1.0
     special_multiplier: float = 1.0
     attack_style_bonus: Optional[int] = Field(default=0)
+    special_attack_cost: Optional[int] = None
+    special_rotation: Optional[float] = None
+    lightbearer: Optional[bool] = None
+    surge_potion: Optional[bool] = None
+    duration: Optional[float] = None
 
     # Melee parameters
     strength_level: Optional[int] = None

--- a/backend/app/repositories/__init__.py
+++ b/backend/app/repositories/__init__.py
@@ -1,0 +1,3 @@
+from .item_repository import *
+from .boss_repository import *
+from .special_attack_repository import *

--- a/backend/app/repositories/special_attack_repository.py
+++ b/backend/app/repositories/special_attack_repository.py
@@ -1,0 +1,17 @@
+from functools import lru_cache
+import json
+from pathlib import Path
+from typing import Dict, Optional, Any
+
+DATA_PATH = Path(__file__).resolve().parent.parent / "data" / "special_attacks.json"
+
+@lru_cache(maxsize=1)
+def _load_data() -> Dict[str, Any]:
+    with open(DATA_PATH, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+def get_special_attack(weapon_name: str) -> Optional[Dict[str, Any]]:
+    """Return special attack data for a given weapon name."""
+    data = _load_data()
+    key = weapon_name.lower().replace(" ", "_")
+    return data.get(key)

--- a/backend/app/testing/UnitTest.py
+++ b/backend/app/testing/UnitTest.py
@@ -58,6 +58,35 @@ class TestDpsCalculator(unittest.TestCase):
         with self.assertRaises(KeyError):
             MeleeCalculator.calculate_dps({"combat_style": "melee"})
 
+    def test_special_rotation_simulation(self):
+        """Special attack rotation should simulate energy and count specials."""
+        params = {
+            "combat_style": "melee",
+            "strength_level": 99,
+            "strength_boost": 0,
+            "strength_prayer": 1.0,
+            "attack_level": 99,
+            "attack_boost": 0,
+            "attack_prayer": 1.0,
+            "melee_strength_bonus": 80,
+            "melee_attack_bonus": 80,
+            "attack_style_bonus_strength": 3,
+            "attack_style_bonus_attack": 0,
+            "attack_speed": 2.4,
+            "target_defence_level": 100,
+            "target_defence_bonus": 50,
+            "special_multiplier": 1.2,
+            "special_attack_cost": 50,
+            "special_rotation": 0.5,
+            "duration": 60,
+        }
+
+        result = DpsCalculator.calculate_dps(params)
+        self.assertIn("special_attacks", result)
+        self.assertEqual(result["special_attacks"], 2)
+        self.assertIn("special_attack_dps", result)
+        self.assertGreater(result["special_attack_dps"], 0)
+
 
 class TestMeleeCalculator(unittest.TestCase):
     """Test the Melee Calculator functionality."""

--- a/backend/app/testing/test_repositories.py
+++ b/backend/app/testing/test_repositories.py
@@ -136,3 +136,12 @@ class TestAsyncRepositoryCaching(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
+
+class TestSpecialAttackRepository(unittest.TestCase):
+    def test_get_special_attack(self):
+        from app.repositories import special_attack_repository
+        data = special_attack_repository.get_special_attack("Dragon dagger")
+        self.assertIsNotNone(data)
+        self.assertEqual(data["cost"], 25)
+
+

--- a/frontend/src/components/features/calculator/DpsResultDisplay.tsx
+++ b/frontend/src/components/features/calculator/DpsResultDisplay.tsx
@@ -16,11 +16,19 @@ export function DpsResultDisplay({ params, results, appliedPassiveEffects }: Dps
         <Calculator className="h-5 w-5 mr-2 text-primary" />
         Calculation Results
       </h2>
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+      <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
         <Card className="bg-muted/30 border">
           <CardContent className="pt-6">
-            <div className="text-sm font-medium text-muted-foreground">DPS</div>
-            <div className="text-3xl font-bold text-primary">{results.dps.toFixed(2)}</div>
+            <div className="text-sm font-medium text-muted-foreground">Total DPS</div>
+            <div className="text-3xl font-bold text-primary">
+              {(results.dps + (results.special_attack_dps ?? 0)).toFixed(2)}
+            </div>
+            {results.special_attack_dps !== undefined && (
+              <div className="text-xs text-muted-foreground">
+                Base {results.dps.toFixed(2)} + Special{' '}
+                {results.special_attack_dps.toFixed(2)}
+              </div>
+            )}
           </CardContent>
         </Card>
         <Card className="bg-muted/30 border">
@@ -35,6 +43,14 @@ export function DpsResultDisplay({ params, results, appliedPassiveEffects }: Dps
             <div className="text-3xl font-bold text-primary">{(results.hit_chance * 100).toFixed(1)}%</div>
           </CardContent>
         </Card>
+        {results.special_attack_dps !== undefined && (
+          <Card className="bg-muted/30 border">
+            <CardContent className="pt-6">
+              <div className="text-sm font-medium text-muted-foreground">Special Attacks</div>
+              <div className="text-3xl font-bold text-primary">{results.special_attacks ?? 0}</div>
+            </CardContent>
+          </Card>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/components/features/calculator/ImprovedDpsCalculator.tsx
+++ b/frontend/src/components/features/calculator/ImprovedDpsCalculator.tsx
@@ -14,6 +14,7 @@ import { PresetSelector } from './PresetSelector';
 import { CalculatorForms } from './CalculatorForms';
 import { CombatStyleTabs } from './CombatStyleTabs';
 import { DpsResultDisplay } from './DpsResultDisplay';
+import { SpecialAttackOptions } from './SpecialAttackOptions';
 import { useDpsCalculator } from '@/hooks/useDpsCalculator';
 import { useToast } from '@/hooks/use-toast';
 import RaidScalingPanel, { RaidScalingConfig } from '../simulation/RaidScalingPanel';
@@ -110,6 +111,7 @@ export function ImprovedDpsCalculator() {
           <CombinedEquipmentDisplay onEquipmentUpdate={handleEquipmentUpdate} bossForm={currentBossForm} />
           {/* Prayer/Potion selector */}
           <PrayerPotionSelector className="flex-grow" />
+          <SpecialAttackOptions />
         </div>
 
         {/* Right column */}

--- a/frontend/src/components/features/calculator/SpecialAttackOptions.tsx
+++ b/frontend/src/components/features/calculator/SpecialAttackOptions.tsx
@@ -1,0 +1,75 @@
+'use client';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import { useCalculatorStore } from '@/store/calculator-store';
+import { Swords } from 'lucide-react';
+
+export function SpecialAttackOptions() {
+  const { params, setParams } = useCalculatorStore();
+
+  return (
+    <Card className="w-full border">
+      <CardHeader>
+        <CardTitle className="flex items-center">
+          <Swords className="h-5 w-5 mr-2 text-primary" />
+          Special Attacks
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div className="space-y-1">
+          <Label>Special Cost</Label>
+          <Input
+            type="number"
+            min={0}
+            max={100}
+            value={params.special_attack_cost ?? 0}
+            onChange={(e) =>
+              setParams({ special_attack_cost: parseInt(e.target.value) || 0 })
+            }
+          />
+        </div>
+        <div className="space-y-1">
+          <Label>Rotation (%)</Label>
+          <Input
+            type="number"
+            min={0}
+            max={100}
+            value={Math.round((params.special_rotation ?? 0) * 100)}
+            onChange={(e) =>
+              setParams({ special_rotation: (parseFloat(e.target.value) || 0) / 100 })
+            }
+          />
+        </div>
+        <div className="flex items-center gap-2">
+          <Switch
+            checked={!!params.lightbearer}
+            onCheckedChange={(v) => setParams({ lightbearer: v })}
+          />
+          <Label>Lightbearer</Label>
+        </div>
+        <div className="flex items-center gap-2">
+          <Switch
+            checked={!!params.surge_potion}
+            onCheckedChange={(v) => setParams({ surge_potion: v })}
+          />
+          <Label>Surge Potion</Label>
+        </div>
+        <div className="space-y-1">
+          <Label>Duration (s)</Label>
+          <Input
+            type="number"
+            min={1}
+            value={params.duration ?? 60}
+            onChange={(e) =>
+              setParams({ duration: parseFloat(e.target.value) || 60 })
+            }
+          />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default SpecialAttackOptions;

--- a/frontend/src/store/calculator-store.ts
+++ b/frontend/src/store/calculator-store.ts
@@ -59,6 +59,11 @@ const defaultMeleeParams: MeleeCalculatorParams = {
   void_melee: false,
   gear_multiplier: 1.0,
   special_multiplier: 1.0,
+  special_attack_cost: 0,
+  special_rotation: 0,
+  lightbearer: false,
+  surge_potion: false,
+  duration: 60,
   target_defence_level: 200,
   target_defence_bonus: 30,
   attack_speed: 2.4
@@ -76,6 +81,11 @@ const defaultRangedParams: RangedCalculatorParams = {
   void_ranged: false,
   gear_multiplier: 1.0,
   special_multiplier: 1.0,
+  special_attack_cost: 0,
+  special_rotation: 0,
+  lightbearer: false,
+  surge_potion: false,
+  duration: 60,
   target_defence_level: 200,
   target_defence_bonus: 150,
   attack_speed: 2.4
@@ -108,7 +118,12 @@ const defaultMagicParams: MagicCalculatorParams = {
   spell_type: 'offensive',
   god_spell_charged: false,
   gear_multiplier: 1.0,
-  special_multiplier: 1.0
+  special_multiplier: 1.0,
+  special_attack_cost: 0,
+  special_rotation: 0,
+  lightbearer: false,
+  surge_potion: false,
+  duration: 60
 };
 
 export const useCalculatorStore = create<CalculatorState>()(

--- a/frontend/src/types/calculator.ts
+++ b/frontend/src/types/calculator.ts
@@ -43,6 +43,11 @@ export interface BaseCalculatorParams {
   attack_style_bonus?: number; // Add this field which is in the backend model
   equipment?: EquipmentLoadout;
   weapon_name?: string;
+  special_attack_cost?: number;
+  special_rotation?: number;
+  lightbearer?: boolean;
+  surge_potion?: boolean;
+  duration?: number;
 }
 
 // Shared fields across styles
@@ -148,6 +153,9 @@ export interface DpsResult {
   effective_str?: number;
   effective_atk?: number;
   damage_multiplier?: number;
+  special_attacks?: number;
+  duration?: number;
+  special_attack_dps?: number;
 }
 
 // Expanded DPS result with additional information


### PR DESCRIPTION
## Summary
- expand `BaseCalculatorParams` and `DpsResult` with special attack fields
- include special attack defaults in calculator store
- show special attack options in `ImprovedDpsCalculator`
- add `SpecialAttackOptions` component for setting cost, rotation and energy mods
- display total DPS with special attack breakdown
- store special attack data in backend and expose repository

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847cff14d34832e8cd7d2c5663198f4