### PR TITLE
Fix Next.js build by marking pages dynamic

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  output: 'export',
+  output: 'standalone',
   trailingSlash: true,
   images: {
     unoptimized: true

--- a/frontend/src/app/import/page.tsx
+++ b/frontend/src/app/import/page.tsx
@@ -1,4 +1,6 @@
 'use client';
+
+export const dynamic = 'force-dynamic';
 import { useState } from 'react';
 import { useCalculatorStore } from '@/store/calculator-store';
 import { itemsApi } from '@/services/api';

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,6 +1,8 @@
 // page.tsx - Updated version with proper bottom padding on main content
 import { ImprovedDpsCalculator } from '@/components/features/calculator/ImprovedDpsCalculator';
 
+export const dynamic = 'force-dynamic';
+
 export default function Home() {
   return (
     <main id="main" className="container mx-auto py-8 px-4 pb-16"> {/* Added extra bottom padding */}

--- a/frontend/src/app/simulate/page.tsx
+++ b/frontend/src/app/simulate/page.tsx
@@ -2,6 +2,8 @@
 
 import MultiBossSimulation from '@/components/features/simulation/MultiBossSimulation';
 
+export const dynamic = 'force-dynamic';
+
 export default function SimulatePage() {
   return (
     <main id="main" className="container mx-auto py-8 px-4 pb-16">


### PR DESCRIPTION
## Summary
- switch `next.config.js` to standalone build output
- mark dynamic pages with `export const dynamic = 'force-dynamic'`

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684843f5b9d8832e97aade213acf3da8