### PR TITLE
Rename manual input toggle

### DIFF
--- a/frontend/src/components/features/calculator/CalculatorForms.tsx
+++ b/frontend/src/components/features/calculator/CalculatorForms.tsx
@@ -28,13 +28,13 @@ export function CalculatorForms({
   return (
     <div className="w-full mb-6">
       <PlayerLevel />
-      <div className="flex items-center gap-4 mb-4">
+      <div className="flex items-center gap-4 mt-4 mb-4">
         <ToggleBox
           id="manual-toggle"
           pressed={showManual}
           onPressedChange={setShowManual}
         />
-        <Label htmlFor="manual-toggle">Show Manual Inputs</Label>
+        <Label htmlFor="manual-toggle">Enable Manual Overrides</Label>
         
       </div>
       {showManual && (


### PR DESCRIPTION
## Summary
- rename label to `Enable Manual Overrides`
- add top margin above manual override toggle

## Testing
- `npm test` in frontend
- `python -m unittest discover -s app/testing`

------
https://chatgpt.com/codex/tasks/task_e_684912d85228832ebd9bdfc3485aaa5a