### PR TITLE
Fix database context for item selection

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -369,16 +369,19 @@ class AzureSQLDatabaseService:
         try:
             with self.connection() as conn:
                 cursor = conn.cursor()
-            
-            cursor.execute("""
+
+                cursor.execute(
+                    """
                 SELECT id, name, has_special_attack, special_attack_text,
                        has_passive_effect, passive_effect_text, has_combat_stats,
                        is_tradeable, slot, combat_stats, icons
                 FROM items
                 WHERE id = ?
-            """, (item_id,))
-            
-            row = cursor.fetchone()
+                """,
+                    (item_id,),
+                )
+
+                row = cursor.fetchone()
             if not row:
                 return None
             


### PR DESCRIPTION
## Summary
- ensure `get_item` keeps the DB connection open while executing its query
- run tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684819dc64b0832eab1fcdb02708e5c8