### PR TITLE
Revert reference data persistence

### DIFF
--- a/frontend/src/app/import/page.tsx
+++ b/frontend/src/app/import/page.tsx
@@ -1,6 +1,4 @@
-
 'use client';
-
 import { useState } from 'react';
 import { useCalculatorStore } from '@/store/calculator-store';
 import { itemsApi } from '@/services/api';


### PR DESCRIPTION
## Summary
- restore persist-based reference data store setup
- remove stray blank line in import page

## Testing
- `python backend/app/testing/UnitTest.py`
- `npm test` *(fails: one failing test)*
- `npm run build` *(fails: Next.js build error)*

------
https://chatgpt.com/codex/tasks/task_e_6848562ab4c0832e8d29e775ab2fa28d