### PR TITLE
Add special attack weapon slot

### DIFF
--- a/frontend/src/components/features/calculator/CombinedEquipmentDisplay.tsx
+++ b/frontend/src/components/features/calculator/CombinedEquipmentDisplay.tsx
@@ -89,7 +89,8 @@ export function CombinedEquipmentDisplay({ onEquipmentUpdate, bossForm }: Combin
     let rangedAtk = 0, rangedStr = 0;
     let magicAtk = 0, magicDmg = 0;
 
-    Object.entries(loadout).forEach(([_, item]) => {
+    Object.entries(loadout).forEach(([slot, item]) => {
+      if (slot === 'spec') return;
       if (!item?.combat_stats) return;
 
       const { attack_bonuses = {}, other_bonuses = {} } = item.combat_stats;

--- a/frontend/src/components/features/calculator/EquipmentDisplay.tsx
+++ b/frontend/src/components/features/calculator/EquipmentDisplay.tsx
@@ -28,6 +28,7 @@ const EQUIPMENT_SLOTS = {
   feet: { name: 'Feet', position: 'bottom-center', icon: '👢' },
   ring: { name: 'Ring', position: 'right-bottom', icon: '💍' },
   '2h': { name: 'Two-Handed', position: 'left-middle-2h', icon: '🗡️' },
+  spec: { name: 'Spec Weapon', position: 'spec-slot', icon: '⚡' },
 };
 
 const POSITION_TO_GRID: Record<string, string> = {
@@ -44,6 +45,7 @@ const POSITION_TO_GRID: Record<string, string> = {
   'left-bottom': 'col-start-1 row-start-5',
   'bottom-center': 'col-start-2 row-start-5',
   'right-bottom': 'col-start-3 row-start-5',
+  'spec-slot': 'col-span-3 row-start-6',
 };
 
 interface EquipmentDisplayProps {
@@ -285,7 +287,7 @@ export function EquipmentDisplay({ loadout, totals }: EquipmentDisplayProps) {
 
       {isExpanded && (
         <CardContent>
-          <div className="grid grid-cols-3 grid-rows-5 gap-2 justify-items-center">
+          <div className="grid grid-cols-3 grid-rows-6 gap-2 justify-items-center">
             {Object.entries(EQUIPMENT_SLOTS).map(([slotKey, slotData]) => {
               const item = loadout[slotKey];
               

--- a/frontend/src/components/features/calculator/EquipmentGrid.tsx
+++ b/frontend/src/components/features/calculator/EquipmentGrid.tsx
@@ -28,7 +28,8 @@ const EQUIPMENT_SLOTS = {
   hands: { name: 'Hands', position: 'left-bottom' },
   feet: { name: 'Feet', position: 'bottom-center' },
   ring: { name: 'Ring', position: 'right-bottom' },
-  '2h': { name: 'Two-Handed', position: 'left-middle-2h' }
+  '2h': { name: 'Two-Handed', position: 'left-middle-2h' },
+  spec: { name: 'Spec Weapon', position: 'spec-slot' }
 };
 
 const POSITION_TO_GRID: Record<string, string> = {
@@ -43,7 +44,8 @@ const POSITION_TO_GRID: Record<string, string> = {
   'center-bottom': 'col-start-2 row-start-4',
   'left-bottom': 'col-start-1 row-start-5',
   'bottom-center': 'col-start-2 row-start-5',
-  'right-bottom': 'col-start-3 row-start-5'
+  'right-bottom': 'col-start-3 row-start-5',
+  'spec-slot': 'col-span-3 row-start-6'
 };
 
 interface EquipmentGridProps {
@@ -80,7 +82,7 @@ export function EquipmentGrid({ loadout, show2hOption, combatStyle, onUpdateLoad
     }
 
     itemsApi.getItemById(item.id).then((fullItem) => {
-      if (!fullItem || !fullItem.combat_stats) {
+      if (slot !== 'spec' && (!fullItem || !fullItem.combat_stats)) {
         toast.error(`Failed to load full stats for ${item.name}`);
         return;
       }
@@ -136,7 +138,7 @@ export function EquipmentGrid({ loadout, show2hOption, combatStyle, onUpdateLoad
 
   return (
     <>
-      <div className="grid grid-cols-3 grid-rows-5 gap-2 justify-items-center mb-4 px-4">
+      <div className="grid grid-cols-3 grid-rows-6 gap-2 justify-items-center mb-4 px-4">
         {getDisplaySlots().map(({ slot, name, position }) => (
           <div
             key={slot}
@@ -182,7 +184,7 @@ export function EquipmentGrid({ loadout, show2hOption, combatStyle, onUpdateLoad
           </DialogHeader>
           {selectedSlot && (
             <ItemSelector
-              slot={selectedSlot}
+              slot={selectedSlot === 'spec' ? undefined : selectedSlot}
               onSelectItem={(item) => handleSelectItem(selectedSlot, item)}
             />
           )}

--- a/frontend/src/hooks/useDpsCalculator.ts
+++ b/frontend/src/hooks/useDpsCalculator.ts
@@ -98,12 +98,13 @@ export function useDpsCalculator() {
   const handleCalculate = useCallback(() => {
     const clean = sanitizeParams(params);
     if (currentLoadout) {
+      const specItem = currentLoadout['spec'];
       const twistedBowEquipped =
         (currentLoadout['2h'] &&
           currentLoadout['2h']!.name.toLowerCase().includes('twisted bow')) ||
         (currentLoadout['mainhand'] &&
           currentLoadout['mainhand']!.name.toLowerCase().includes('twisted bow'));
-      if (twistedBowEquipped && params.combat_style === 'ranged') {
+      if (!specItem && twistedBowEquipped && params.combat_style === 'ranged') {
         (clean as any).weapon_name = 'twisted bow';
         if (currentBossForm?.magic_level) {
           (clean as any).target_magic_level = currentBossForm.magic_level;
@@ -118,6 +119,9 @@ export function useDpsCalculator() {
           currentLoadout['mainhand']!.name.toLowerCase().includes('tumeken'));
       if (tumekenShadowEquipped && params.combat_style === 'magic') {
         (clean as any).shadow_bonus = 0.5;
+      }
+      if (specItem) {
+        (clean as any).weapon_name = specItem.name.toLowerCase();
       }
     }
     calculateMutation.mutate(clean);

--- a/frontend/src/types/calculator.ts
+++ b/frontend/src/types/calculator.ts
@@ -14,6 +14,7 @@ export type EquipmentSlot =
   | 'hands'
   | 'feet'
   | 'ring'
+  | 'spec'
   | '2h';
 
 // Equipment loadout interface
@@ -29,6 +30,7 @@ export interface EquipmentLoadout {
   hands?: Item | null;
   feet?: Item | null;
   ring?: Item | null;
+  spec?: Item | null;
   '2h'?: Item | null;
 }
 


### PR DESCRIPTION
## Summary
- update type definitions for a new `spec` equipment slot
- show the spec weapon slot in the equipment grid and character preview
- ignore the spec slot when computing regular gear bonuses
- send the spec weapon to the backend if selected
- removed unsupported binary image

## Testing
- `npm test --prefix frontend` *(fails: jest not found)*
- `pytest -q` *(fails: ModuleNotFoundError: httpx)*

------
https://chatgpt.com/codex/tasks/task_e_68490ccde44c832ea24fbde190c87b77