### PR TITLE
Improve special attack parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,17 @@ Additional documentation can be found in the `docs/` folder:
     docs/ARCHITECTURE.md - High level component diagram
     docs/WIREFRAME.md    - Basic UI wireframe
 
+Updating Special Attack Data
+----------------------------
+
+The `scripts/reparse_special_attacks.py` helper can re-run the
+special attack parser against the stored dataset and optionally
+write any updates back to the JSON file.
+
+```bash
+python scripts/reparse_special_attacks.py --write
+```
+
 Technical Documentation
 Frontend Architecture
 

--- a/scripts/reparse_special_attacks.py
+++ b/scripts/reparse_special_attacks.py
@@ -1,0 +1,36 @@
+import json
+import argparse
+import sys
+from pathlib import Path
+
+# Allow importing the parser
+sys.path.append(str(Path(__file__).resolve().parent.parent / 'webscraper' / 'runescape-items' / 'special_attacks'))
+from osrs_parser import OSRSSpecialAttackParser
+
+DEFAULT_PATH = Path(__file__).resolve().parent.parent / 'webscraper' / 'runescape-items' / 'osrs_special_attacks_v3.json'
+
+
+def main(json_path=DEFAULT_PATH, write=False):
+    parser = OSRSSpecialAttackParser()
+    with open(json_path, encoding='utf-8') as f:
+        data = json.load(f)
+
+    updated = 0
+    for entry in data:
+        parsed = parser.parse(entry.get('effect', ''), entry.get('weapon_name', ''))
+        parsed_dict = parsed.to_dict()
+        for key, value in parsed_dict.items():
+            if entry.get(key) != value:
+                entry[key] = value
+                updated += 1
+    if write:
+        with open(json_path, 'w', encoding='utf-8') as f:
+            json.dump(data, f, indent=2)
+    print(f'Updated fields: {updated}')
+
+if __name__ == '__main__':
+    ap = argparse.ArgumentParser(description='Reparse special attack data and optionally update the JSON file.')
+    ap.add_argument('--json', type=Path, default=DEFAULT_PATH, help='Path to osrs_special_attacks_v3.json')
+    ap.add_argument('--write', action='store_true', help='Write updates back to file')
+    args = ap.parse_args()
+    main(args.json, args.write)

--- a/webscraper/runescape-items/special_attacks/osrs_parser.py
+++ b/webscraper/runescape-items/special_attacks/osrs_parser.py
@@ -77,6 +77,8 @@ class SpecialAttackCostExtractor:
         low_priority_patterns = [
             r'costs (\d+)%.*?energy',
             r'(\d+)%.*?special attack energy',
+            # Cases like "Backstab (75%)" where the cost appears in parentheses
+            r'\(\s*(\d{1,3})%\s*\)'
         ]
         
         for pattern in low_priority_patterns:
@@ -188,7 +190,9 @@ class DamageModifierExtractor:
             r'(\d+)%.*?damage.*?increase',
             # For the saradomin/zamorak godsword tests
             r'(\d+)% increased max hit',
-            r'increases max hit by (\d+)%'
+            r'increases\s+max hit by (\d+)%',
+            # Allow phrases like "increases the player's max hit by 25%"
+            r'increases[^\n]*?max hit by (\d+)%'
         ]
         
         for pattern in increase_patterns:
@@ -343,7 +347,11 @@ class StatDrainExtractor:
         
         # Check for percentage drains - FIXED for the failing test
         # The failing test: "lowers the opponent's Strength, Attack, and Defence levels by 5%"
-        percentage_pattern = r'(?:lowers|drains|reduces).*?opponent\'?s?\s+([^.]*?)(?:levels?\s+)?by\s+(\d+)%'
+        percentage_pattern = (
+            r'(?:lowers|drains|reduces).*?'
+            r'(?:opponent|target|enemy)\'?s?\s+([^.]*?)'
+            r'(?:levels?\s+)?by\s+(\d+)%'
+        )
         match = re.search(percentage_pattern, text_lower)
         if match:
             stats_text = match.group(1)


### PR DESCRIPTION
## Summary
- allow more flexible wording for max hit damage increases
- support target-oriented stat drain phrases
- recognize costs written as `(75%)`
- add helper script to reparse data
- document update process in README

## Testing
- `python -m pytest test_osrs_parser.py -q`
- `python scripts/reparse_special_attacks.py`

------
https://chatgpt.com/codex/tasks/task_e_6847fbd32444832e943f37a320ec50ea