### PR TITLE
Integrate passive effects and improved specials

### DIFF
--- a/backend/app/calculators/__init__.py
+++ b/backend/app/calculators/__init__.py
@@ -3,6 +3,7 @@ from .ranged import RangedCalculator
 from .magic import MagicCalculator
 from .raid_scaling import apply_raid_scaling
 from typing import Dict, Any
+from ..repositories import special_attack_repository, passive_effect_repository
 
 
 class DpsCalculator:
@@ -14,6 +15,45 @@ class DpsCalculator:
         Dispatch DPS calculation based on combat style.
         """
         params = apply_raid_scaling(params)
+
+        weapon_name = str(params.get("weapon_name", "")).lower()
+        if weapon_name:
+            sa = special_attack_repository.get_special_attack(weapon_name)
+            if sa:
+                params.setdefault("special_multiplier", sa.get("damage_multiplier", 1.0))
+                params.setdefault("special_accuracy_multiplier", sa.get("accuracy_multiplier", 1.0))
+                params.setdefault("special_hit_count", sa.get("hit_count", 1))
+                params.setdefault("guaranteed_hit", sa.get("guaranteed_hit", False))
+                params.setdefault("special_attack_cost", sa.get("special_cost"))
+
+            pe = passive_effect_repository.get_passive_effect(weapon_name)
+            if pe:
+                mech = pe.get("special_mechanics", {})
+                dmg = mech.get("damage_multiplier")
+                acc = mech.get("accuracy_multiplier")
+                apply = True
+                if mech.get("wilderness_only") and not params.get("in_wilderness"):
+                    apply = False
+                charge_req = None
+                if mech.get("requires_charge"):
+                    for n in pe.get("numerical_values", []):
+                        if n.get("unit") == "ether":
+                            charge_req = n.get("value")
+                            break
+                    if charge_req is not None and params.get("ether_charge", 0) < charge_req:
+                        apply = False
+                if apply:
+                    if dmg:
+                        params["gear_multiplier"] = params.get("gear_multiplier", 1.0) * dmg
+                    if acc:
+                        params["special_accuracy_multiplier"] = params.get("special_accuracy_multiplier", 1.0) * acc
+
+                if mech.get("scales_with") == "target_magic_level":
+                    target_level = params.get("target_magic_level")
+                    if target_level is not None:
+                        bonus = RangedCalculator.calculate_twisted_bow_bonus(target_level)
+                        params["gear_multiplier"] = params.get("gear_multiplier", 1.0) * bonus["damage_multiplier"]
+                        params["special_accuracy_multiplier"] = params.get("special_accuracy_multiplier", 1.0) * bonus["accuracy_multiplier"]
         combat_style = params.get("combat_style", "melee").lower()
 
         calculator = None

--- a/backend/app/calculators/melee.py
+++ b/backend/app/calculators/melee.py
@@ -43,20 +43,25 @@ class MeleeCalculator:
         # Step 4: Attack Roll
         attack_roll = math.floor(effective_atk * (params["melee_attack_bonus"] + EQUIPMENT_BONUS_OFFSET))
         attack_roll = math.floor(attack_roll * params.get("gear_multiplier", 1.0))
+        attack_roll = math.floor(attack_roll * params.get("special_accuracy_multiplier", 1.0))
 
         # Step 5–6: Defence Roll
         def_roll = (params["target_defence_level"] + 9) * (params["target_defence_bonus"] + EQUIPMENT_BONUS_OFFSET)
 
         # Step 7: Hit Chance (Wiki accurate)
-        if attack_roll > def_roll:
-            hit_chance = 1 - (def_roll + 2) / (2 * (attack_roll + 1))
+        if params.get("guaranteed_hit"):
+            hit_chance = 1.0
         else:
-            hit_chance = attack_roll / (2 * (def_roll + 1))
+            if attack_roll > def_roll:
+                hit_chance = 1 - (def_roll + 2) / (2 * (attack_roll + 1))
+            else:
+                hit_chance = attack_roll / (2 * (def_roll + 1))
 
-        hit_chance = max(0, min(1, hit_chance))  # Clamp between 0 and 1
+            hit_chance = max(0, min(1, hit_chance))  # Clamp between 0 and 1
 
         # Step 8: Average Hit and DPS
         avg_hit = hit_chance * (max_hit + 1) / 2
+        avg_hit *= params.get("special_hit_count", 1)
         dps = avg_hit / params["attack_speed"]
 
         if params.get("debug"):

--- a/backend/app/calculators/ranged.py
+++ b/backend/app/calculators/ranged.py
@@ -131,6 +131,7 @@ class RangedCalculator:
         # - but NOT the Twisted Bow accuracy yet
         base_gear_multiplier = params.get("gear_multiplier", 1.0) / tbow_damage_multiplier if tbow_damage_multiplier > 0 else 1.0
         attack_roll = math.floor(attack_roll * base_gear_multiplier)
+        attack_roll = math.floor(attack_roll * params.get("special_accuracy_multiplier", 1.0))
         
         # Now apply the Twisted Bow accuracy modifier separately
         attack_roll = math.floor(attack_roll * tbow_accuracy_multiplier)
@@ -139,15 +140,19 @@ class RangedCalculator:
         def_roll = (params["target_defence_level"] + 9) * (params["target_defence_bonus"] + EQUIPMENT_BONUS_OFFSET)
 
         # Step 6: Hit Chance
-        if attack_roll > def_roll:
-            hit_chance = 1 - (def_roll + 2) / (2 * (attack_roll + 1))
+        if params.get("guaranteed_hit"):
+            hit_chance = 1.0
         else:
-            hit_chance = attack_roll / (2 * (def_roll + 1))
+            if attack_roll > def_roll:
+                hit_chance = 1 - (def_roll + 2) / (2 * (attack_roll + 1))
+            else:
+                hit_chance = attack_roll / (2 * (def_roll + 1))
 
-        hit_chance = max(0, min(1, hit_chance))
+            hit_chance = max(0, min(1, hit_chance))
 
         # Step 7: Average Hit and DPS
         avg_hit = hit_chance * (max_hit + 1) / 2
+        avg_hit *= params.get("special_hit_count", 1)
         dps = avg_hit / params["attack_speed"]
 
         if params.get("debug"):

--- a/backend/app/data/passive_effects.json
+++ b/backend/app/data/passive_effects.json
@@ -151,6 +151,8 @@
       "accuracy_multiplier": 1.5
     }
   },
+  {
+    "item_name": "Zaryte crossbow",
     "effect_description": "The effects of enchanted bolts are strengthened by 10%.",
     "effect_type": "combat",
     "category": "weapon",
@@ -307,14 +309,13 @@
       "consumable": true
     }
   },
+  {
+    "item_name": "Kodai wand",
     "effect_description": "Each combat spell cast with the weapon has a 3/20 (15%) chance to not consume runes.",
     "effect_type": "utility",
     "category": "weapon",
     "stackable": false,
-    "numerical_values": [
-      {"value": 3, "unit": "in_20", "context": "3 in 20 chance"},
-      {"value": 15, "unit": "%", "context": "15% chance"}
-    ],
+    "numerical_values": [{"value": 3, "unit": "in_20", "context": "3 in 20 chance"}, {"value": 15, "unit": "%", "context": "15% chance"}],
     "percentages": [15.0],
     "special_mechanics": {
       "rune_save_chance": 0.15,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,7 +9,7 @@ from dotenv import load_dotenv
 # Load environment variables from a .env file if present
 load_dotenv()
 
-from .repositories import item_repository, boss_repository, special_attack_repository
+from .repositories import item_repository, boss_repository, special_attack_repository, passive_effect_repository
 from .config.settings import CACHE_TTL_SECONDS
 from .models import (
     DpsResult, 
@@ -527,6 +527,15 @@ async def get_special_attacks():
         return special_attack_repository.get_all_special_attacks()
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to retrieve special attacks: {str(e)}")
+
+
+@app.get("/passive-effects", tags=["Items"])
+async def get_passive_effects():
+    """Return the passive effect reference data."""
+    try:
+        return passive_effect_repository.get_all_passive_effects()
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Failed to retrieve passive effects: {str(e)}")
 
 # For direct execution during development
 if __name__ == "__main__":

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -145,6 +145,9 @@ class DpsParameters(BaseModel):
     attack_speed: float = 2.4
     gear_multiplier: float = 1.0
     special_multiplier: float = 1.0
+    special_accuracy_multiplier: Optional[float] = None
+    special_hit_count: Optional[int] = None
+    guaranteed_hit: Optional[bool] = None
     attack_style_bonus: Optional[int] = Field(default=0)
     special_attack_cost: Optional[int] = None
     special_rotation: Optional[float] = None

--- a/backend/app/repositories/__init__.py
+++ b/backend/app/repositories/__init__.py
@@ -1,3 +1,4 @@
 from .item_repository import *
 from .boss_repository import *
 from .special_attack_repository import *
+from .passive_effect_repository import *

--- a/backend/app/repositories/passive_effect_repository.py
+++ b/backend/app/repositories/passive_effect_repository.py
@@ -1,0 +1,55 @@
+from functools import lru_cache
+import json
+import re
+from pathlib import Path
+from typing import Dict, Optional, Any, List
+
+DATA_PATH = Path(__file__).resolve().parent.parent / "data" / "passive_effects.json"
+
+
+def _parse_objects(text: str) -> List[Dict[str, Any]]:
+    """Parse potentially malformed JSON containing a list of objects."""
+    decoder = json.JSONDecoder()
+    i = 0
+    objs = []
+    while True:
+        match = re.search(r"{", text[i:])
+        if not match:
+            break
+        start = i + match.start()
+        try:
+            obj, end = decoder.raw_decode(text[start:])
+            objs.append(obj)
+            i = start + end
+        except json.JSONDecodeError:
+            i = start + 1
+    return objs
+
+
+@lru_cache(maxsize=1)
+def _load_data() -> Dict[str, Any]:
+    with open(DATA_PATH, "r", encoding="utf-8") as f:
+        raw = f.read()
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        data = _parse_objects(raw)
+
+    result: Dict[str, Any] = {}
+    for entry in data:
+        name = entry.get("item_name")
+        if not name:
+            continue
+        key = name.lower().replace(" ", "_")
+        result[key] = entry
+    return result
+
+
+def get_passive_effect(item_name: str) -> Optional[Dict[str, Any]]:
+    data = _load_data()
+    key = item_name.lower().replace(" ", "_")
+    return data.get(key)
+
+
+def get_all_passive_effects() -> Dict[str, Any]:
+    return _load_data()

--- a/backend/app/repositories/special_attack_repository.py
+++ b/backend/app/repositories/special_attack_repository.py
@@ -8,7 +8,20 @@ DATA_PATH = Path(__file__).resolve().parent.parent / "data" / "special_attacks.j
 @lru_cache(maxsize=1)
 def _load_data() -> Dict[str, Any]:
     with open(DATA_PATH, "r", encoding="utf-8") as f:
-        return json.load(f)
+        raw = json.load(f)
+
+    # Dataset may be a list of objects; convert to a lookup dict
+    if isinstance(raw, list):
+        data: Dict[str, Any] = {}
+        for entry in raw:
+            name = entry.get("weapon_name")
+            if not name:
+                continue
+            key = name.lower().replace(" ", "_")
+            data[key] = entry
+        return data
+
+    return raw
 
 def get_special_attack(weapon_name: str) -> Optional[Dict[str, Any]]:
     """Return special attack data for a given weapon name."""

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -138,3 +138,10 @@ export const specialAttacksApi = {
     return data;
   },
 };
+
+export const passiveEffectsApi = {
+  getAll: async (): Promise<Record<string, unknown>> => {
+    const { data } = await apiClient.get('/passive-effects');
+    return data;
+  },
+};


### PR DESCRIPTION
## Summary
- add passive effect repository with tolerant JSON parsing
- support list-based special attacks data
- enhance calculators with special accuracy, hit count, and guaranteed hits
- auto-apply special attack and passive effect bonuses
- expose new `/passive-effects` API endpoint
- extend frontend API service for passive effects

## Testing
- `pytest` *(fails: ModuleNotFoundError: cachetools)*

------
https://chatgpt.com/codex/tasks/task_e_6848f49cfa4c832e909bae354652c035