### PR TITLE
Display special attacks

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,7 +9,7 @@ from dotenv import load_dotenv
 # Load environment variables from a .env file if present
 load_dotenv()
 
-from .repositories import item_repository, boss_repository
+from .repositories import item_repository, boss_repository, special_attack_repository
 from .config.settings import CACHE_TTL_SECONDS
 from .models import (
     DpsResult, 
@@ -518,6 +518,15 @@ async def calculate_item_effect(params: Dict[str, Any]):
         return result
     except Exception as e:
         raise HTTPException(status_code=400, detail=str(e))
+
+
+@app.get("/special-attacks", tags=["Items"])
+async def get_special_attacks():
+    """Return the special attack reference data."""
+    try:
+        return special_attack_repository.get_all_special_attacks()
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Failed to retrieve special attacks: {str(e)}")
 
 # For direct execution during development
 if __name__ == "__main__":

--- a/backend/app/repositories/special_attack_repository.py
+++ b/backend/app/repositories/special_attack_repository.py
@@ -15,3 +15,8 @@ def get_special_attack(weapon_name: str) -> Optional[Dict[str, Any]]:
     data = _load_data()
     key = weapon_name.lower().replace(" ", "_")
     return data.get(key)
+
+
+def get_all_special_attacks() -> Dict[str, Any]:
+    """Return the entire special attack dataset."""
+    return _load_data()

--- a/backend/app/testing/test_api.py
+++ b/backend/app/testing/test_api.py
@@ -143,6 +143,14 @@ class TestApiRoutes(unittest.TestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertIsInstance(resp.json(), dict)
 
+    def test_special_attacks(self):
+        with self.client_ctx as client:
+            resp = client.get('/special-attacks')
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertIsInstance(data, dict)
+        self.assertIn('dragon_dagger', data)
+
     def test_cache_headers(self):
         """Endpoints should include Cache-Control headers."""
         with self.client_ctx as client:

--- a/backend/app/testing/test_repositories.py
+++ b/backend/app/testing/test_repositories.py
@@ -181,4 +181,10 @@ class TestSpecialAttackRepository(unittest.TestCase):
         self.assertIsNotNone(data)
         self.assertEqual(data["cost"], 25)
 
+    def test_get_all_special_attacks(self):
+        from app.repositories import special_attack_repository
+        data = special_attack_repository.get_all_special_attacks()
+        self.assertIsInstance(data, dict)
+        self.assertIn("dragon_dagger", data)
+
 

--- a/frontend/src/components/features/calculator/SpecialAttackOptions.tsx
+++ b/frontend/src/components/features/calculator/SpecialAttackOptions.tsx
@@ -1,13 +1,19 @@
 'use client';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { Switch } from '@/components/ui/switch';
-import { useCalculatorStore } from '@/store/calculator-store';
 import { Swords } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { specialAttacksApi } from '@/services/api';
+import { SpecialAttack } from '@/types/calculator';
 
 export function SpecialAttackOptions() {
-  const { params, setParams } = useCalculatorStore();
+  const [attacks, setAttacks] = useState<Record<string, SpecialAttack>>({});
+
+  useEffect(() => {
+    specialAttacksApi
+      .getAll()
+      .then(setAttacks)
+      .catch(() => setAttacks({}));
+  }, []);
 
   return (
     <Card className="w-full border">
@@ -17,56 +23,15 @@ export function SpecialAttackOptions() {
           Special Attacks
         </CardTitle>
       </CardHeader>
-      <CardContent className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <div className="space-y-1">
-          <Label>Special Cost</Label>
-          <Input
-            type="number"
-            min={0}
-            max={100}
-            value={params.special_attack_cost ?? 0}
-            onChange={(e) =>
-              setParams({ special_attack_cost: parseInt(e.target.value) || 0 })
-            }
-          />
-        </div>
-        <div className="space-y-1">
-          <Label>Rotation (%)</Label>
-          <Input
-            type="number"
-            min={0}
-            max={100}
-            value={Math.round((params.special_rotation ?? 0) * 100)}
-            onChange={(e) =>
-              setParams({ special_rotation: (parseFloat(e.target.value) || 0) / 100 })
-            }
-          />
-        </div>
-        <div className="flex items-center gap-2">
-          <Switch
-            checked={!!params.lightbearer}
-            onCheckedChange={(v) => setParams({ lightbearer: v })}
-          />
-          <Label>Lightbearer</Label>
-        </div>
-        <div className="flex items-center gap-2">
-          <Switch
-            checked={!!params.surge_potion}
-            onCheckedChange={(v) => setParams({ surge_potion: v })}
-          />
-          <Label>Surge Potion</Label>
-        </div>
-        <div className="space-y-1">
-          <Label>Duration (s)</Label>
-          <Input
-            type="number"
-            min={1}
-            value={params.duration ?? 60}
-            onChange={(e) =>
-              setParams({ duration: parseFloat(e.target.value) || 60 })
-            }
-          />
-        </div>
+      <CardContent className="space-y-4">
+        {Object.entries(attacks).map(([key, info]) => (
+          <div key={key} className="text-sm space-y-1">
+            <div className="font-semibold">
+              {info.special_name} - Cost {info.cost}%
+            </div>
+            <div>{info.effect}</div>
+          </div>
+        ))}
       </CardContent>
     </Card>
   );

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,10 +1,11 @@
 import axios from 'axios';
-import { 
-  CalculatorParams, 
-  DpsResult, 
-  Boss, 
-  Item, 
-  BossForm 
+import {
+  CalculatorParams,
+  DpsResult,
+  Boss,
+  Item,
+  BossForm,
+  SpecialAttack
 } from '@/types/calculator';
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
@@ -127,6 +128,13 @@ export const itemsApi = {
       params.limit = limit;
     }
     const { data } = await apiClient.get('/search/items', { params });
+    return data;
+  },
+};
+
+export const specialAttacksApi = {
+  getAll: async (): Promise<Record<string, SpecialAttack>> => {
+    const { data } = await apiClient.get('/special-attacks');
     return data;
   },
 };

--- a/frontend/src/types/calculator.ts
+++ b/frontend/src/types/calculator.ts
@@ -287,3 +287,11 @@ export interface SearchParams {
   slot?: EquipmentSlot;
   limit?: number;
 }
+
+export interface SpecialAttack {
+  special_name: string;
+  cost: number;
+  effect: string;
+  attack_roll_modifier: number;
+  damage_roll_modifier: number;
+}


### PR DESCRIPTION
## Summary
- add function to retrieve all special attacks
- expose `/special-attacks` API endpoint
- show special attack data in SpecialAttackOptions instead of inputs
- update API service and types
- add tests for special attack repository and endpoint

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6848edb76828832ebe40444f0ef01deb