### PR TITLE
Add debounce to search inputs

### DIFF
--- a/frontend/src/components/features/calculator/BossSelector.tsx
+++ b/frontend/src/components/features/calculator/BossSelector.tsx
@@ -28,6 +28,7 @@ import {
   SelectValue 
 } from '@/components/ui/select';
 import { useToast } from '@/hooks/use-toast';
+import { useDebounce } from '@/hooks/useDebounce';
 import { bossesApi } from '@/services/api';
 import { Boss, BossSummary, BossForm, MeleeCalculatorParams, RangedCalculatorParams, MagicCalculatorParams } from '@/types/calculator';
 import { useCalculatorStore } from '@/store/calculator-store';
@@ -59,6 +60,7 @@ export function BossSelector({ onSelectBoss, onSelectForm }: BossSelectorProps) 
   }, [initData]);
 
   const [searchTerm, setSearchTerm] = useState('');
+  const debouncedSearch = useDebounce(searchTerm, 300);
 
   const initialLoading = storeBosses.length === 0 && searchTerm.length === 0;
 
@@ -66,9 +68,9 @@ export function BossSelector({ onSelectBoss, onSelectForm }: BossSelectorProps) 
     data: searchResults,
     isLoading,
   } = useQuery({
-    queryKey: ['boss-search', searchTerm],
-    queryFn: () => bossesApi.searchBosses(searchTerm),
-    enabled: searchTerm.length > 0,
+    queryKey: ['boss-search', debouncedSearch],
+    queryFn: () => bossesApi.searchBosses(debouncedSearch),
+    enabled: debouncedSearch.length > 0,
     staleTime: Infinity,
     onSuccess: (d) => addBosses(d),
   });

--- a/frontend/src/components/features/calculator/DirectBossSelector.tsx
+++ b/frontend/src/components/features/calculator/DirectBossSelector.tsx
@@ -22,6 +22,7 @@ import {
   SelectValue 
 } from '@/components/ui/select';
 import { useToast } from '@/hooks/use-toast';
+import { useDebounce } from '@/hooks/useDebounce';
 import { bossesApi } from '@/services/api';
 import { Boss, BossSummary, BossForm } from '@/types/calculator';
 import { useCalculatorStore } from '@/store/calculator-store';
@@ -38,6 +39,7 @@ interface DirectBossSelectorProps {
 export function DirectBossSelector({ onSelectBoss, onSelectForm, className }: DirectBossSelectorProps) {
   const [searchOpen, setSearchOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
+  const debouncedQuery = useDebounce(searchQuery, 300);
   const [selectedBoss, setSelectedBoss] = useState<BossSummary | null>(null);
   const [selectedForm, setSelectedForm] = useState<BossForm | null>(null);
   const [bossIcons, setBossIcons] = useState<Record<number, string>>({});
@@ -59,9 +61,9 @@ export function DirectBossSelector({ onSelectBoss, onSelectForm, className }: Di
     data: searchResults,
     isLoading,
   } = useQuery({
-    queryKey: ['boss-search', searchQuery],
-    queryFn: () => bossesApi.searchBosses(searchQuery),
-    enabled: searchQuery.length > 0,
+    queryKey: ['boss-search', debouncedQuery],
+    queryFn: () => bossesApi.searchBosses(debouncedQuery),
+    enabled: debouncedQuery.length > 0,
     staleTime: Infinity,
     onSuccess: (d) => addBosses(d),
   });

--- a/frontend/src/components/features/calculator/ItemSelector.tsx
+++ b/frontend/src/components/features/calculator/ItemSelector.tsx
@@ -23,6 +23,7 @@ import { useCalculatorStore } from '@/store/calculator-store';
 import { CombatStyle } from '@/types/calculator';
 import { ItemPassiveEffects } from './ItemPassiveEffects';
 import { useReferenceDataStore } from '@/store/reference-data-store';
+import { useDebounce } from '@/hooks/useDebounce';
 
 interface ItemSelectorProps {
   slot?: string;
@@ -44,14 +45,15 @@ export function ItemSelector({ slot, onSelectItem }: ItemSelectorProps) {
   }, [initData]);
 
   const [searchTerm, setSearchTerm] = useState('');
+  const debouncedSearch = useDebounce(searchTerm, 300);
 
   const {
     data: searchResults,
     isLoading,
   } = useQuery({
-    queryKey: ['item-search', searchTerm],
-    queryFn: () => itemsApi.searchItems(searchTerm),
-    enabled: searchTerm.length > 0,
+    queryKey: ['item-search', debouncedSearch],
+    queryFn: () => itemsApi.searchItems(debouncedSearch),
+    enabled: debouncedSearch.length > 0,
     staleTime: Infinity,
     onSuccess: (d) => addItems(d),
   });

--- a/frontend/src/components/features/simulation/MultiBossSimulation.tsx
+++ b/frontend/src/components/features/simulation/MultiBossSimulation.tsx
@@ -35,6 +35,7 @@ import {
 import { bossesApi, calculatorApi } from '@/services/api';
 import { useCalculatorStore } from '@/store/calculator-store';
 import { useReferenceDataStore } from '@/store/reference-data-store';
+import { useDebounce } from '@/hooks/useDebounce';
 import {
   Boss,
   BossForm,
@@ -60,6 +61,7 @@ export function MultiBossSimulation() {
   const [raidConfig, setRaidConfig] = useState<RaidScalingConfig>({ teamSize: 1 });
   const [results, setResults] = useState<SimulationEntry[]>([]);
   const [searchTerm, setSearchTerm] = useState('');
+  const debouncedSearch = useDebounce(searchTerm, 300);
   const [open, setOpen] = useState(false);
   const [isRunning, setIsRunning] = useState(false);
   const storeBosses = useReferenceDataStore((s) => s.bosses);
@@ -82,9 +84,9 @@ export function MultiBossSimulation() {
   }, [storeBosses]);
 
   const { data: searchResults, isLoading } = useQuery({
-    queryKey: ['sim-boss-search', searchTerm],
-    queryFn: () => bossesApi.searchBosses(searchTerm, 50),
-    enabled: searchTerm.length > 0,
+    queryKey: ['sim-boss-search', debouncedSearch],
+    queryFn: () => bossesApi.searchBosses(debouncedSearch, 50),
+    enabled: debouncedSearch.length > 0,
     staleTime: Infinity,
     onSuccess: (d) => addBosses(d),
   });

--- a/frontend/src/hooks/useDebounce.ts
+++ b/frontend/src/hooks/useDebounce.ts
@@ -1,0 +1,14 @@
+import { useState, useEffect } from 'react';
+
+export function useDebounce<T>(value: T, delay = 300): T {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const handler = setTimeout(() => setDebouncedValue(value), delay);
+    return () => {
+      clearTimeout(handler);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+}


### PR DESCRIPTION
## Summary
- delay API calls until user pauses typing by introducing `useDebounce` hook
- apply debounced search to boss, item and simulation selectors
- install dependencies and run backend unit tests

## Testing
- `python -m unittest discover backend/app/testing`

------
https://chatgpt.com/codex/tasks/task_e_684919307dc0832eb515b6eace3a819e