### PR TITLE
Expose player level sliders

### DIFF
--- a/frontend/src/components/features/calculator/CalculatorForms.tsx
+++ b/frontend/src/components/features/calculator/CalculatorForms.tsx
@@ -7,6 +7,7 @@ import { useState } from 'react';
 import { MeleeForm } from './MeleeForm';
 import { RangedForm } from './RangedForm';
 import { MagicForm } from './MagicForm';
+import { PlayerLevel } from './PlayerLevel';
 import { CombatStyle } from '@/types/calculator';
 
 interface CalculatorFormsProps {
@@ -26,6 +27,7 @@ export function CalculatorForms({
 
   return (
     <div className="w-full mb-6">
+      <PlayerLevel />
       <div className="flex items-center gap-4 mb-4">
         <ToggleBox
           id="manual-toggle"

--- a/frontend/src/components/features/calculator/MagicForm.tsx
+++ b/frontend/src/components/features/calculator/MagicForm.tsx
@@ -113,28 +113,6 @@ export function MagicForm() {
             
             <FormField
               control={form.control}
-              name="magic_level"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Magic Level: {field.value}</FormLabel>
-                  <FormControl>
-                    <Slider
-                      min={1}
-                      max={99}
-                      step={1}
-                      value={[field.value]}
-                      onValueChange={(values) => {
-                        field.onChange(values[0]);
-                        onValueChange({ magic_level: values[0] });
-                      }}
-                    />
-                  </FormControl>
-                </FormItem>
-              )}
-            />
-
-            <FormField
-              control={form.control}
               name="magic_boost"
               render={({ field }) => (
                 <FormItem>

--- a/frontend/src/components/features/calculator/MeleeForm.tsx
+++ b/frontend/src/components/features/calculator/MeleeForm.tsx
@@ -84,28 +84,6 @@ export function MeleeForm() {
             
             <FormField
               control={form.control}
-              name="strength_level"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Strength Level: {field.value}</FormLabel>
-                  <FormControl>
-                    <Slider
-                      min={1}
-                      max={99}
-                      step={1}
-                      value={[field.value]}
-                      onValueChange={(values) => {
-                        field.onChange(values[0]);
-                        onValueChange({ strength_level: values[0] });
-                      }}
-                    />
-                  </FormControl>
-                </FormItem>
-              )}
-            />
-
-            <FormField
-              control={form.control}
               name="strength_boost"
               render={({ field }) => (
                 <FormItem>
@@ -125,28 +103,6 @@ export function MeleeForm() {
                   <FormDescription>
                     Super Strength: 5, Super Combat: 5, Overload: 6+
                   </FormDescription>
-                </FormItem>
-              )}
-            />
-
-            <FormField
-              control={form.control}
-              name="attack_level"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Attack Level: {field.value}</FormLabel>
-                  <FormControl>
-                    <Slider
-                      min={1}
-                      max={99}
-                      step={1}
-                      value={[field.value]}
-                      onValueChange={(values) => {
-                        field.onChange(values[0]);
-                        onValueChange({ attack_level: values[0] });
-                      }}
-                    />
-                  </FormControl>
                 </FormItem>
               )}
             />

--- a/frontend/src/components/features/calculator/PlayerLevel.tsx
+++ b/frontend/src/components/features/calculator/PlayerLevel.tsx
@@ -1,0 +1,81 @@
+'use client';
+import { Slider } from '@/components/ui/slider';
+import { Label } from '@/components/ui/label';
+import { useCalculatorStore } from '@/store/calculator-store';
+
+export function PlayerLevel() {
+  const params = useCalculatorStore((s) => s.params);
+  const setParams = useCalculatorStore((s) => s.setParams);
+
+  const handleChange = (field: string, value: number) => {
+    setParams({ [field]: value } as any);
+  };
+
+  if (params.combat_style === 'melee') {
+    return (
+      <div className="space-y-4">
+        <h3 className="text-3xl font-semibold m-6">Player Levels</h3>
+        <div>
+          <Label>Attack Level: {params.attack_level}</Label>
+          <Slider
+            min={1}
+            max={99}
+            step={1}
+            value={[params.attack_level]}
+            onValueChange={(v) => handleChange('attack_level', v[0])}
+          />
+        </div>
+        <div>
+          <Label>Strength Level: {params.strength_level}</Label>
+          <Slider
+            min={1}
+            max={99}
+            step={1}
+            value={[params.strength_level]}
+            onValueChange={(v) => handleChange('strength_level', v[0])}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  if (params.combat_style === 'ranged') {
+    return (
+      <div className="space-y-4">
+        <h3 className="text-3xl font-semibold m-6">Player Levels</h3>
+        <div>
+          <Label>Ranged Level: {params.ranged_level}</Label>
+          <Slider
+            min={1}
+            max={99}
+            step={1}
+            value={[params.ranged_level]}
+            onValueChange={(v) => handleChange('ranged_level', v[0])}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  if (params.combat_style === 'magic') {
+    return (
+      <div className="space-y-4">
+        <h3 className="text-3xl font-semibold m-6">Player Levels</h3>
+        <div>
+          <Label>Magic Level: {params.magic_level}</Label>
+          <Slider
+            min={1}
+            max={99}
+            step={1}
+            value={[params.magic_level]}
+            onValueChange={(v) => handleChange('magic_level', v[0])}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  return null;
+}
+
+export default PlayerLevel;

--- a/frontend/src/components/features/calculator/RangedForm.tsx
+++ b/frontend/src/components/features/calculator/RangedForm.tsx
@@ -78,28 +78,6 @@ export function RangedForm() {
             
             <FormField
               control={form.control}
-              name="ranged_level"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Ranged Level: {field.value}</FormLabel>
-                  <FormControl>
-                    <Slider
-                      min={1}
-                      max={99}
-                      step={1}
-                      value={[field.value]}
-                      onValueChange={(values) => {
-                        field.onChange(values[0]);
-                        onValueChange({ ranged_level: values[0] });
-                      }}
-                    />
-                  </FormControl>
-                </FormItem>
-              )}
-            />
-
-            <FormField
-              control={form.control}
               name="ranged_boost"
               render={({ field }) => (
                 <FormItem>


### PR DESCRIPTION
## Summary
- add PlayerLevel component and display it above manual forms
- remove strength/attack/ranged/magic level sliders from manual forms

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849103e92a8832e83b1009b9407dfd4