### PR TITLE
Optimize frontend data fetching

### DIFF
--- a/frontend/src/components/features/calculator/BossSelector.tsx
+++ b/frontend/src/components/features/calculator/BossSelector.tsx
@@ -29,13 +29,13 @@ import {
 } from '@/components/ui/select';
 import { useToast } from '@/hooks/use-toast';
 import { bossesApi } from '@/services/api';
-import { Boss, BossForm, MeleeCalculatorParams, RangedCalculatorParams, MagicCalculatorParams } from '@/types/calculator';
+import { Boss, BossSummary, BossForm, MeleeCalculatorParams, RangedCalculatorParams, MagicCalculatorParams } from '@/types/calculator';
 import { useCalculatorStore } from '@/store/calculator-store';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { useReferenceDataStore } from '@/store/reference-data-store';
 
 interface BossSelectorProps {
-  onSelectBoss?: (boss: Boss) => void;
+  onSelectBoss?: (boss: BossSummary) => void;
   onSelectForm?: (form: BossForm | null) => void;
 }
 
@@ -109,7 +109,7 @@ export function BossSelector({ onSelectBoss, onSelectForm }: BossSelectorProps) 
   }, [unlockBoss, selectedForm]);
 
   // Handle boss selection
-  const handleSelectBoss = (boss: Boss) => {
+  const handleSelectBoss = (boss: BossSummary) => {
     setSelectedBoss(boss);
     setSelectedForm(null);
     setOpen(false);

--- a/frontend/src/components/features/calculator/DirectBossSelector.tsx
+++ b/frontend/src/components/features/calculator/DirectBossSelector.tsx
@@ -23,14 +23,14 @@ import {
 } from '@/components/ui/select';
 import { useToast } from '@/hooks/use-toast';
 import { bossesApi } from '@/services/api';
-import { Boss, BossForm } from '@/types/calculator';
+import { Boss, BossSummary, BossForm } from '@/types/calculator';
 import { useCalculatorStore } from '@/store/calculator-store';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { useReferenceDataStore } from '@/store/reference-data-store';
 import { cn } from '@/lib/utils';
 
 interface DirectBossSelectorProps {
-  onSelectBoss?: (boss: Boss) => void;
+  onSelectBoss?: (boss: BossSummary) => void;
   onSelectForm?: (form: BossForm | null) => void;
   className?: string;
 }
@@ -38,7 +38,7 @@ interface DirectBossSelectorProps {
 export function DirectBossSelector({ onSelectBoss, onSelectForm, className }: DirectBossSelectorProps) {
   const [searchOpen, setSearchOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
-  const [selectedBoss, setSelectedBoss] = useState<Boss | null>(null);
+  const [selectedBoss, setSelectedBoss] = useState<BossSummary | null>(null);
   const [selectedForm, setSelectedForm] = useState<BossForm | null>(null);
   const [bossIcons, setBossIcons] = useState<Record<number, string>>({});
   const storeBosses = useReferenceDataStore((s) => s.bosses);
@@ -116,7 +116,7 @@ export function DirectBossSelector({ onSelectBoss, onSelectForm, className }: Di
   }, [unlockBoss, selectedForm]);
 
   // Handle boss selection
-  const handleSelectBoss = (boss: Boss) => {
+  const handleSelectBoss = (boss: BossSummary) => {
     setSelectedBoss(boss);
     setSelectedForm(null);
     setSearchOpen(false);

--- a/frontend/src/components/features/calculator/EquipmentGrid.tsx
+++ b/frontend/src/components/features/calculator/EquipmentGrid.tsx
@@ -12,7 +12,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { ItemSelector } from './ItemSelector';
-import { Item } from '@/types/calculator';
+import { Item, ItemSummary } from '@/types/calculator';
 import { useToast } from '@/hooks/use-toast';
 import { itemsApi } from '@/services/api';
 
@@ -69,7 +69,7 @@ export function EquipmentGrid({ loadout, show2hOption, combatStyle, onUpdateLoad
       .map(([slot, data]) => ({ slot, ...data }));
   };
 
-  const handleSelectItem = (slot: string, item: Item | null) => {
+  const handleSelectItem = (slot: string, item: ItemSummary | null) => {
     const updated = { ...loadout };
     if (!item) {
       delete updated[slot];

--- a/frontend/src/components/features/calculator/EquipmentLoadout.tsx
+++ b/frontend/src/components/features/calculator/EquipmentLoadout.tsx
@@ -16,7 +16,7 @@ import { useCalculatorStore } from '@/store/calculator-store';
 import { EquipmentDisplay } from '@/components/features/calculator/EquipmentDisplay';
 import PassiveEffectsDisplay from './PassiveEffectsDisplay';
 import { ItemSelector } from './ItemSelector';
-import { Item } from '@/types/calculator';
+import { Item, ItemSummary } from '@/types/calculator';
 import { itemsApi } from '@/services/api';
 
 const EQUIPMENT_SLOTS = [
@@ -202,7 +202,7 @@ export function EquipmentLoadout({ onEquipmentUpdate }: EquipmentLoadoutProps) {
     }
   }, [loadout, applyGearTotals, gearLocked, onEquipmentUpdate]);
 
-  const handleSelectItem = (slot: string, item: Item | null) => {
+  const handleSelectItem = (slot: string, item: ItemSummary | null) => {
     if (!item) {
       if (process.env.NODE_ENV !== 'production') {
         console.debug(`[DEBUG] Deselected item for slot: ${slot}`);

--- a/frontend/src/components/features/calculator/ItemSelector.tsx
+++ b/frontend/src/components/features/calculator/ItemSelector.tsx
@@ -18,7 +18,7 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { itemsApi } from '@/services/api';
-import { Item } from '@/types/calculator';
+import { Item, ItemSummary } from '@/types/calculator';
 import { useCalculatorStore } from '@/store/calculator-store';
 import { CombatStyle } from '@/types/calculator';
 import { ItemPassiveEffects } from './ItemPassiveEffects';
@@ -26,12 +26,12 @@ import { useReferenceDataStore } from '@/store/reference-data-store';
 
 interface ItemSelectorProps {
   slot?: string;
-  onSelectItem?: (item: Item) => void;
+  onSelectItem?: (item: ItemSummary) => void;
 }
 
 export function ItemSelector({ slot, onSelectItem }: ItemSelectorProps) {
   const [open, setOpen] = useState(false);
-  const [selectedItem, setSelectedItem] = useState<Item | null>(null);
+  const [selectedItem, setSelectedItem] = useState<ItemSummary | null>(null);
   const { params, setParams } = useCalculatorStore();
   const combatStyle = params.combat_style;
 
@@ -72,7 +72,7 @@ export function ItemSelector({ slot, onSelectItem }: ItemSelectorProps) {
   const itemsToDisplay = searchTerm.length > 0 ? searchResults ?? [] : filteredItems;
 
   // Handle item selection and update calculator params based on its stats
-  const handleSelectItem = (item: Item) => {
+  const handleSelectItem = (item: ItemSummary) => {
     setSelectedItem(item);
     setOpen(false);
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -3,7 +3,9 @@ import {
   CalculatorParams,
   DpsResult,
   Boss,
+  BossSummary,
   Item,
+  ItemSummary,
   BossForm,
   SpecialAttack
 } from '@/types/calculator';
@@ -47,7 +49,7 @@ export const bossesApi = {
 
   getAllBosses: async (
     params?: { page?: number; page_size?: number }
-  ): Promise<Boss[]> => {
+  ): Promise<BossSummary[]> => {
 
     const { data } = await apiClient.get('/bosses', { params });
     return data;
@@ -91,7 +93,7 @@ export const bossesApi = {
     }
   },
 
-  searchBosses: async (query: string, limit?: number): Promise<Boss[]> => {
+  searchBosses: async (query: string, limit?: number): Promise<BossSummary[]> => {
     const params: Record<string, unknown> = { query };
     if (limit !== undefined) {
       params.limit = limit;
@@ -112,7 +114,7 @@ export const itemsApi = {
       tradeable_only?: boolean;
     }
 
-  ): Promise<Item[]> => {
+  ): Promise<ItemSummary[]> => {
     const { data } = await apiClient.get('/items', { params });
     return data;
   },
@@ -122,7 +124,7 @@ export const itemsApi = {
     return data;
   },
 
-  searchItems: async (query: string, limit?: number): Promise<Item[]> => {
+  searchItems: async (query: string, limit?: number): Promise<ItemSummary[]> => {
     const params: Record<string, unknown> = { query };
     if (limit !== undefined) {
       params.limit = limit;

--- a/frontend/src/store/reference-data-store.ts
+++ b/frontend/src/store/reference-data-store.ts
@@ -4,18 +4,18 @@ import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 import { safeStorage } from '@/utils/safeStorage';
 import { bossesApi, itemsApi } from '@/services/api';
-import { Boss, BossForm, Item } from '@/types/calculator';
+import { BossForm, BossSummary, ItemSummary } from '@/types/calculator';
 
 interface ReferenceDataState {
-  bosses: Boss[];
+  bosses: BossSummary[];
   bossForms: Record<number, BossForm[]>;
-  items: Item[];
+  items: ItemSummary[];
   initialized: boolean;
   timestamp: number;
   initData: () => Promise<void>;
-  addBosses: (b: Boss[]) => void;
+  addBosses: (b: BossSummary[]) => void;
   addBossForms: (id: number, forms: BossForm[]) => void;
-  addItems: (i: Item[]) => void;
+  addItems: (i: ItemSummary[]) => void;
 }
 
 const REFERENCE_TTL_MS = 12 * 60 * 60 * 1000; // 12 hours
@@ -35,18 +35,9 @@ export const useReferenceDataStore = create<ReferenceDataState>()(
         let page = 1;
         while (true) {
           try {
-            const data = await bossesApi.getBossesWithForms({ page, page_size: pageSize });
+            const data = await bossesApi.getAllBosses({ page, page_size: pageSize });
             if (!data.length) break;
             set((state) => ({ bosses: [...state.bosses, ...data] }));
-            const formsMap: Record<number, BossForm[]> = {};
-            for (const b of data) {
-              if (b.forms && b.forms.length) {
-                formsMap[b.id] = b.forms;
-              }
-            }
-            if (Object.keys(formsMap).length) {
-              set((state) => ({ bossForms: { ...state.bossForms, ...formsMap } }));
-            }
             if (data.length < pageSize) break;
             page += 1;
           } catch {

--- a/frontend/src/types/calculator.ts
+++ b/frontend/src/types/calculator.ts
@@ -217,6 +217,15 @@ export interface BossForm {
   size?: number;
 }
 
+export interface BossSummary {
+  id: number;
+  name: string;
+  raid_group?: string;
+  location?: string;
+  has_multiple_forms?: boolean;
+  icon_url?: string;
+}
+
 export interface Item {
   id: number;
   name: string;
@@ -236,6 +245,17 @@ export interface Item {
     quests?: string[];
   };
   release_date?: string;
+  icons?: string[];
+}
+
+export interface ItemSummary {
+  id: number;
+  name: string;
+  slot?: string;
+  has_special_attack: boolean;
+  has_passive_effect: boolean;
+  is_tradeable: boolean;
+  has_combat_stats: boolean;
   icons?: string[];
 }
 


### PR DESCRIPTION
## Summary
- use lightweight `BossSummary` and `ItemSummary` types
- hydrate reference store with summaries only
- update API service and selectors for the new summaries
- adapt equipment components to accept summary items

## Testing
- `npm test` *(fails: jest not found)*
- `python app/testing/UnitTest.py`

------
https://chatgpt.com/codex/tasks/task_e_6848f5f4f63c832ebe517aaf460ce4b4