### PR TITLE
Fix hydration hook call check

### DIFF
--- a/frontend/src/store/calculator-store.ts
+++ b/frontend/src/store/calculator-store.ts
@@ -249,7 +249,7 @@ export const useCalculatorStore = create<CalculatorState>()(
 );
 
 // After hydration, populate objects from persisted IDs
-useCalculatorStore.persist.onFinishHydration(async (state) => {
+useCalculatorStore.persist?.onFinishHydration?.(async (state) => {
   if (!state) return;
   const { loadoutIds, selectedBossId, selectedBossFormId } = state as any;
   const refStore = useReferenceDataStore.getState();


### PR DESCRIPTION
## Summary
- patch calculator-store to check persist plugin before running hydration

## Testing
- `npm test --ci`
- `python -m unittest discover -s app/testing`

------
https://chatgpt.com/codex/tasks/task_e_68484184f688832eac14f690d67a8ff3