### PR TITLE
Remove aioodbc and use simple pyodbc pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ source venv/bin/activate  # On Windows: venv\Scripts\activate
 # Install dependencies
 pip install -r requirements.txt
 
-The backend relies on `aioodbc` for asynchronous SQL Server access. Ensure the
-system has the Microsoft ODBC driver installed.
+The backend relies on `pyodbc` for SQL Server access. Ensure the
+Microsoft ODBC driver is installed on your system.
 
 # Run development server
 uvicorn app.main:app --reload
@@ -198,9 +198,9 @@ environment variables:
 - `DB_MAX_RETRIES` – Number of connection retries for transient failures
   (default `3`).
 
-The async database layer uses `aioodbc`, so the appropriate ODBC driver must be
-installed on the host system. Ensure these environment variables are set before
-starting the API so the connection pool can connect successfully.
+The backend uses a small thread-based connection pool built on
+`pyodbc`. Ensure the Microsoft ODBC driver is installed and the above
+environment variables are configured before starting the API.
 
 🔄 API Reference
 Calculate DPS

--- a/backend/app/config/settings.py
+++ b/backend/app/config/settings.py
@@ -4,7 +4,7 @@ import os
 CACHE_TTL_SECONDS = int(os.getenv("CACHE_TTL_SECONDS", "3600"))
 
 # Database connection pool settings
-# Ensure the pool size is always at least 1 to avoid aioodbc errors
+# Ensure the pool size is always at least 1 to avoid pool errors
 try:
     DB_POOL_SIZE = max(1, int(os.getenv("DB_POOL_SIZE", "5")))
 except ValueError:

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,9 +1,10 @@
-import aioodbc
+import pyodbc
 import os
 import json
 import time
 import asyncio
 from contextlib import contextmanager, asynccontextmanager
