### PR TITLE
Add display for item special and passive effects

### DIFF
--- a/frontend/src/components/features/calculator/ImprovedDpsCalculator.tsx
+++ b/frontend/src/components/features/calculator/ImprovedDpsCalculator.tsx
@@ -15,6 +15,7 @@ import { CalculatorForms } from './CalculatorForms';
 import { CombatStyleTabs } from './CombatStyleTabs';
 import { DpsResultDisplay } from './DpsResultDisplay';
 import { SpecialAttackOptions } from './SpecialAttackOptions';
+import { PassiveEffectOptions } from './PassiveEffectOptions';
 import { useDpsCalculator } from '@/hooks/useDpsCalculator';
 import { useToast } from '@/hooks/use-toast';
 import RaidScalingPanel, { RaidScalingConfig } from '../simulation/RaidScalingPanel';
@@ -112,6 +113,7 @@ export function ImprovedDpsCalculator() {
           {/* Prayer/Potion selector */}
           <PrayerPotionSelector className="flex-grow" />
           <SpecialAttackOptions />
+          <PassiveEffectOptions />
         </div>
 
         {/* Right column */}

--- a/frontend/src/components/features/calculator/PassiveEffectOptions.tsx
+++ b/frontend/src/components/features/calculator/PassiveEffectOptions.tsx
@@ -1,0 +1,38 @@
+'use client';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Sparkles } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { passiveEffectsApi } from '@/services/api';
+import { PassiveEffect } from '@/types/calculator';
+
+export function PassiveEffectOptions() {
+  const [effects, setEffects] = useState<Record<string, PassiveEffect>>({});
+
+  useEffect(() => {
+    passiveEffectsApi
+      .getAll()
+      .then(setEffects)
+      .catch(() => setEffects({}));
+  }, []);
+
+  return (
+    <Card className="w-full border">
+      <CardHeader>
+        <CardTitle className="flex items-center">
+          <Sparkles className="h-5 w-5 mr-2 text-primary" />
+          Passive Effects
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {Object.entries(effects).map(([key, info]) => (
+          <div key={key} className="text-sm space-y-1">
+            <div className="font-semibold">{info.item_name}</div>
+            <div>{info.effect_description}</div>
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}
+
+export default PassiveEffectOptions;

--- a/frontend/src/components/features/calculator/SpecialAttackOptions.tsx
+++ b/frontend/src/components/features/calculator/SpecialAttackOptions.tsx
@@ -24,14 +24,17 @@ export function SpecialAttackOptions() {
         </CardTitle>
       </CardHeader>
       <CardContent className="space-y-4">
-        {Object.entries(attacks).map(([key, info]) => (
-          <div key={key} className="text-sm space-y-1">
-            <div className="font-semibold">
-              {info.special_name} - Cost {info.cost}%
+        {Object.entries(attacks).map(([key, info]) => {
+          const [specialName, description] = info.effect.split(':', 2);
+          return (
+            <div key={key} className="text-sm space-y-1">
+              <div className="font-semibold">
+                {info.weapon_name} - {specialName.trim()} (Cost {info.special_cost}%)
+              </div>
+              <div>{description?.trim()}</div>
             </div>
-            <div>{info.effect}</div>
-          </div>
-        ))}
+          );
+        })}
       </CardContent>
     </Card>
   );

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -7,7 +7,8 @@ import {
   Item,
   ItemSummary,
   BossForm,
-  SpecialAttack
+  SpecialAttack,
+  PassiveEffect
 } from '@/types/calculator';
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
@@ -142,7 +143,7 @@ export const specialAttacksApi = {
 };
 
 export const passiveEffectsApi = {
-  getAll: async (): Promise<Record<string, unknown>> => {
+  getAll: async (): Promise<Record<string, PassiveEffect>> => {
     const { data } = await apiClient.get('/passive-effects');
     return data;
   },

--- a/frontend/src/types/calculator.ts
+++ b/frontend/src/types/calculator.ts
@@ -309,9 +309,17 @@ export interface SearchParams {
 }
 
 export interface SpecialAttack {
-  special_name: string;
-  cost: number;
+  weapon_name: string;
   effect: string;
-  attack_roll_modifier: number;
-  damage_roll_modifier: number;
+  special_cost: number;
+  accuracy_multiplier: number;
+  damage_multiplier: number;
+}
+
+export interface PassiveEffect {
+  item_name: string;
+  effect_description: string;
+  effect_type?: string;
+  category?: string;
+  stackable?: boolean;
 }


### PR DESCRIPTION
## Summary
- show weapon name and cost in SpecialAttackOptions component
- add PassiveEffectOptions component to list passive item effects
- expose passive effect types from API
- integrate passive effect list into improved DPS calculator

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68490757bb10832e9f5d64208b8dfecc