### PR TITLE
Add NPC forms migration

### DIFF
--- a/webscraper/migrate_bossforms_to_azure.py
+++ b/webscraper/migrate_bossforms_to_azure.py
@@ -19,6 +19,7 @@ AZURE_SQL_CONNECTION = (
 
 # SQLite database file paths
 SQLITE_BOSSES_DB = "osrs_bosses.db"
+SQLITE_NPCS_DB = "osrs_npcs.db"
 
 def test_azure_connection():
     """Test connection to Azure SQL Database using Entra ID"""
@@ -67,35 +68,59 @@ def check_boss_forms_status():
         print(f"✗ Error checking status: {e}")
         return 0, 0
 
+def check_npc_forms_status():
+    """Check current status of NPC forms migration"""
+    try:
+        print("Checking NPC forms migration status...")
+
+        sqlite_conn = sqlite3.connect(SQLITE_NPCS_DB)
+        sqlite_cursor = sqlite_conn.cursor()
+
+        azure_conn = pyodbc.connect(AZURE_SQL_CONNECTION)
+        azure_cursor = azure_conn.cursor()
+
+        sqlite_cursor.execute("SELECT COUNT(*) FROM npc_forms")
+        sqlite_count = sqlite_cursor.fetchone()[0]
+
+        azure_cursor.execute("SELECT COUNT(*) FROM npc_forms")
+        azure_count = azure_cursor.fetchone()[0]
+
+        print(f"SQLite npc_forms: {sqlite_count} records")
+        print(f"Azure SQL npc_forms: {azure_count} records")
+
+        sqlite_conn.close()
+        azure_conn.close()
+
+        return sqlite_count, azure_count
+
+    except Exception as e:
+        print(f"✗ Error checking NPC forms status: {e}")
+        return 0, 0
+
 def migrate_boss_forms_standalone():
     """Migrate boss forms from SQLite to Azure SQL (standalone function)"""
     try:
         print("Starting boss forms migration...")
-        
+
         # Check if SQLite file exists
         if not os.path.exists(SQLITE_BOSSES_DB):
             print(f"✗ SQLite file not found: {SQLITE_BOSSES_DB}")
             return False
-            
+
         # Connect to SQLite
         sqlite_conn = sqlite3.connect(SQLITE_BOSSES_DB)
         sqlite_cursor = sqlite_conn.cursor()
-        
+
         # Connect to Azure SQL
         azure_conn = pyodbc.connect(AZURE_SQL_CONNECTION)
         azure_cursor = azure_conn.cursor()
         
-        # Clear existing boss_forms data in Azure SQL (in case of partial migration)
-        print("Clearing existing boss_forms data in Azure SQL...")
-        azure_cursor.execute("DELETE FROM boss_forms")
-        azure_conn.commit()
-        
         # Get boss forms from SQLite
         sqlite_cursor.execute("SELECT * FROM boss_forms")
         forms = sqlite_cursor.fetchall()
-        
+
         print(f"Found {len(forms)} boss forms to migrate")
-        
+
         if len(forms) == 0:
             print("No boss forms found in SQLite database")
             return True
@@ -134,6 +159,14 @@ def migrate_boss_forms_standalone():
                 
             new_boss_id = azure_result[0]
             
+            # Skip duplicate boss forms
+            azure_cursor.execute(
+                "SELECT 1 FROM boss_forms WHERE boss_id = ? AND form_name = ?",
+                (new_boss_id, form[2]),
+            )
+            if azure_cursor.fetchone():
+                continue
+
             # Replace the boss_id in the form data
             form_data = list(form[1:])  # Skip SQLite ID
             form_data[0] = new_boss_id  # Replace boss_id with new Azure SQL boss_id
@@ -167,6 +200,98 @@ def migrate_boss_forms_standalone():
         print(f"✗ Error migrating boss forms: {e}")
         return False
 
+def migrate_npc_forms_standalone():
+    """Migrate NPC forms from SQLite to Azure SQL"""
+    try:
+        print("Starting NPC forms migration...")
+
+        if not os.path.exists(SQLITE_NPCS_DB):
+            print(f"✗ SQLite file not found: {SQLITE_NPCS_DB}")
+            return False
+
+        sqlite_conn = sqlite3.connect(SQLITE_NPCS_DB)
+        sqlite_cursor = sqlite_conn.cursor()
+
+        azure_conn = pyodbc.connect(AZURE_SQL_CONNECTION)
+        azure_cursor = azure_conn.cursor()
+
+        sqlite_cursor.execute("SELECT * FROM npc_forms")
+        forms = sqlite_cursor.fetchall()
+
+        print(f"Found {len(forms)} NPC forms to migrate")
+
+        if len(forms) == 0:
+            print("No NPC forms found in SQLite database")
+            return True
+
+        sqlite_cursor.execute("PRAGMA table_info(npc_forms)")
+        columns = [col[1] for col in sqlite_cursor.fetchall()][1:]
+
+        print(f"Columns to migrate: {columns}")
+
+        form_count = 0
+        failed_count = 0
+
+        for form in forms:
+            old_npc_id = form[1]
+
+            sqlite_cursor.execute("SELECT name FROM npcs WHERE id = ?", (old_npc_id,))
+            npc_result = sqlite_cursor.fetchone()
+
+            if not npc_result:
+                print(f"Warning: NPC with ID {old_npc_id} not found in SQLite")
+                failed_count += 1
+                continue
+
+            npc_name = npc_result[0]
+
+            azure_cursor.execute("SELECT id FROM npcs WHERE name = ?", (npc_name,))
+            azure_result = azure_cursor.fetchone()
+
+            if not azure_result:
+                print(f"Warning: NPC '{npc_name}' not found in Azure SQL")
+                failed_count += 1
+                continue
+
+            new_npc_id = azure_result[0]
+
+            azure_cursor.execute(
+                "SELECT 1 FROM npc_forms WHERE npc_id = ? AND form_name = ?",
+                (new_npc_id, form[2]),
+            )
+            if azure_cursor.fetchone():
+                continue
+
+            form_data = list(form[1:])
+            form_data[0] = new_npc_id
+
+            placeholders = ', '.join(['?' for _ in range(len(columns))])
+            insert_columns = ', '.join(columns)
+            query = f"INSERT INTO npc_forms ({insert_columns}) VALUES ({placeholders})"
+
+            try:
+                azure_cursor.execute(query, form_data)
+                form_count += 1
+                if form_count % 10 == 0:
+                    print(f"  Migrated {form_count} NPC forms...")
+            except Exception as e:
+                print(f"✗ Failed to migrate form for NPC '{npc_name}': {e}")
+                failed_count += 1
+
+        azure_conn.commit()
+
+        print("✓ NPC forms migration completed!")
+        print(f"  Successfully migrated: {form_count} NPC forms")
+        print(f"  Failed: {failed_count} NPC forms")
+
+        sqlite_conn.close()
+        azure_conn.close()
+        return True
+
+    except Exception as e:
+        print(f"✗ Error migrating NPC forms: {e}")
+        return False
+
 def verify_migration():
     """Verify the migration was successful"""
     try:
@@ -176,7 +301,7 @@ def verify_migration():
         azure_conn = pyodbc.connect(AZURE_SQL_CONNECTION)
         azure_cursor = azure_conn.cursor()
         
-        # Get some sample data
+        # Get some sample boss form data
         azure_cursor.execute("""
             SELECT TOP 5 
                 bf.form_name, 
@@ -187,15 +312,36 @@ def verify_migration():
             JOIN bosses b ON bf.boss_id = b.id
             ORDER BY b.name
         """)
-        
+
         results = azure_cursor.fetchall()
-        
+
         if results:
             print("✓ Sample migrated data:")
             for row in results:
                 print(f"  {row[1]} - {row[0]} (Level: {row[2]}, HP: {row[3]})")
         else:
             print("✗ No data found in boss_forms table")
+
+        # Get some sample NPC form data
+        azure_cursor.execute("""
+            SELECT TOP 5
+                nf.form_name,
+                n.name as npc_name,
+                nf.combat_level,
+                nf.hitpoints
+            FROM npc_forms nf
+            JOIN npcs n ON nf.npc_id = n.id
+            ORDER BY n.name
+        """)
+
+        npc_results = azure_cursor.fetchall()
+
+        if npc_results:
+            print("\n✓ Sample NPC form data:")
+            for row in npc_results:
+                print(f"  {row[1]} - {row[0]} (Level: {row[2]}, HP: {row[3]})")
+        else:
+            print("\n✗ No data found in npc_forms table")
         
         azure_conn.close()
         
@@ -214,19 +360,32 @@ def main():
     
     # Check current status
     sqlite_count, azure_count = check_boss_forms_status()
-    
-    if azure_count > 0:
-        response = input(f"\nAzure SQL already has {azure_count} boss forms. Continue and replace them? (y/n): ")
+    npc_sqlite_count, npc_azure_count = check_npc_forms_status()
+
+    if azure_count > 0 or npc_azure_count > 0:
+        response = input(
+            f"\nAzure SQL already has {azure_count} boss forms and {npc_azure_count} NPC forms. Continue and replace them? (y/n): "
+        )
         if response.lower() != 'y':
             print("Migration cancelled.")
             return
     
     # Migrate boss forms
-    if migrate_boss_forms_standalone():
+    boss_success = migrate_boss_forms_standalone()
+    if boss_success:
         print("✓ Boss forms migration completed successfully!")
-        verify_migration()
     else:
         print("✗ Boss forms migration failed")
+
+    # Migrate NPC forms
+    npc_success = migrate_npc_forms_standalone()
+    if npc_success:
+        print("✓ NPC forms migration completed successfully!")
+    else:
+        print("✗ NPC forms migration failed")
+
+    if boss_success or npc_success:
+        verify_migration()
     
     print("\n" + "=" * 50)
     print("Migration process completed!")

--- a/webscraper/migrate_sql_to_azure.py
+++ b/webscraper/migrate_sql_to_azure.py
@@ -20,6 +20,7 @@ AZURE_SQL_CONNECTION = (
 # SQLite database file paths
 SQLITE_BOSSES_DB = "osrs_bosses.db"
 SQLITE_ITEMS_DB = "osrs_combat_items.db"  # Using combat items DB
+SQLITE_NPCS_DB = "osrs_npcs.db"
 
 def test_azure_connection():
     """Test connection to Azure SQL Database using Entra ID"""
@@ -117,6 +118,79 @@ def create_tables():
                 FOREIGN KEY (boss_id) REFERENCES bosses(id)
             )
         """)
+
+        # Create npcs table
+        cursor.execute("""
+            IF NOT EXISTS (SELECT * FROM sysobjects WHERE name='npcs' AND xtype='U')
+            CREATE TABLE npcs (
+                id INT IDENTITY(1,1) PRIMARY KEY,
+                name NVARCHAR(255) NOT NULL UNIQUE,
+                raid_group NVARCHAR(255),
+                examine NVARCHAR(MAX),
+                release_date NVARCHAR(100),
+                location NVARCHAR(255),
+                slayer_level INT,
+                slayer_xp INT,
+                slayer_category NVARCHAR(100),
+                wiki_url NVARCHAR(255),
+                has_multiple_forms BIT,
+                raw_html NVARCHAR(MAX),
+                last_updated DATETIME
+            )
+        """)
+
+        # Create npc_forms table
+        cursor.execute("""
+            IF NOT EXISTS (SELECT * FROM sysobjects WHERE name='npc_forms' AND xtype='U')
+            CREATE TABLE npc_forms (
+                id INT IDENTITY(1,1) PRIMARY KEY,
+                npc_id INT NOT NULL,
+                form_name NVARCHAR(255),
+                form_order INT,
+                combat_level INT,
+                hitpoints INT,
+                max_hit NVARCHAR(255),
+                attack_speed INT,
+                attack_style NVARCHAR(255),
+                attack_level INT,
+                strength_level INT,
+                defence_level INT,
+                magic_level INT,
+                ranged_level INT,
+                aggressive_attack_bonus INT,
+                aggressive_strength_bonus INT,
+                aggressive_magic_bonus INT,
+                aggressive_magic_strength_bonus INT,
+                aggressive_ranged_bonus INT,
+                aggressive_ranged_strength_bonus INT,
+                defence_stab INT,
+                defence_slash INT,
+                defence_crush INT,
+                defence_magic INT,
+                elemental_weakness_type NVARCHAR(100),
+                elemental_weakness_percent NVARCHAR(100),
+                defence_ranged_light INT,
+                defence_ranged_standard INT,
+                defence_ranged_heavy INT,
+                attribute NVARCHAR(255),
+                xp_bonus NVARCHAR(100),
+                aggressive BIT,
+                poisonous BIT,
+                poison_immunity BIT,
+                venom_immunity BIT,
+                melee_immunity BIT,
+                magic_immunity BIT,
+                ranged_immunity BIT,
+                cannon_immunity BIT,
+                thrall_immunity BIT,
+                special_mechanics NVARCHAR(MAX),
+                image_url NVARCHAR(500),
+                icons NVARCHAR(MAX),
+                size INT,
+                assigned_by NVARCHAR(255),
+                FOREIGN KEY (npc_id) REFERENCES npcs(id)
+            )
+        """)
         
         # Create items table  
         cursor.execute("""
@@ -177,12 +251,17 @@ def migrate_bosses():
         boss_count = 0
         for boss in bosses:
             boss_data = boss[1:]  # Skip the SQLite ID
-            
-            # Create parameterized query
+
+            # Skip duplicate bosses
+            azure_cursor.execute("SELECT 1 FROM bosses WHERE name = ?", (boss[1],))
+            if azure_cursor.fetchone():
+                print(f"• Boss {boss[1]} already exists, skipping")
+                continue
+
             placeholders = ', '.join(['?' for _ in range(len(columns))])
             insert_columns = ', '.join(columns)
             query = f"INSERT INTO bosses ({insert_columns}) VALUES ({placeholders})"
-            
+
             try:
                 azure_cursor.execute(query, boss_data)
                 boss_count += 1
@@ -190,13 +269,13 @@ def migrate_bosses():
                     print(f"  Migrated {boss_count} bosses...")
             except Exception as e:
                 print(f"✗ Failed to migrate boss {boss[1]}: {e}")
-        
-        azure_conn.commit()
+
         print(f"✓ Migrated {boss_count} bosses successfully!")
-        
+
         # Now migrate boss forms
         migrate_boss_forms(sqlite_cursor, azure_cursor)
-        
+
+        azure_conn.commit()
         sqlite_conn.close()
         azure_conn.close()
         return True
@@ -240,8 +319,15 @@ def migrate_boss_forms(sqlite_cursor, azure_cursor):
                 continue
                 
             new_boss_id = azure_result[0]
-            
-            # Replace the boss_id in the form data
+
+            # Skip duplicate forms
+            azure_cursor.execute(
+                "SELECT 1 FROM boss_forms WHERE boss_id = ? AND form_name = ?",
+                (new_boss_id, form[2]),
+            )
+            if azure_cursor.fetchone():
+                continue
+
             form_data = list(form[1:])  # Skip SQLite ID
             form_data[0] = new_boss_id  # Replace boss_id
             
@@ -314,10 +400,125 @@ def migrate_items():
         
         print(f"✓ Migrated {item_count} items successfully!")
         return True
-        
+
     except Exception as e:
         print(f"✗ Error migrating items: {e}")
         return False
+
+def migrate_npcs():
+    """Migrate NPCs from SQLite to Azure SQL"""
+    try:
+        print("Migrating NPCs...")
+
+        if not os.path.exists(SQLITE_NPCS_DB):
+            print(f"✗ SQLite file not found: {SQLITE_NPCS_DB}")
+            return False
+
+        sqlite_conn = sqlite3.connect(SQLITE_NPCS_DB)
+        sqlite_cursor = sqlite_conn.cursor()
+
+        azure_conn = pyodbc.connect(AZURE_SQL_CONNECTION)
+        azure_cursor = azure_conn.cursor()
+
+        sqlite_cursor.execute("SELECT * FROM npcs")
+        npcs = sqlite_cursor.fetchall()
+
+        print(f"Found {len(npcs)} NPCs to migrate")
+
+        sqlite_cursor.execute("PRAGMA table_info(npcs)")
+        columns = [col[1] for col in sqlite_cursor.fetchall()][1:]
+
+        npc_count = 0
+        for npc in npcs:
+            npc_data = npc[1:]
+
+            azure_cursor.execute("SELECT 1 FROM npcs WHERE name = ?", (npc[1],))
+            if azure_cursor.fetchone():
+                print(f"• NPC {npc[1]} already exists, skipping")
+                continue
+
+            placeholders = ', '.join(['?' for _ in range(len(columns))])
+            insert_columns = ', '.join(columns)
+            query = f"INSERT INTO npcs ({insert_columns}) VALUES ({placeholders})"
+
+            try:
+                azure_cursor.execute(query, npc_data)
+                npc_count += 1
+                if npc_count % 50 == 0:
+                    print(f"  Migrated {npc_count} NPCs...")
+            except Exception as e:
+                print(f"✗ Failed to migrate NPC {npc[1]}: {e}")
+
+        print(f"✓ Migrated {npc_count} NPCs successfully!")
+
+        migrate_npc_forms(sqlite_cursor, azure_cursor)
+
+        azure_conn.commit()
+        azure_conn.close()
+        sqlite_conn.close()
+        return True
+
+    except Exception as e:
+        print(f"✗ Error migrating NPCs: {e}")
+        return False
+
+def migrate_npc_forms(sqlite_cursor, azure_cursor):
+    """Migrate NPC forms"""
+    try:
+        print("Migrating NPC forms...")
+
+        sqlite_cursor.execute("SELECT * FROM npc_forms")
+        forms = sqlite_cursor.fetchall()
+
+        print(f"Found {len(forms)} NPC forms to migrate")
+
+        sqlite_cursor.execute("PRAGMA table_info(npc_forms)")
+        columns = [col[1] for col in sqlite_cursor.fetchall()][1:]
+
+        form_count = 0
+        for form in forms:
+            old_npc_id = form[1]
+
+            sqlite_cursor.execute("SELECT name FROM npcs WHERE id = ?", (old_npc_id,))
+            npc_result = sqlite_cursor.fetchone()
+            if not npc_result:
+                continue
+
+            npc_name = npc_result[0]
+
+            azure_cursor.execute("SELECT id FROM npcs WHERE name = ?", (npc_name,))
+            azure_result = azure_cursor.fetchone()
+            if not azure_result:
+                continue
+
+            new_npc_id = azure_result[0]
+
+            azure_cursor.execute(
+                "SELECT 1 FROM npc_forms WHERE npc_id = ? AND form_name = ?",
+                (new_npc_id, form[2]),
+            )
+            if azure_cursor.fetchone():
+                continue
+
+            form_data = list(form[1:])
+            form_data[0] = new_npc_id
+
+            placeholders = ', '.join(['?' for _ in range(len(columns))])
+            insert_columns = ', '.join(columns)
+            query = f"INSERT INTO npc_forms ({insert_columns}) VALUES ({placeholders})"
+
+            try:
+                azure_cursor.execute(query, form_data)
+                form_count += 1
+                if form_count % 50 == 0:
+                    print(f"  Migrated {form_count} NPC forms...")
+            except Exception as e:
+                print(f"✗ Failed to migrate form {form[2]}: {e}")
+
+        print(f"✓ Migrated {form_count} NPC forms successfully!")
+
+    except Exception as e:
+        print(f"✗ Error migrating NPC forms: {e}")
 
 def main():
     """Main migration function"""
@@ -349,12 +550,18 @@ def main():
         print("✓ Boss migration completed")
     else:
         print("✗ Boss migration failed")
-    
+
     # Migrate items
     if migrate_items():
         print("✓ Item migration completed")
     else:
         print("✗ Item migration failed")
+
+    # Migrate NPCs
+    if migrate_npcs():
+        print("✓ NPC migration completed")
+    else:
+        print("✗ NPC migration failed")
     
     print("\n" + "=" * 50)
     print("Migration completed!")

--- a/webscraper/runescape-items/migrate_sql_to_azure.py
+++ b/webscraper/runescape-items/migrate_sql_to_azure.py
@@ -20,6 +20,7 @@ AZURE_SQL_CONNECTION = (
 # SQLite database file paths
 SQLITE_BOSSES_DB = "osrs_bosses.db"
 SQLITE_ITEMS_DB = "osrs_combat_items.db"  # Using combat items DB
+SQLITE_NPCS_DB = "osrs_npcs.db"
 
 def test_azure_connection():
     """Test connection to Azure SQL Database using Entra ID"""
@@ -117,6 +118,79 @@ def create_tables():
                 FOREIGN KEY (boss_id) REFERENCES bosses(id)
             )
         """)
+
+        # Create npcs table
+        cursor.execute("""
+            IF NOT EXISTS (SELECT * FROM sysobjects WHERE name='npcs' AND xtype='U')
+            CREATE TABLE npcs (
+                id INT IDENTITY(1,1) PRIMARY KEY,
+                name NVARCHAR(255) NOT NULL UNIQUE,
+                raid_group NVARCHAR(255),
+                examine NVARCHAR(MAX),
+                release_date NVARCHAR(100),
+                location NVARCHAR(255),
+                slayer_level INT,
+                slayer_xp INT,
+                slayer_category NVARCHAR(100),
+                wiki_url NVARCHAR(255),
+                has_multiple_forms BIT,
+                raw_html NVARCHAR(MAX),
+                last_updated DATETIME
+            )
+        """)
+
+        # Create npc_forms table
+        cursor.execute("""
+            IF NOT EXISTS (SELECT * FROM sysobjects WHERE name='npc_forms' AND xtype='U')
+            CREATE TABLE npc_forms (
+                id INT IDENTITY(1,1) PRIMARY KEY,
+                npc_id INT NOT NULL,
+                form_name NVARCHAR(255),
+                form_order INT,
+                combat_level INT,
+                hitpoints INT,
+                max_hit NVARCHAR(255),
+                attack_speed INT,
+                attack_style NVARCHAR(255),
+                attack_level INT,
+                strength_level INT,
+                defence_level INT,
+                magic_level INT,
+                ranged_level INT,
+                aggressive_attack_bonus INT,
+                aggressive_strength_bonus INT,
+                aggressive_magic_bonus INT,
+                aggressive_magic_strength_bonus INT,
+                aggressive_ranged_bonus INT,
+                aggressive_ranged_strength_bonus INT,
+                defence_stab INT,
+                defence_slash INT,
+                defence_crush INT,
+                defence_magic INT,
+                elemental_weakness_type NVARCHAR(100),
+                elemental_weakness_percent NVARCHAR(100),
+                defence_ranged_light INT,
+                defence_ranged_standard INT,
+                defence_ranged_heavy INT,
+                attribute NVARCHAR(255),
+                xp_bonus NVARCHAR(100),
+                aggressive BIT,
+                poisonous BIT,
+                poison_immunity BIT,
+                venom_immunity BIT,
+                melee_immunity BIT,
+                magic_immunity BIT,
+                ranged_immunity BIT,
+                cannon_immunity BIT,
+                thrall_immunity BIT,
+                special_mechanics NVARCHAR(MAX),
+                image_url NVARCHAR(500),
+                icons NVARCHAR(MAX),
+                size INT,
+                assigned_by NVARCHAR(255),
+                FOREIGN KEY (npc_id) REFERENCES npcs(id)
+            )
+        """)
         
         # Create items table  
         cursor.execute("""
@@ -177,12 +251,16 @@ def migrate_bosses():
         boss_count = 0
         for boss in bosses:
             boss_data = boss[1:]  # Skip the SQLite ID
-            
-            # Create parameterized query
+
+            azure_cursor.execute("SELECT 1 FROM bosses WHERE name = ?", (boss[1],))
+            if azure_cursor.fetchone():
+                print(f"• Boss {boss[1]} already exists, skipping")
+                continue
+
             placeholders = ', '.join(['?' for _ in range(len(columns))])
             insert_columns = ', '.join(columns)
             query = f"INSERT INTO bosses ({insert_columns}) VALUES ({placeholders})"
-            
+
             try:
                 azure_cursor.execute(query, boss_data)
                 boss_count += 1
@@ -190,13 +268,12 @@ def migrate_bosses():
                     print(f"  Migrated {boss_count} bosses...")
             except Exception as e:
                 print(f"✗ Failed to migrate boss {boss[1]}: {e}")
-        
-        azure_conn.commit()
+
         print(f"✓ Migrated {boss_count} bosses successfully!")
-        
-        # Now migrate boss forms
+
         migrate_boss_forms(sqlite_cursor, azure_cursor)
-        
+
+        azure_conn.commit()
         sqlite_conn.close()
         azure_conn.close()
         return True
@@ -240,8 +317,14 @@ def migrate_boss_forms(sqlite_cursor, azure_cursor):
                 continue
                 
             new_boss_id = azure_result[0]
-            
-            # Replace the boss_id in the form data
+
+            azure_cursor.execute(
+                "SELECT 1 FROM boss_forms WHERE boss_id = ? AND form_name = ?",
+                (new_boss_id, form[2]),
+            )
+            if azure_cursor.fetchone():
+                continue
+
             form_data = list(form[1:])  # Skip SQLite ID
             form_data[0] = new_boss_id  # Replace boss_id
             
@@ -319,6 +402,121 @@ def migrate_items():
         print(f"✗ Error migrating items: {e}")
         return False
 
+def migrate_npcs():
+    """Migrate NPCs from SQLite to Azure SQL"""
+    try:
+        print("Migrating NPCs...")
+
+        if not os.path.exists(SQLITE_NPCS_DB):
+            print(f"✗ SQLite file not found: {SQLITE_NPCS_DB}")
+            return False
+
+        sqlite_conn = sqlite3.connect(SQLITE_NPCS_DB)
+        sqlite_cursor = sqlite_conn.cursor()
+
+        azure_conn = pyodbc.connect(AZURE_SQL_CONNECTION)
+        azure_cursor = azure_conn.cursor()
+
+        sqlite_cursor.execute("SELECT * FROM npcs")
+        npcs = sqlite_cursor.fetchall()
+
+        print(f"Found {len(npcs)} NPCs to migrate")
+
+        sqlite_cursor.execute("PRAGMA table_info(npcs)")
+        columns = [col[1] for col in sqlite_cursor.fetchall()][1:]
+
+        npc_count = 0
+        for npc in npcs:
+            npc_data = npc[1:]
+
+            azure_cursor.execute("SELECT 1 FROM npcs WHERE name = ?", (npc[1],))
+            if azure_cursor.fetchone():
+                print(f"• NPC {npc[1]} already exists, skipping")
+                continue
+
+            placeholders = ', '.join(['?' for _ in range(len(columns))])
+            insert_columns = ', '.join(columns)
+            query = f"INSERT INTO npcs ({insert_columns}) VALUES ({placeholders})"
+
+            try:
+                azure_cursor.execute(query, npc_data)
+                npc_count += 1
+                if npc_count % 50 == 0:
+                    print(f"  Migrated {npc_count} NPCs...")
+            except Exception as e:
+                print(f"✗ Failed to migrate NPC {npc[1]}: {e}")
+
+        print(f"✓ Migrated {npc_count} NPCs successfully!")
+
+        migrate_npc_forms(sqlite_cursor, azure_cursor)
+
+        azure_conn.commit()
+        azure_conn.close()
+        sqlite_conn.close()
+        return True
+
+    except Exception as e:
+        print(f"✗ Error migrating NPCs: {e}")
+        return False
+
+def migrate_npc_forms(sqlite_cursor, azure_cursor):
+    """Migrate NPC forms"""
+    try:
+        print("Migrating NPC forms...")
+
+        sqlite_cursor.execute("SELECT * FROM npc_forms")
+        forms = sqlite_cursor.fetchall()
+
+        print(f"Found {len(forms)} NPC forms to migrate")
+
+        sqlite_cursor.execute("PRAGMA table_info(npc_forms)")
+        columns = [col[1] for col in sqlite_cursor.fetchall()][1:]
+
+        form_count = 0
+        for form in forms:
+            old_npc_id = form[1]
+
+            sqlite_cursor.execute("SELECT name FROM npcs WHERE id = ?", (old_npc_id,))
+            npc_result = sqlite_cursor.fetchone()
+            if not npc_result:
+                continue
+
+            npc_name = npc_result[0]
+
+            azure_cursor.execute("SELECT id FROM npcs WHERE name = ?", (npc_name,))
+            azure_result = azure_cursor.fetchone()
+            if not azure_result:
+                continue
+
+            new_npc_id = azure_result[0]
+
+            azure_cursor.execute(
+                "SELECT 1 FROM npc_forms WHERE npc_id = ? AND form_name = ?",
+                (new_npc_id, form[2]),
+            )
+            if azure_cursor.fetchone():
+                continue
+
+            form_data = list(form[1:])
+            form_data[0] = new_npc_id
+
+            placeholders = ', '.join(['?' for _ in range(len(columns))])
+            insert_columns = ', '.join(columns)
+            query = f"INSERT INTO npc_forms ({insert_columns}) VALUES ({placeholders})"
+
+            try:
+                azure_cursor.execute(query, form_data)
+                form_count += 1
+                if form_count % 50 == 0:
+                    print(f"  Migrated {form_count} NPC forms...")
+            except Exception as e:
+                print(f"✗ Failed to migrate form {form[2]}: {e}")
+
+        print(f"✓ Migrated {form_count} NPC forms successfully!")
+
+    except Exception as e:
+        print(f"✗ Error migrating NPC forms: {e}")
+
 def main():
     """Main migration function"""
     print("=" * 50)
@@ -349,12 +547,18 @@ def main():
         print("✓ Boss migration completed")
     else:
         print("✗ Boss migration failed")
-    
+
     # Migrate items
     if migrate_items():
         print("✓ Item migration completed")
     else:
         print("✗ Item migration failed")
+
+    # Migrate NPCs
+    if migrate_npcs():
+        print("✓ NPC migration completed")
+    else:
+        print("✗ NPC migration failed")
     
     print("\n" + "=" * 50)
     print("Migration completed!")


### PR DESCRIPTION
## Summary
- support NPC forms migration in the standalone uploader
- show counts for NPC forms before migrating
- verify boss and NPC form data after upload

## Testing
- `python -m py_compile webscraper/migrate_sql_to_azure.py webscraper/runescape-items/migrate_sql_to_azure.py webscraper/migrate_bossforms_to_azure.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_684915d513f8832ead9d4cf47900e1a3