### PR TITLE
Fix reference store duplicates

### DIFF
--- a/frontend/src/__tests__/reference-data-store.test.ts
+++ b/frontend/src/__tests__/reference-data-store.test.ts
@@ -60,4 +60,20 @@ describe('reference data store', () => {
     expect(mockedBossApi.getBossForms).toHaveBeenCalledTimes(0);
     expect(mockedItemsApi.getAllItems).toHaveBeenCalledTimes(1);
   });
+
+  it('deduplicates bosses and items', () => {
+    act(() => {
+      const store = getStore();
+      store.addBosses([{ id: 1, name: 'A' } as any]);
+      store.addBosses([{ id: 1, name: 'B' } as any, { id: 2, name: 'C' } as any]);
+      store.addItems([{ id: 10, name: 'X' } as any]);
+      store.addItems([{ id: 10, name: 'Y' } as any, { id: 11, name: 'Z' } as any]);
+    });
+
+    const state = getStore();
+    expect(state.bosses).toHaveLength(2);
+    expect(state.items).toHaveLength(2);
+    expect(state.bosses.find((b) => b.id === 1)?.name).toBe('B');
+    expect(state.items.find((i) => i.id === 10)?.name).toBe('Y');
+  });
 });

--- a/frontend/src/store/reference-data-store.ts
+++ b/frontend/src/store/reference-data-store.ts
@@ -72,13 +72,21 @@ export const useReferenceDataStore = create<ReferenceDataState>()(
         }
       },
       addBosses(b) {
-        set((state) => ({ bosses: [...state.bosses, ...b] }));
+        set((state) => {
+          const map = new Map(state.bosses.map((boss) => [boss.id, boss]));
+          b.forEach((boss) => map.set(boss.id, boss));
+          return { bosses: Array.from(map.values()) };
+        });
       },
       addBossForms(id, forms) {
         set((state) => ({ bossForms: { ...state.bossForms, [id]: forms } }));
       },
       addItems(i) {
-        set((state) => ({ items: [...state.items, ...i] }));
+        set((state) => {
+          const map = new Map(state.items.map((item) => [item.id, item]));
+          i.forEach((item) => map.set(item.id, item));
+          return { items: Array.from(map.values()) };
+        });
       },
     }),
     {
@@ -102,3 +110,4 @@ export const useReferenceDataStore = create<ReferenceDataState>()(
     }
   )
 );
+


### PR DESCRIPTION
## Summary
- deduplicate bosses and items when updating reference data store
- cover deduplication with tests

## Testing
- `npm test --prefix frontend`
- `python -m unittest discover backend/app/testing -v`


------
https://chatgpt.com/codex/tasks/task_e_68481d7a60b8832eba8d0a095a33a3d2