### PR TITLE
Improve special attack search

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -505,6 +505,16 @@ async def search_items(query: str, limit: int | None = None):
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Search failed: {str(e)}")
 
+
+@app.get("/search/special-attacks", tags=["Search"])
+async def search_special_attacks(query: str, limit: int | None = None):
+    """Search for weapons with special attacks by name."""
+    try:
+        results = special_attack_repository.search_special_attacks(query, limit=limit)
+        return results
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Search failed: {str(e)}")
+
 @app.post("/calculate/item-effect", tags=["DPS"])
 async def calculate_item_effect(params: Dict[str, Any]):
     """

--- a/backend/app/repositories/special_attack_repository.py
+++ b/backend/app/repositories/special_attack_repository.py
@@ -1,33 +1,53 @@
-from functools import lru_cache
 import json
 from pathlib import Path
-from typing import Dict, Optional, Any
+from typing import Dict, Optional, Any, List
+
+from cachetools import TTLCache
+
+from ..config.settings import CACHE_TTL_SECONDS
+
+_data_cache: TTLCache[str, Dict[str, Any]] = TTLCache(maxsize=1, ttl=CACHE_TTL_SECONDS)
 
 DATA_PATH = Path(__file__).resolve().parent.parent / "data" / "special_attacks.json"
 
-@lru_cache(maxsize=1)
+
 def _load_data() -> Dict[str, Any]:
+    data = _data_cache.get("all")
+    if data is not None:
+        return data
+
     with open(DATA_PATH, "r", encoding="utf-8") as f:
         raw = json.load(f)
 
-    # Dataset may be a list of objects; convert to a lookup dict
     if isinstance(raw, list):
-        data: Dict[str, Any] = {}
+        data = {}
         for entry in raw:
             name = entry.get("weapon_name")
             if not name:
                 continue
             key = name.lower().replace(" ", "_")
             data[key] = entry
-        return data
+    else:
+        data = raw
 
-    return raw
+    _data_cache["all"] = data
+    return data
 
 def get_special_attack(weapon_name: str) -> Optional[Dict[str, Any]]:
     """Return special attack data for a given weapon name."""
     data = _load_data()
     key = weapon_name.lower().replace(" ", "_")
     return data.get(key)
+
+
+def search_special_attacks(query: str, limit: int | None = None) -> List[Dict[str, Any]]:
+    """Return special attack entries whose weapon names contain the query."""
+    data = _load_data()
+    q = query.lower().replace(" ", "_")
+    results = [v for k, v in data.items() if q in k]
+    if limit is not None:
+        return results[:limit]
+    return results
 
 
 def get_all_special_attacks() -> Dict[str, Any]:

--- a/backend/app/testing/test_api.py
+++ b/backend/app/testing/test_api.py
@@ -151,6 +151,13 @@ class TestApiRoutes(unittest.TestCase):
         self.assertIsInstance(data, dict)
         self.assertIn('dragon_dagger', data)
 
+    def test_search_special_attacks(self):
+        with self.client_ctx as client:
+            resp = client.get('/search/special-attacks', params={'query': 'dragon dag'})
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertTrue(any(item['weapon_name'] == 'Dragon dagger' for item in data))
+
     def test_cache_headers(self):
         """Endpoints should include Cache-Control headers."""
         with self.client_ctx as client:

--- a/backend/app/testing/test_repositories.py
+++ b/backend/app/testing/test_repositories.py
@@ -179,7 +179,12 @@ class TestSpecialAttackRepository(unittest.TestCase):
         from app.repositories import special_attack_repository
         data = special_attack_repository.get_special_attack("Dragon dagger")
         self.assertIsNotNone(data)
-        self.assertEqual(data["cost"], 25)
+        self.assertEqual(data["special_cost"], 25)
+
+    def test_search_special_attacks(self):
+        from app.repositories import special_attack_repository
+        results = special_attack_repository.search_special_attacks("dragon dag")
+        self.assertTrue(any(r["weapon_name"] == "Dragon dagger" for r in results))
 
     def test_get_all_special_attacks(self):
         from app.repositories import special_attack_repository


### PR DESCRIPTION
## Summary
- add TTLCache to the special attack repository
- implement `search_special_attacks` helper
- expose `/search/special-attacks` API route
- update repository and API tests

## Testing
- `pytest backend/app/testing/test_repositories.py::TestSpecialAttackRepository::test_search_special_attacks -q`
- `pytest backend/app/testing/test_repositories.py::TestSpecialAttackRepository::test_get_special_attack -q`
- `pytest -q` *(fails: Client.__init__() got an unexpected keyword argument 'app')*

------
https://chatgpt.com/codex/tasks/task_e_6849115593bc832e9dd26818188ded96