+from queue import Queue, Empty
 from typing import Dict, List, Optional, Any
 from .config.settings import (
     DB_POOL_SIZE,
@@ -17,6 +18,35 @@ CONNECTION_TIMEOUT = DB_CONNECTION_TIMEOUT
 MAX_RETRIES = DB_MAX_RETRIES
 
 
+class _ConnectionPool:
+    """Simple thread-based connection pool for pyodbc."""
+
+    def __init__(self, conn_str: str, size: int, timeout: int) -> None:
+        self.conn_str = conn_str
+        self.timeout = timeout
+        self.pool: Queue[pyodbc.Connection] = Queue(maxsize=size)
+
+    def _create(self) -> pyodbc.Connection:
+        return pyodbc.connect(self.conn_str, timeout=self.timeout)
+
+    def acquire(self) -> pyodbc.Connection:
+        try:
+            return self.pool.get_nowait()
+        except Empty:
+            return self._create()
+
+    def release(self, conn: pyodbc.Connection) -> None:
+        try:
+            self.pool.put_nowait(conn)
+        except Exception:
+            conn.close()
+
+    async def acquire_async(self) -> pyodbc.Connection:
+        return await asyncio.to_thread(self.acquire)
+
+    async def release_async(self, conn: pyodbc.Connection) -> None:
+        await asyncio.to_thread(self.release, conn)
+
 class AzureSQLDatabaseService:
     """Service for handling database operations using Azure SQL Database."""
 
@@ -24,21 +54,21 @@ class AzureSQLDatabaseService:
         """Initialize the Azure SQL Database service."""
         # Try to get connection string first (Azure Connection Strings format)
         connection_string = os.environ.get("SQLAZURECONNSTR_DefaultConnection")
-
+        
         if connection_string:
             # Use the connection string directly
             self.connection_string = connection_string
         else:
             # Fallback to individual environment variables
             self.server = os.environ.get("AZURE_SQL_SERVER")
-            self.database = os.environ.get("AZURE_SQL_DATABASE")
+            self.database = os.environ.get("AZURE_SQL_DATABASE") 
             self.username = os.environ.get("AZURE_SQL_USERNAME")
             self.password = os.environ.get("AZURE_SQL_PASSWORD")
-
+            
             # For production, we'll use Entra ID authentication
             if not all([self.server, self.database]):
                 print("Warning: Azure SQL Database configuration incomplete")
-
+            
             # Use Entra ID authentication (for production)
             if not self.username or not self.password:
                 self.connection_string = (
@@ -63,205 +93,447 @@ class AzureSQLDatabaseService:
                     f"Connection Timeout=30;"
                 )
 
-        # Async connection pool will be created lazily
-        self._async_pool: aioodbc.pool.Pool | None = None
+        # Initialize connection pool
+        self.pool = _ConnectionPool(
+            self.connection_string,
+            size=POOL_SIZE,
+            timeout=CONNECTION_TIMEOUT,
+        )
 
-    async def _get_async_pool(self) -> aioodbc.pool.Pool:
-        if self._async_pool is None:
-            self._async_pool = await aioodbc.create_pool(
-                dsn=self.connection_string,
-                maxsize=POOL_SIZE,
-                timeout=CONNECTION_TIMEOUT,
-            )
-        return self._async_pool
+    def _get_connection(self) -> pyodbc.Connection:
+        """Get a connection from the pool."""
+        return self.pool.acquire()
 
-    async def _get_connection_async(self) -> aioodbc.Connection:
-        pool = await self._get_async_pool()
-        return await pool.acquire()
+    async def _get_connection_async(self) -> pyodbc.Connection:
+        """Asynchronously get a connection from the pool."""
+        return await self.pool.acquire_async()
+
+    @contextmanager
+    def connection(self):
+        """Context manager with retry logic for DB connections."""
+        for attempt in range(MAX_RETRIES):
+            try:
+                conn = self._get_connection()
+                try:
+                    yield conn
+                finally:
+                    self.pool.release(conn)
+                break
+            except Exception as e:
+                if attempt == MAX_RETRIES - 1:
+                    raise
+                time.sleep(2**attempt)
 
     @asynccontextmanager
     async def connection_async(self):
         """Async context manager with retry logic for DB connections."""
         for attempt in range(MAX_RETRIES):
-            conn = None
             try:
                 conn = await self._get_connection_async()
-                yield conn
+                try:
+                    yield conn
+                finally:
+                    await self.pool.release_async(conn)
+                break
             except Exception:
-                if conn:
-                    try:
-                        pool = await self._get_async_pool()
-                        await pool.release(conn)
-                    except Exception:
-                        pass
                 if attempt == MAX_RETRIES - 1:
                     raise
                 await asyncio.sleep(2**attempt)
-            else:
-                if conn:
-                    pool = await self._get_async_pool()
-                    await pool.release(conn)
-                break
 
-    # Async implementations -----------------------------------------------------
-
-    async def get_all_bosses_async(
-        self, limit: int | None = None, offset: int | None = None
+    def get_all_bosses(
+        self,
+        limit: int | None = None,
+        offset: int | None = None,
     ) -> List[Dict[str, Any]]:
+        """Get all bosses from the database with optional pagination."""
         try:
-            async with self.connection_async() as conn:
-                async with conn.cursor() as cursor:
-                    query = (
-                        "SELECT id, name, raid_group, location, has_multiple_forms\n"
-                        "FROM bosses\n"
-                        "ORDER BY name"
-                    )
-                    params: list[Any] = []
-                    if limit is not None:
-                        off = offset or 0
-                        query += " OFFSET ? ROWS FETCH NEXT ? ROWS ONLY"
-                        params.extend([off, limit])
+            with self.connection() as conn:
+                cursor = conn.cursor()
 
-                    await cursor.execute(query, params)
-                    rows = await cursor.fetchall()
-                    bosses = []
-                    for row in rows:
-                        icon_url = None
-                        await cursor.execute(
-                            """
-                        SELECT TOP 1 icons, image_url
-                        FROM boss_forms
-                        WHERE boss_id = ?
-                        """,
-                            (row[0],),
-                        )
-                        form_row = await cursor.fetchone()
-                        if form_row:
-                            if form_row[0]:
-                                try:
-                                    icons = json.loads(form_row[0])
-                                    if icons:
-                                        icon_url = icons[0]
-                                except Exception:
-                                    pass
-                            if not icon_url and form_row[1]:
-                                icon_url = form_row[1]
-                        bosses.append(
-                            {
-                                "id": row[0],
-                                "name": row[1],
-                                "raid_group": row[2],
-                                "location": row[3],
-                                "has_multiple_forms": bool(row[4]),
-                                "icon_url": icon_url,
-                            }
-                        )
-                    return bosses
+                query = (
+                    "SELECT id, name, raid_group, location, has_multiple_forms\n"
+                    "FROM bosses\n"
+                    "ORDER BY name"
+                )
+                params: list[Any] = []
+                if limit is not None:
+                    off = offset or 0
+                    query += " OFFSET ? ROWS FETCH NEXT ? ROWS ONLY"
+                    params.extend([off, limit])
+
+                cursor.execute(query, params)
+
+                bosses = []
+                for row in cursor.fetchall():
+                    icon_url = None
+                    # Try to get icon from first boss form
+                    cursor.execute(
+                        """
+                    SELECT TOP 1 icons, image_url
+                    FROM boss_forms
+                    WHERE boss_id = ?
+                    """,
+                        (row[0],),
+                    )
+
+                    form_row = cursor.fetchone()
+                    if form_row:
+                        if form_row[0]:  # icons JSON
+                            try:
+                                icons = json.loads(form_row[0])
+                                if icons and len(icons) > 0:
+                                    icon_url = icons[0]
+                            except:
+                                pass
+                        if not icon_url and form_row[1]:  # image_url
+                            icon_url = form_row[1]
+
+                    bosses.append(
+                        {
+                            "id": row[0],
+                            "name": row[1],
+                            "raid_group": row[2],
+                            "location": row[3],
+                            "has_multiple_forms": bool(row[4]),
+                            "icon_url": icon_url,
+                        }
+                    )
+
+                return bosses
+            
         except Exception as e:
             print(f"Error getting bosses: {e}")
             return []
 
-    async def get_boss_async(self, boss_id: int) -> Optional[Dict[str, Any]]:
+    def get_boss(self, boss_id: int) -> Optional[Dict[str, Any]]:
+        """Get a specific boss with all its forms."""
         try:
-            async with self.connection_async() as conn:
-                async with conn.cursor() as cursor:
-                    await cursor.execute(
-                        """
-                    SELECT id, name, raid_group, location, examine, has_multiple_forms
-                    FROM bosses
-                    WHERE id = ?
-                    """,
-                        (boss_id,),
-                    )
-                    boss_row = await cursor.fetchone()
-                    if not boss_row:
-                        return None
+            with self.connection() as conn:
+                cursor = conn.cursor()
 
-                    boss_data = {
-                        "id": boss_row[0],
-                        "name": boss_row[1],
-                        "raid_group": boss_row[2],
-                        "location": boss_row[3],
-                        "examine": boss_row[4],
-                        "has_multiple_forms": bool(boss_row[5]),
-                        "forms": [],
+                cursor.execute(
+                    """
+                SELECT id, name, raid_group, location, examine, has_multiple_forms
+                FROM bosses
+                WHERE id = ?
+                """,
+                    (boss_id,),
+                )
+
+                boss_row = cursor.fetchone()
+                if not boss_row:
+                    return None
+
+                boss_data = {
+                    "id": boss_row[0],
+                    "name": boss_row[1],
+                    "raid_group": boss_row[2],
+                    "location": boss_row[3],
+                    "examine": boss_row[4],
+                    "has_multiple_forms": bool(boss_row[5]),
+                    "forms": [],
+                }
+
+                cursor.execute(
+                    """
+                SELECT id, boss_id, form_name, form_order, combat_level, hitpoints,
+                       defence_level, magic_level, ranged_level, defence_stab, defence_slash,
+                       defence_crush, defence_magic, defence_ranged_standard, icons, image_url,
+                       size
+                FROM boss_forms
+                WHERE boss_id = ?
+                ORDER BY form_order
+                """,
+                    (boss_id,),
+                )
+
+                for form_row in cursor.fetchall():
+                    icons = []
+                    if form_row[14]:
+                        try:
+                            icons = json.loads(form_row[14])
+                        except Exception:
+                            pass
+
+                    form_data = {
+                        "id": form_row[0],
+                        "boss_id": form_row[1],
+                        "form_name": form_row[2],
+                        "form_order": form_row[3],
+                        "combat_level": form_row[4],
+                        "hitpoints": form_row[5],
+                        "defence_level": form_row[6],
+                        "magic_level": form_row[7],
+                        "ranged_level": form_row[8],
+                        "defence_stab": form_row[9],
+                        "defence_slash": form_row[10],
+                        "defence_crush": form_row[11],
+                        "defence_magic": form_row[12],
+                        "defence_ranged_standard": form_row[13],
+                        "icons": icons,
+                        "image_url": form_row[15],
+                        "size": form_row[16],
                     }
+                    boss_data["forms"].append(form_data)
 
-                    await cursor.execute(
-                        """
-                    SELECT id, boss_id, form_name, form_order, combat_level, hitpoints,
-                           defence_level, magic_level, ranged_level, defence_stab, defence_slash,
-                           defence_crush, defence_magic, defence_ranged_standard, icons, image_url,
-                           size
-                    FROM boss_forms
-                    WHERE boss_id = ?
-                    ORDER BY form_order
-                    """,
-                        (boss_id,),
-                    )
-                    form_rows = await cursor.fetchall()
-                    for form_row in form_rows:
-                        icons = []
-                        if form_row[14]:
-                            try:
-                                icons = json.loads(form_row[14])
-                            except Exception:
-                                pass
-                        form_data = {
-                            "id": form_row[0],
-                            "boss_id": form_row[1],
-                            "form_name": form_row[2],
-                            "form_order": form_row[3],
-                            "combat_level": form_row[4],
-                            "hitpoints": form_row[5],
-                            "defence_level": form_row[6],
-                            "magic_level": form_row[7],
-                            "ranged_level": form_row[8],
-                            "defence_stab": form_row[9],
-                            "defence_slash": form_row[10],
-                            "defence_crush": form_row[11],
-                            "defence_magic": form_row[12],
-                            "defence_ranged_standard": form_row[13],
-                            "icons": icons,
-                            "image_url": form_row[15],
-                            "size": form_row[16],
-                        }
-                        boss_data["forms"].append(form_data)
+                if boss_data["forms"]:
+                    first_form = boss_data["forms"][0]
+                    if first_form.get("icons"):
+                        boss_data["icon_url"] = first_form["icons"][0]
+                    elif first_form.get("image_url"):
+                        boss_data["icon_url"] = first_form["image_url"]
 
-                    if boss_data["forms"]:
-                        first_form = boss_data["forms"][0]
-                        if first_form.get("icons"):
-                            boss_data["icon_url"] = first_form["icons"][0]
-                        elif first_form.get("image_url"):
-                            boss_data["icon_url"] = first_form["image_url"]
+                return boss_data
 
-                    return boss_data
         except Exception as e:
             print(f"Error getting boss {boss_id}: {e}")
             return None
 
-    async def get_boss_id_by_form_async(self, form_id: int) -> Optional[int]:
+    def get_boss_id_by_form(self, form_id: int) -> Optional[int]:
+        """Return the boss_id associated with a boss form."""
         try:
-            async with self.connection_async() as conn:
-                async with conn.cursor() as cursor:
-                    await cursor.execute(
-                        "SELECT boss_id FROM boss_forms WHERE id = ?",
-                        (form_id,),
-                    )
-
-                    row = await cursor.fetchone()
-                    if row:
-                        return row[0]
-                    return None
+            with self.connection() as conn:
+                cursor = conn.cursor()
+                cursor.execute("SELECT boss_id FROM boss_forms WHERE id = ?", (form_id,))
+                row = cursor.fetchone()
+                if row:
+                    return row[0]
+                return None
         except Exception as e:
             print(f"Error getting boss id from form {form_id}: {e}")
             return None
 
-    async def get_boss_by_form_async(self, form_id: int) -> Optional[Dict[str, Any]]:
-        boss_id = await self.get_boss_id_by_form_async(form_id)
+    def get_boss_by_form(self, form_id: int) -> Optional[Dict[str, Any]]:
+        """Get boss details using a form id."""
+        boss_id = self.get_boss_id_by_form(form_id)
         if boss_id is None:
             return None
-        return await self.get_boss_async(boss_id)
+        return self.get_boss(boss_id)
+
+    def get_all_items(
+        self,
+        combat_only: bool = True,
+        tradeable_only: bool = False,
+        limit: int | None = None,
+        offset: int | None = None,
+    ) -> List[Dict[str, Any]]:
+        """Get all items from the database with optional filters and pagination."""
+        try:
+            with self.connection() as conn:
+                cursor = conn.cursor()
+            
+            query = """
+                SELECT id, name, has_special_attack, has_passive_effect,
+                       has_combat_stats, is_tradeable, slot, icons
+                FROM items
+                WHERE 1=1
+            """
+            params = []
+            
+            if combat_only:
+                query += " AND has_combat_stats = 1"
+            if tradeable_only:
+                query += " AND is_tradeable = 1"
+                
+            query += " ORDER BY name"
+
+            if limit is not None:
+                off = offset or 0
+                query += " OFFSET ? ROWS FETCH NEXT ? ROWS ONLY"
+                params.extend([off, limit])
+
+                cursor.execute(query, params)
+
+                items = []
+                for row in cursor.fetchall():
+                    # Parse icons JSON
+                    icons = []
+                    if row[7]:  # icons column
+                        try:
+                            icons = json.loads(row[7])
+                        except:
+                            pass
+
+                    items.append({
+                        "id": row[0],
+                        "name": row[1],
+                        "has_special_attack": bool(row[2]),
+                        "has_passive_effect": bool(row[3]),
+                        "has_combat_stats": bool(row[4]),
+                        "is_tradeable": bool(row[5]),
+                        "slot": row[6],
+                        "icons": icons,
+                    })
+
+                return items
+            
+        except Exception as e:
+            print(f"Error getting items: {e}")
+            return []
+
+    def get_item(self, item_id: int) -> Optional[Dict[str, Any]]:
+        """Get a specific item."""
+        try:
+            with self.connection() as conn:
+                cursor = conn.cursor()
+            
+            cursor.execute("""
+                SELECT id, name, has_special_attack, special_attack_text,
+                       has_passive_effect, passive_effect_text, has_combat_stats,
+                       is_tradeable, slot, combat_stats, icons
+                FROM items
+                WHERE id = ?
+            """, (item_id,))
+            
+            row = cursor.fetchone()
+            if not row:
+                return None
+            
+            # Parse JSON fields
+            combat_stats = {}
+            if row[9]:
+                try:
+                    combat_stats = json.loads(row[9])
+                except:
+                    pass
+            
+            icons = []
+            if row[10]:
+                try:
+                    icons = json.loads(row[10])
+                except:
+                    pass
+            
+            item_data = {
+                "id": row[0],
+                "name": row[1],
+                "has_special_attack": bool(row[2]),
+                "special_attack_text": row[3],
+                "has_passive_effect": bool(row[4]),
+                "passive_effect_text": row[5],
+                "has_combat_stats": bool(row[6]),
+                "is_tradeable": bool(row[7]),
+                "slot": row[8],
+                "combat_stats": combat_stats,
+                "icons": icons,
+            }
+
+            return item_data
+            
+        except Exception as e:
+            print(f"Error getting item {item_id}: {e}")
+            return None
+
+    def search_bosses(self, query: str, limit: int | None = None) -> List[Dict[str, Any]]:
+        """Search bosses by name."""
+        try:
+            with self.connection() as conn:
+                cursor = conn.cursor()
+
+            sql = (
+                "SELECT id, name, raid_group, location\n"
+                "FROM bosses\n"
+                "WHERE name LIKE ?\n"
+                "ORDER BY name"
+            )
+            params: list[Any] = [f"%{query}%"]
+            if limit is not None:
+                sql = (
+                    "SELECT TOP (?) id, name, raid_group, location\n"
+                    "FROM bosses\n"
+                    "WHERE name LIKE ?\n"
+                    "ORDER BY name"
+                )
+                params.insert(0, limit)
+
+            cursor.execute(sql, params)
+            
+            bosses = []
+            for row in cursor.fetchall():
+                bosses.append(
+                    {
+                        "id": row[0],
+                        "name": row[1],
+                        "raid_group": row[2],
+                        "location": row[3],
+                    }
+                )
+
+            return bosses
+            
+        except Exception as e:
+            print(f"Error searching bosses: {e}")
+            return []
+
+    def search_items(self, query: str, limit: int | None = None) -> List[Dict[str, Any]]:
+        """Search items by name."""
+        try:
+            with self.connection() as conn:
+                cursor = conn.cursor()
+
+            sql = (
+                "SELECT id, name, has_special_attack, has_passive_effect,\n"
+                "       has_combat_stats, is_tradeable, slot, icons\n"
+                "FROM items\n"
+                "WHERE name LIKE ?\n"
+                "ORDER BY name"
+            )
+            params: list[Any] = [f"%{query}%"]
+            if limit is not None:
+                sql = (
+                    "SELECT TOP (?) id, name, has_special_attack, has_passive_effect,\n"
+                    "       has_combat_stats, is_tradeable, slot, icons\n"
+                    "FROM items\n"
+                    "WHERE name LIKE ?\n"
+                    "ORDER BY name"
+                )
+                params.insert(0, limit)
+
+            cursor.execute(sql, params)
+            
+            items = []
+            for row in cursor.fetchall():
+                icons = []
+                if row[7]:
+                    try:
+                        icons = json.loads(row[7])
+                    except Exception:
+                        pass
+
+                items.append(
+                    {
+                        "id": row[0],
+                        "name": row[1],
+                        "has_special_attack": bool(row[2]),
+                        "has_passive_effect": bool(row[3]),
+                        "has_combat_stats": bool(row[4]),
+                        "is_tradeable": bool(row[5]),
+                        "slot": row[6],
+                        "icons": icons,
+                    }
+                )
+
+            return items
+
+        except Exception as e:
+            print(f"Error searching items: {e}")
+            return []
+
+    # Async wrappers -----------------------------------------------------
+
+    async def get_all_bosses_async(
+        self, limit: int | None = None, offset: int | None = None
+    ) -> List[Dict[str, Any]]:
+        return await asyncio.to_thread(self.get_all_bosses, limit=limit, offset=offset)
+
+    async def get_boss_async(self, boss_id: int) -> Optional[Dict[str, Any]]:
+        return await asyncio.to_thread(self.get_boss, boss_id)
+
+    async def get_boss_id_by_form_async(self, form_id: int) -> Optional[int]:
+        return await asyncio.to_thread(self.get_boss_id_by_form, form_id)
+
+    async def get_boss_by_form_async(self, form_id: int) -> Optional[Dict[str, Any]]:
+        return await asyncio.to_thread(self.get_boss_by_form, form_id)
 
     async def get_all_items_async(
         self,
@@ -270,202 +542,26 @@ class AzureSQLDatabaseService:
         limit: int | None = None,
         offset: int | None = None,
     ) -> List[Dict[str, Any]]:
-        try:
-            async with self.connection_async() as conn:
-                async with conn.cursor() as cursor:
-                    query = """
-                        SELECT id, name, has_special_attack, has_passive_effect,
-                               has_combat_stats, is_tradeable, slot, icons
-                        FROM items
-                        WHERE 1=1
-                    """
-                    params = []
-
-                    if combat_only:
-                        query += " AND has_combat_stats = 1"
-                    if tradeable_only:
-                        query += " AND is_tradeable = 1"
-
-                    query += " ORDER BY name"
-
-                    if limit is not None:
-                        off = offset or 0
-                        query += " OFFSET ? ROWS FETCH NEXT ? ROWS ONLY"
-                        params.extend([off, limit])
-
-                    await cursor.execute(query, params)
-                    rows = await cursor.fetchall()
-
-                    items = []
-                    for row in rows:
-                        icons = []
-                        if row[7]:
-                            try:
-                                icons = json.loads(row[7])
-                            except Exception:
-                                pass
-                        items.append(
-                            {
-                                "id": row[0],
-                                "name": row[1],
-                                "has_special_attack": bool(row[2]),
-                                "has_passive_effect": bool(row[3]),
-                                "has_combat_stats": bool(row[4]),
-                                "is_tradeable": bool(row[5]),
-                                "slot": row[6],
-                                "icons": icons,
-                            }
-                        )
-
-                    return items
-        except Exception as e:
-            print(f"Error getting items: {e}")
-            return []
+        return await asyncio.to_thread(
+            self.get_all_items,
+            combat_only,
+            tradeable_only,
+            limit,
+            offset,
+        )
 
     async def get_item_async(self, item_id: int) -> Optional[Dict[str, Any]]:
-        try:
-            async with self.connection_async() as conn:
-                async with conn.cursor() as cursor:
-                    await cursor.execute(
-                        """
-                    SELECT id, name, has_special_attack, special_attack_text,
-                           has_passive_effect, passive_effect_text, has_combat_stats,
-                           is_tradeable, slot, combat_stats, icons
-                    FROM items
-                    WHERE id = ?
-                    """,
-                        (item_id,),
-                    )
-
-                    row = await cursor.fetchone()
-                    if not row:
-                        return None
-
-                    combat_stats = {}
-                    if row[9]:
-                        try:
-                            combat_stats = json.loads(row[9])
-                        except Exception:
-                            pass
-
-                    icons = []
-                    if row[10]:
-                        try:
-                            icons = json.loads(row[10])
-                        except Exception:
-                            pass
-
-                    item_data = {
-                        "id": row[0],
-                        "name": row[1],
-                        "has_special_attack": bool(row[2]),
-                        "special_attack_text": row[3],
-                        "has_passive_effect": bool(row[4]),
-                        "passive_effect_text": row[5],
-                        "has_combat_stats": bool(row[6]),
-                        "is_tradeable": bool(row[7]),
-                        "slot": row[8],
-                        "combat_stats": combat_stats,
-                        "icons": icons,
-                    }
-
-                    return item_data
-        except Exception as e:
-            print(f"Error getting item {item_id}: {e}")
-            return None
+        return await asyncio.to_thread(self.get_item, item_id)
 
     async def search_bosses_async(
         self, query: str, limit: int | None = None
     ) -> List[Dict[str, Any]]:
-        try:
-            async with self.connection_async() as conn:
-                async with conn.cursor() as cursor:
-                    sql = (
-                        "SELECT id, name, raid_group, location\n"
-                        "FROM bosses\n"
-                        "WHERE name LIKE ?\n"
-                        "ORDER BY name"
-                    )
-                    params: list[Any] = [f"%{query}%"]
-                    if limit is not None:
-                        sql = (
-                            "SELECT TOP (?) id, name, raid_group, location\n"
-                            "FROM bosses\n"
-                            "WHERE name LIKE ?\n"
-                            "ORDER BY name"
-                        )
-                        params.insert(0, limit)
-
-                    await cursor.execute(sql, params)
-                    rows = await cursor.fetchall()
-                    bosses = []
-                    for row in rows:
-                        bosses.append(
-                            {
-                                "id": row[0],
-                                "name": row[1],
-                                "raid_group": row[2],
-                                "location": row[3],
-                            }
-                        )
-
-                    return bosses
-        except Exception as e:
-            print(f"Error searching bosses: {e}")
-            return []
+        return await asyncio.to_thread(self.search_bosses, query, limit)
 
     async def search_items_async(
         self, query: str, limit: int | None = None
     ) -> List[Dict[str, Any]]:
-        try:
-            async with self.connection_async() as conn:
-                async with conn.cursor() as cursor:
-                    sql = (
-                        "SELECT id, name, has_special_attack, has_passive_effect,\n"
-                        "       has_combat_stats, is_tradeable, slot, icons\n"
-                        "FROM items\n"
-                        "WHERE name LIKE ?\n"
-                        "ORDER BY name"
-                    )
-                    params: list[Any] = [f"%{query}%"]
-                    if limit is not None:
-                        sql = (
-                            "SELECT TOP (?) id, name, has_special_attack, has_passive_effect,\n"
-                            "       has_combat_stats, is_tradeable, slot, icons\n"
-                            "FROM items\n"
-                            "WHERE name LIKE ?\n"
-                            "ORDER BY name"
-                        )
-                        params.insert(0, limit)
-
-                    await cursor.execute(sql, params)
-                    rows = await cursor.fetchall()
-                    items = []
-                    for row in rows:
-                        icons = []
-                        if row[7]:
-                            try:
-                                icons = json.loads(row[7])
-                            except Exception:
-                                pass
-                        items.append(
-                            {
-                                "id": row[0],
-                                "name": row[1],
-                                "has_special_attack": bool(row[2]),
-                                "has_passive_effect": bool(row[3]),
-                                "has_combat_stats": bool(row[4]),
-                                "is_tradeable": bool(row[5]),
-                                "slot": row[6],
-                                "icons": icons,
-                            }
-                        )
-
-                    return items
-        except Exception as e:
-            print(f"Error searching items: {e}")
-            return []
-
+        return await asyncio.to_thread(self.search_items, query, limit)
 
 # Provide legacy name for unit tests
 DatabaseService = AzureSQLDatabaseService

--- a/backend/app/repositories/boss_repository.py
+++ b/backend/app/repositories/boss_repository.py
@@ -1,13 +1,22 @@
 from typing import Any, Dict, List, Optional
 import asyncio
 
-from cachetools import TTLCache
+from cachetools import TTLCache, cached
 
 from ..database import azure_sql_service as db_service
 from ..config.settings import CACHE_TTL_SECONDS
 
 _all_bosses_cache = TTLCache(maxsize=1, ttl=CACHE_TTL_SECONDS)
 _boss_cache = TTLCache(maxsize=256, ttl=CACHE_TTL_SECONDS)
+
+
+def _load_all_bosses() -> List[Dict[str, Any]]:
+    """Load all bosses from the database and cache them."""
+    bosses = _all_bosses_cache.get("all")
+    if bosses is None:
+        bosses = db_service.get_all_bosses()
+        _all_bosses_cache["all"] = bosses
+    return bosses
 
 
 async def _load_all_bosses_async() -> List[Dict[str, Any]]:
@@ -17,6 +26,37 @@ async def _load_all_bosses_async() -> List[Dict[str, Any]]:
         bosses = await db_service.get_all_bosses_async()
         _all_bosses_cache["all"] = bosses
     return bosses
+
+
+def get_all_bosses(
+    limit: int | None = None, offset: int | None = None
+) -> List[Dict[str, Any]]:
+    """Return bosses with optional pagination using cached data."""
+    bosses = _load_all_bosses()
+    if limit is not None or offset is not None:
+        off = offset or 0
+        if limit is None:
+            return bosses[off:]
+        return bosses[off : off + limit]
+    return bosses
+
+@cached(_boss_cache)
+def get_boss(boss_id: int) -> Optional[Dict[str, Any]]:
+    """Return a specific boss by id, cached for the configured TTL."""
+    return db_service.get_boss(boss_id)
+
+
+def get_boss_by_form(form_id: int) -> Optional[Dict[str, Any]]:
+    """Return boss details by looking up a form id."""
+    boss_id = db_service.get_boss_id_by_form(form_id)
+    if boss_id is None:
+        return None
+    return get_boss(boss_id)
+
+
+def search_bosses(query: str, limit: int | None = None) -> List[Dict[str, Any]]:
+    """Search bosses directly using the database service."""
+    return db_service.search_bosses(query, limit)
 
 
 async def get_all_bosses_async(
@@ -52,9 +92,7 @@ async def get_boss_by_form_async(form_id: int) -> Optional[Dict[str, Any]]:
     return await get_boss_async(boss_id)
 
 
-async def search_bosses_async(
-    query: str, limit: int | None = None
-) -> List[Dict[str, Any]]:
+async def search_bosses_async(query: str, limit: int | None = None) -> List[Dict[str, Any]]:
     return await db_service.search_bosses_async(query, limit)
 
 
@@ -66,5 +104,7 @@ async def get_bosses_with_forms_async(
     if not bosses:
         return []
 
-    results = await asyncio.gather(*[get_boss_async(boss["id"]) for boss in bosses])
+    results = await asyncio.gather(
+        *[get_boss_async(boss["id"]) for boss in bosses]
+    )
     return [b for b in results if b is not None]

--- a/backend/app/repositories/item_repository.py
+++ b/backend/app/repositories/item_repository.py
@@ -1,13 +1,22 @@
 from typing import Any, Dict, List, Optional
 import asyncio
 
-from cachetools import TTLCache
+from cachetools import TTLCache, cached
 
 from ..database import azure_sql_service as db_service
 from ..config.settings import CACHE_TTL_SECONDS
 
 _all_items_cache = TTLCache(maxsize=1, ttl=CACHE_TTL_SECONDS)
 _item_cache = TTLCache(maxsize=512, ttl=CACHE_TTL_SECONDS)
+
+
+def _load_all_items() -> List[Dict[str, Any]]:
+    """Load all items from the database and cache them."""
+    items = _all_items_cache.get("all")
+    if items is None:
+        items = db_service.get_all_items(combat_only=False)
+        _all_items_cache["all"] = items
+    return items
 
 
 async def _load_all_items_async() -> List[Dict[str, Any]]:
@@ -17,6 +26,39 @@ async def _load_all_items_async() -> List[Dict[str, Any]]:
         items = await db_service.get_all_items_async(combat_only=False)
         _all_items_cache["all"] = items
     return items
+
+
+def get_all_items(
+    combat_only: bool = True,
+    tradeable_only: bool = False,
+    limit: int | None = None,
+    offset: int | None = None,
+) -> List[Dict[str, Any]]:
+    """Return items with optional pagination using cached data."""
+    items = _load_all_items()
+    # Apply filters locally for the cached list
+    if combat_only:
+        items = [i for i in items if i.get("has_combat_stats")]
+    if tradeable_only:
+        items = [i for i in items if i.get("is_tradeable")]
+
+    if limit is not None or offset is not None:
+        off = offset or 0
+        if limit is None:
+            return items[off:]
+        return items[off : off + limit]
+    return items
+
+
+@cached(_item_cache)
+def get_item(item_id: int) -> Optional[Dict[str, Any]]:
+    """Return a single item by id, cached for the configured TTL."""
+    return db_service.get_item(item_id)
+
+
+def search_items(query: str, limit: int | None = None) -> List[Dict[str, Any]]:
+    """Search items directly using the database service."""
+    return db_service.search_items(query, limit)
 
 
 async def get_all_items_async(
@@ -53,7 +95,5 @@ async def get_item_async(item_id: int) -> Optional[Dict[str, Any]]:
     return item
 
 
-async def search_items_async(
-    query: str, limit: int | None = None
-) -> List[Dict[str, Any]]:
+async def search_items_async(query: str, limit: int | None = None) -> List[Dict[str, Any]]:
     return await db_service.search_items_async(query, limit)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,4 +9,3 @@ azure-storage-blob==12.19.0
 python-dotenv==1.0.1
 pyodbc>=5.0.0
 cachetools==5.3.2
-aioodbc==0.5.0


### PR DESCRIPTION
## Summary
- revert database layer to use a small pyodbc-based connection pool
- bring back synchronous repository APIs alongside async wrappers
- document pyodbc requirement
- update settings comment and remove aioodbc from dependencies

## Testing
- `pip install -r backend/requirements.txt`
- `python -m unittest discover backend/app/testing`

------
https://chatgpt.com/codex/tasks/task_e_6848243cde14832e88c1791ee0395275