### PR TITLE
Add loading banner and trim frontend cache

### DIFF
--- a/frontend/src/__tests__/reference-data-store.test.ts
+++ b/frontend/src/__tests__/reference-data-store.test.ts
@@ -14,16 +14,15 @@ function getStore() {
 describe('reference data store', () => {
   beforeEach(() => {
     act(() => {
-      useReferenceDataStore.setState({ bosses: [], bossForms: {}, items: [], initialized: false });
+      useReferenceDataStore.setState({ bosses: [], bossForms: {}, items: [], initialized: false, loading: false });
     });
-    mockedBossApi.getBossesWithForms.mockReset();
-    mockedBossApi.getBossForms.mockReset();
+    mockedBossApi.getAllBosses.mockReset();
     mockedItemsApi.getAllItems.mockReset();
   });
 
   it('loads data from APIs', async () => {
-    mockedBossApi.getBossesWithForms
-      .mockResolvedValueOnce([{ id: 1, name: 'Boss', forms: [{ id: 10, boss_id: 1 }] } as any])
+    mockedBossApi.getAllBosses
+      .mockResolvedValueOnce([{ id: 1, name: 'Boss' } as any])
       .mockResolvedValueOnce([]);
 
     mockedItemsApi.getAllItems
@@ -36,16 +35,13 @@ describe('reference data store', () => {
 
     const state = getStore();
     expect(state.bosses).toHaveLength(1);
-    expect(state.bossForms[1]).toHaveLength(1);
     expect(state.items).toHaveLength(1);
-    expect(mockedBossApi.getBossesWithForms).toHaveBeenCalledTimes(1);
-    expect(mockedBossApi.getBossForms).toHaveBeenCalledTimes(0);
+    expect(mockedBossApi.getAllBosses).toHaveBeenCalledTimes(1);
     expect(mockedItemsApi.getAllItems).toHaveBeenCalledTimes(1);
   });
 
   it('does not load again when initialized', async () => {
-    mockedBossApi.getBossesWithForms.mockResolvedValue([]);
-    mockedBossApi.getBossForms.mockResolvedValue([]);
+    mockedBossApi.getAllBosses.mockResolvedValue([]);
     mockedItemsApi.getAllItems.mockResolvedValue([]);
 
     await act(async () => {
@@ -56,8 +52,7 @@ describe('reference data store', () => {
       await getStore().initData();
     });
 
-    expect(mockedBossApi.getBossesWithForms).toHaveBeenCalledTimes(1);
-    expect(mockedBossApi.getBossForms).toHaveBeenCalledTimes(0);
+    expect(mockedBossApi.getAllBosses).toHaveBeenCalledTimes(1);
     expect(mockedItemsApi.getAllItems).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -2,6 +2,7 @@
 import { Providers } from '@/app/providers';
 import { Navigation } from '@/components/layout/Navigation';
 import { Footer } from '@/components/layout/Footer';
+import { ReferenceDataBanner } from '@/components/layout/ReferenceDataBanner';
 import './globals.css';
 import type { Metadata } from "next";
 
@@ -21,6 +22,7 @@ export default function RootLayout({
         <a href="#main" className="sr-only focus:not-sr-only absolute left-2 top-2 z-50 bg-primary text-primary-foreground px-2 py-1 rounded">Skip to content</a>
         <Providers>
           <Navigation />
+          <ReferenceDataBanner />
           <div className="flex-grow mb-24"> {/* Added sufficient bottom margin to prevent footer overlap */}
             {children}
           </div>

--- a/frontend/src/components/layout/ReferenceDataBanner.tsx
+++ b/frontend/src/components/layout/ReferenceDataBanner.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { Loader2 } from 'lucide-react';
+import { useReferenceDataStore } from '@/store/reference-data-store';
+
+export function ReferenceDataBanner() {
+  const loading = useReferenceDataStore((s) => s.loading);
+  const initialized = useReferenceDataStore((s) => s.initialized);
+
+  if (!loading && initialized) return null;
+
+  return (
+    <div className="w-full bg-muted text-muted-foreground text-sm py-1 flex items-center justify-center gap-2">
+      <Loader2 className="h-4 w-4 animate-spin" />
+      <span>Loading game data...</span>
+    </div>
+  );
+}

--- a/frontend/src/store/reference-data-store.ts
+++ b/frontend/src/store/reference-data-store.ts
@@ -11,6 +11,7 @@ interface ReferenceDataState {
   bossForms: Record<number, BossForm[]>;
   items: ItemSummary[];
   initialized: boolean;
+  loading: boolean;
   timestamp: number;
   initData: () => Promise<void>;
   addBosses: (b: BossSummary[]) => void;
@@ -27,17 +28,19 @@ export const useReferenceDataStore = create<ReferenceDataState>()(
       bossForms: {},
       items: [],
       initialized: false,
+      loading: false,
       timestamp: 0,
       async initData() {
-        if (get().initialized) return;
-        set({ initialized: true, timestamp: Date.now() });
+        if (get().initialized || get().loading) return;
+        set({ loading: true, timestamp: Date.now() });
         const pageSize = 50;
         let page = 1;
+        const bosses: BossSummary[] = [];
         while (true) {
           try {
             const data = await bossesApi.getAllBosses({ page, page_size: pageSize });
             if (!data.length) break;
-            set((state) => ({ bosses: [...state.bosses, ...data] }));
+            bosses.push(...data);
             if (data.length < pageSize) break;
             page += 1;
           } catch {
@@ -45,6 +48,7 @@ export const useReferenceDataStore = create<ReferenceDataState>()(
           }
         }
         page = 1;
+        const items: ItemSummary[] = [];
         while (true) {
           try {
             const data = await itemsApi.getAllItems({
@@ -54,13 +58,14 @@ export const useReferenceDataStore = create<ReferenceDataState>()(
               tradeable_only: false,
             });
             if (!data.length) break;
-            set((state) => ({ items: [...state.items, ...data] }));
+            items.push(...data);
             if (data.length < pageSize) break;
             page += 1;
           } catch {
             break;
           }
         }
+        set({ bosses, items, initialized: true, loading: false });
       },
       addBosses(b) {
         set((state) => ({ bosses: [...state.bosses, ...b] }));
@@ -76,18 +81,17 @@ export const useReferenceDataStore = create<ReferenceDataState>()(
       name: 'osrs-reference-data',
       storage: createJSONStorage(() => safeStorage),
       partialize: (state) => ({
-        bosses: state.bosses,
-        bossForms: state.bossForms,
-        items: state.items,
+        bosses: state.bosses.map(b => ({ id: b.id, name: b.name })),
+        items: state.items.map(i => ({ id: i.id, name: i.name })),
         timestamp: state.timestamp,
       }),
       onRehydrateStorage: (state) => (stored) => {
         if (!stored) return;
         const expired = Date.now() - stored.timestamp > REFERENCE_TTL_MS;
         if (expired) {
-          state.setState({ bosses: [], bossForms: {}, items: [], initialized: false, timestamp: Date.now() });
+          state.setState({ bosses: [], bossForms: {}, items: [], initialized: false, loading: false, timestamp: Date.now() });
         } else {
-          state.setState({ initialized: true });
+          state.setState({ bosses: stored.bosses, items: stored.items, initialized: false, loading: false });
         }
       },
     }


### PR DESCRIPTION
## Summary
- show a banner while reference data loads
- persist only ids and names in the reference-data cache
- adjust reference data tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849038ca108832eaa0d4da4607711e9