### PR TITLE
Make passive/spec options collapsible

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@hookform/resolvers": "^5.0.1",
+        "@radix-ui/react-collapsible": "^1.1.11",
         "@radix-ui/react-dialog": "^1.1.13",
         "@radix-ui/react-label": "^2.1.6",
         "@radix-ui/react-popover": "^1.1.13",
@@ -2107,6 +2108,77 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.11.tgz",
+      "integrity": "sha512-2qrRsVGSCYasSz1RFOorXwl0H7g7J1frQtgpQgYrt+MOidtPAINHn9CPovQXb83r8ahapdx3Tu0fa/pdFFSdPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^5.0.1",
+    "@radix-ui/react-collapsible": "^1.1.11",
     "@radix-ui/react-dialog": "^1.1.13",
     "@radix-ui/react-label": "^2.1.6",
     "@radix-ui/react-popover": "^1.1.13",
@@ -41,21 +42,21 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3",
     "@tailwindcss/postcss": "^4",
+    "@testing-library/jest-dom": "^6.0.0",
+    "@testing-library/react": "^16.0.0",
+    "@testing-library/user-event": "^14.0.0",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "15.3.2",
     "eslint-config-prettier": "^10.1.5",
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
     "prettier": "^3.5.3",
     "tailwindcss": "^4",
-    "tw-animate-css": "^1.2.9",
-    "typescript": "^5",
-    "jest": "^29.7.0",
     "ts-jest": "^29.1.1",
-    "@testing-library/react": "^16.0.0",
-    "@testing-library/jest-dom": "^6.0.0",
-    "@testing-library/user-event": "^14.0.0",
-    "jest-environment-jsdom": "^29.7.0"
+    "tw-animate-css": "^1.2.9",
+    "typescript": "^5"
   }
 }

--- a/frontend/src/components/features/calculator/ImprovedDpsCalculator.tsx
+++ b/frontend/src/components/features/calculator/ImprovedDpsCalculator.tsx
@@ -112,8 +112,6 @@ export function ImprovedDpsCalculator() {
           <CombinedEquipmentDisplay onEquipmentUpdate={handleEquipmentUpdate} bossForm={currentBossForm} />
           {/* Prayer/Potion selector */}
           <PrayerPotionSelector className="flex-grow" />
-          <SpecialAttackOptions />
-          <PassiveEffectOptions />
         </div>
 
         {/* Right column */}
@@ -142,6 +140,8 @@ export function ImprovedDpsCalculator() {
           className="flex-grow"
           onPresetLoad={() => toast.success("Preset loaded successfully!")}
         />
+        <SpecialAttackOptions />
+        <PassiveEffectOptions />
       </div>
       
     </div>

--- a/frontend/src/components/features/calculator/PassiveEffectOptions.tsx
+++ b/frontend/src/components/features/calculator/PassiveEffectOptions.tsx
@@ -1,12 +1,15 @@
 'use client';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Sparkles } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Collapsible, CollapsibleTrigger, CollapsibleContent } from '@/components/ui/collapsible';
+import { Sparkles, ChevronDown, ChevronUp } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { passiveEffectsApi } from '@/services/api';
 import { PassiveEffect } from '@/types/calculator';
 
 export function PassiveEffectOptions() {
   const [effects, setEffects] = useState<Record<string, PassiveEffect>>({});
+  const [isOpen, setIsOpen] = useState(false);
 
   useEffect(() => {
     passiveEffectsApi
@@ -16,22 +19,35 @@ export function PassiveEffectOptions() {
   }, []);
 
   return (
-    <Card className="w-full border">
-      <CardHeader>
-        <CardTitle className="flex items-center">
-          <Sparkles className="h-5 w-5 mr-2 text-primary" />
-          Passive Effects
-        </CardTitle>
-      </CardHeader>
-      <CardContent className="space-y-4">
-        {Object.entries(effects).map(([key, info]) => (
-          <div key={key} className="text-sm space-y-1">
-            <div className="font-semibold">{info.item_name}</div>
-            <div>{info.effect_description}</div>
-          </div>
-        ))}
-      </CardContent>
-    </Card>
+    <Collapsible open={isOpen} onOpenChange={setIsOpen} className="w-full">
+      <Card className="w-full border">
+        <CardHeader className="flex flex-row items-center justify-between">
+          <CardTitle className="flex items-center">
+            <Sparkles className="h-5 w-5 mr-2 text-primary" />
+            Passive Effects
+          </CardTitle>
+          <CollapsibleTrigger asChild>
+            <Button variant="ghost" size="sm">
+              {isOpen ? (
+                <ChevronUp className="h-4 w-4" />
+              ) : (
+                <ChevronDown className="h-4 w-4" />
+              )}
+            </Button>
+          </CollapsibleTrigger>
+        </CardHeader>
+        <CollapsibleContent asChild>
+          <CardContent className="space-y-4">
+            {Object.entries(effects).map(([key, info]) => (
+              <div key={key} className="text-sm space-y-1">
+                <div className="font-semibold">{info.item_name}</div>
+                <div>{info.effect_description}</div>
+              </div>
+            ))}
+          </CardContent>
+        </CollapsibleContent>
+      </Card>
+    </Collapsible>
   );
 }
 

--- a/frontend/src/components/features/calculator/SpecialAttackOptions.tsx
+++ b/frontend/src/components/features/calculator/SpecialAttackOptions.tsx
@@ -1,12 +1,15 @@
 'use client';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Swords } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Collapsible, CollapsibleTrigger, CollapsibleContent } from '@/components/ui/collapsible';
