### PR TITLE
Use IndexedDB storage for Zustand persistence

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -25,6 +25,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
+        "idb-keyval": "^6.2.2",
         "lucide-react": "^0.510.0",
         "next": "15.3.2",
         "react": "^19.0.0",
@@ -7422,6 +7423,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/idb-keyval": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.2.tgz",
+      "integrity": "sha512-yjD9nARJ/jb1g+CvD0tlhUHOrJ9Sy0P8T9MF3YaLlHnSRpwPfpTX0XIvpmw3gAJUmEu3FiICLBDPXVwyEvrleg==",
+      "license": "Apache-2.0"
     },
     "node_modules/ignore": {
       "version": "5.3.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,6 +27,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
+    "idb-keyval": "^6.2.2",
     "lucide-react": "^0.510.0",
     "next": "15.3.2",
     "react": "^19.0.0",
@@ -41,21 +42,21 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3",
     "@tailwindcss/postcss": "^4",
+    "@testing-library/jest-dom": "^6.0.0",
+    "@testing-library/react": "^16.0.0",
+    "@testing-library/user-event": "^14.0.0",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "15.3.2",
     "eslint-config-prettier": "^10.1.5",
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
     "prettier": "^3.5.3",
     "tailwindcss": "^4",
-    "tw-animate-css": "^1.2.9",
-    "typescript": "^5",
-    "jest": "^29.7.0",
     "ts-jest": "^29.1.1",
-    "@testing-library/react": "^16.0.0",
-    "@testing-library/jest-dom": "^6.0.0",
-    "@testing-library/user-event": "^14.0.0",
-    "jest-environment-jsdom": "^29.7.0"
+    "tw-animate-css": "^1.2.9",
+    "typescript": "^5"
   }
 }

--- a/frontend/src/store/calculator-store.ts
+++ b/frontend/src/store/calculator-store.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 import { safeStorage } from '@/utils/safeStorage';
+import { idbStorage } from '@/utils/idbStorage';
 import {
   CalculatorParams,
   DpsResult,
@@ -239,7 +240,7 @@ export const useCalculatorStore = create<CalculatorState>()(
     }),
     {
       name: 'osrs-calculator-storage',
-      storage: createJSONStorage(() => safeStorage),
+      storage: createJSONStorage(() => (typeof window !== 'undefined' && 'indexedDB' in window ? idbStorage : safeStorage)),
       partialize: (state) => ({
         params: state.params,
         gearLocked: state.gearLocked,

--- a/frontend/src/utils/idbStorage.ts
+++ b/frontend/src/utils/idbStorage.ts
@@ -1,0 +1,30 @@
+import { StateStorage } from 'zustand/middleware';
+import { get, set, del } from 'idb-keyval';
+
+/**
+ * Zustand storage backed by IndexedDB using idb-keyval.
+ * Falls back silently if operations fail.
+ */
+export const idbStorage: StateStorage = {
+  async getItem(name) {
+    try {
+      return await get<string | null>(name);
+    } catch {
+      return null;
+    }
+  },
+  async setItem(name, value) {
+    try {
+      await set(name, value);
+    } catch (err) {
+      console.warn('Failed to persist state', err);
+    }
+  },
+  async removeItem(name) {
+    try {
+      await del(name);
+    } catch {
+      /* ignore */
+    }
+  }
+};


### PR DESCRIPTION
## Summary
- add `idb-keyval` dependency
- create `idbStorage` helper backed by IndexedDB
- persist calculator store using IndexedDB when available

## Testing
- `npm test`
- `pytest` *(fails without extra deps)*
- `pip install -r requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68482b9543bc832eb6971564ea857435