### PR TITLE
Fix DB pool size env var handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ Database connections are pooled. Tune pool behaviour with the following
 environment variables:
 
 - `DB_POOL_SIZE` – Maximum number of open connections (default `5`).
+  Values below `1` are automatically clamped to `1`.
 - `DB_CONNECTION_TIMEOUT` – Connection timeout in seconds (default `30`).
 - `DB_MAX_RETRIES` – Number of connection retries for transient failures
   (default `3`).

--- a/backend/app/config/settings.py
+++ b/backend/app/config/settings.py
@@ -4,6 +4,11 @@ import os
 CACHE_TTL_SECONDS = int(os.getenv("CACHE_TTL_SECONDS", "3600"))
 
 # Database connection pool settings
-DB_POOL_SIZE = int(os.getenv("DB_POOL_SIZE", "5"))
+# Ensure the pool size is always at least 1 to avoid aioodbc errors
+try:
+    DB_POOL_SIZE = max(1, int(os.getenv("DB_POOL_SIZE", "5")))
+except ValueError:
+    # Fallback to default if the environment variable is not an integer
+    DB_POOL_SIZE = 5
 DB_CONNECTION_TIMEOUT = int(os.getenv("DB_CONNECTION_TIMEOUT", "30"))
 DB_MAX_RETRIES = int(os.getenv("DB_MAX_RETRIES", "3"))

--- a/backend/app/testing/test_services.py
+++ b/backend/app/testing/test_services.py
@@ -84,6 +84,18 @@ class TestSettings(unittest.TestCase):
         settings = importlib.reload(importlib.import_module('app.config.settings'))
         self.assertEqual(settings.CACHE_TTL_SECONDS, 123)
 
+    def test_db_pool_size_minimum(self):
+        """DB_POOL_SIZE should never be less than 1."""
+        import importlib, os
+        orig = os.environ.get('DB_POOL_SIZE')
+        os.environ['DB_POOL_SIZE'] = '0'
+        settings = importlib.reload(importlib.import_module('app.config.settings'))
+        self.assertEqual(settings.DB_POOL_SIZE, 1)
+        if orig is None:
+            del os.environ['DB_POOL_SIZE']
+        else:
+            os.environ['DB_POOL_SIZE'] = orig
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- guard against invalid `DB_POOL_SIZE`
- document minimum DB pool size
- test that pool size never goes below 1

## Testing
- `python -m unittest discover backend/app/testing -v`

------
https://chatgpt.com/codex/tasks/task_e_6848090c25ac832e9e8607002fee64a9