### PR TITLE
Remove DB connection pooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,17 +178,16 @@ request the server loads and caches the full boss and item lists, and all
 subsequent search requests are served from this in-memory cache so the
 database is only queried when a specific record is requested.
 
-Database connections are pooled. Tune pool behaviour with the following
-environment variables:
+Database connections are created on demand. Control connection behaviour with
+the following environment variables:
 
-- `DB_POOL_SIZE` – Maximum number of open connections (default `5`).
 - `DB_CONNECTION_TIMEOUT` – Connection timeout in seconds (default `30`).
 - `DB_MAX_RETRIES` – Number of connection retries for transient failures
   (default `3`).
 
 The async database layer uses `aioodbc`, so the appropriate ODBC driver must be
 installed on the host system. Ensure these environment variables are set before
-starting the API so the connection pool can connect successfully.
+starting the API so the database connection can be established successfully.
 
 🔄 API Reference
 Calculate DPS

--- a/backend/app/config/settings.py
+++ b/backend/app/config/settings.py
@@ -3,7 +3,6 @@ import os
 # TTL for in-memory caches (in seconds)
 CACHE_TTL_SECONDS = int(os.getenv("CACHE_TTL_SECONDS", "3600"))
 
-# Database connection pool settings
-DB_POOL_SIZE = int(os.getenv("DB_POOL_SIZE", "5"))
+# Database connection settings
 DB_CONNECTION_TIMEOUT = int(os.getenv("DB_CONNECTION_TIMEOUT", "30"))
 DB_MAX_RETRIES = int(os.getenv("DB_MAX_RETRIES", "3"))


### PR DESCRIPTION
## Summary
- drop DB_POOL_SIZE configuration
- remove async connection pooling logic
- update docs

## Testing
- `python -m unittest discover backend/app/testing` *(fails: ModuleNotFoundError: No module named 'httpx')*


------
https://chatgpt.com/codex/tasks/task_e_68490025e85c832ea3e8f490c50913eb