+import { Swords, ChevronDown, ChevronUp } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { specialAttacksApi } from '@/services/api';
 import { SpecialAttack } from '@/types/calculator';
 
 export function SpecialAttackOptions() {
   const [attacks, setAttacks] = useState<Record<string, SpecialAttack>>({});
+  const [isOpen, setIsOpen] = useState(false);
 
   useEffect(() => {
     specialAttacksApi
@@ -16,27 +19,40 @@ export function SpecialAttackOptions() {
   }, []);
 
   return (
-    <Card className="w-full border">
-      <CardHeader>
-        <CardTitle className="flex items-center">
-          <Swords className="h-5 w-5 mr-2 text-primary" />
-          Special Attacks
-        </CardTitle>
-      </CardHeader>
-      <CardContent className="space-y-4">
-        {Object.entries(attacks).map(([key, info]) => {
-          const [specialName, description] = info.effect.split(':', 2);
-          return (
-            <div key={key} className="text-sm space-y-1">
-              <div className="font-semibold">
-                {info.weapon_name} - {specialName.trim()} (Cost {info.special_cost}%)
-              </div>
-              <div>{description?.trim()}</div>
-            </div>
-          );
-        })}
-      </CardContent>
-    </Card>
+    <Collapsible open={isOpen} onOpenChange={setIsOpen} className="w-full">
+      <Card className="w-full border">
+        <CardHeader className="flex flex-row items-center justify-between">
+          <CardTitle className="flex items-center">
+            <Swords className="h-5 w-5 mr-2 text-primary" />
+            Special Attacks
+          </CardTitle>
+          <CollapsibleTrigger asChild>
+            <Button variant="ghost" size="sm">
+              {isOpen ? (
+                <ChevronUp className="h-4 w-4" />
+              ) : (
+                <ChevronDown className="h-4 w-4" />
+              )}
+            </Button>
+          </CollapsibleTrigger>
+        </CardHeader>
+        <CollapsibleContent asChild>
+          <CardContent className="space-y-4">
+            {Object.entries(attacks).map(([key, info]) => {
+              const [specialName, description] = info.effect.split(':', 2);
+              return (
+                <div key={key} className="text-sm space-y-1">
+                  <div className="font-semibold">
+                    {info.weapon_name} - {specialName.trim()} (Cost {info.special_cost}%)
+                  </div>
+                  <div>{description?.trim()}</div>
+                </div>
+              );
+            })}
+          </CardContent>
+        </CollapsibleContent>
+      </Card>
+    </Collapsible>
   );
 }
 

--- a/frontend/src/components/ui/collapsible.tsx
+++ b/frontend/src/components/ui/collapsible.tsx
@@ -1,0 +1,47 @@
+"use client"
+
+import * as React from "react"
+import * as CollapsiblePrimitive from "@radix-ui/react-collapsible"
+
+import { cn } from "@/lib/utils"
+
+function Collapsible({
+  className,
+  ...props
+}: React.ComponentProps<typeof CollapsiblePrimitive.Root>) {
+  return (
+    <CollapsiblePrimitive.Root
+      className={cn("space-y-2", className)}
+      {...props}
+    />
+  )
+}
+
+function CollapsibleTrigger({
+  className,
+  ...props
+}: React.ComponentProps<typeof CollapsiblePrimitive.Trigger>) {
+  return (
+    <CollapsiblePrimitive.Trigger
+      className={cn(
+        "flex items-center justify-between w-full select-none",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CollapsibleContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof CollapsiblePrimitive.Content>) {
+  return (
+    <CollapsiblePrimitive.Content
+      className={cn("overflow-hidden data-[state=closed]:animate-collapsible-up data-[state=open]:animate-collapsible-down", className)}
+      {...props}
+    />
+  )
+}
+
+export { Collapsible, CollapsibleTrigger, CollapsibleContent }


### PR DESCRIPTION
## Summary
- add new Collapsible ui component
- collapse SpecialAttackOptions and PassiveEffectOptions by default
- move special/passive options under the other panels
- update deps for `@radix-ui/react-collapsible`

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68490a58dbe4832eb9dd9e57101af684