### PR TITLE
Fix special attack weapon stat calculations

### DIFF
--- a/frontend/src/components/features/calculator/CombatStatsSummary.tsx
+++ b/frontend/src/components/features/calculator/CombatStatsSummary.tsx
@@ -22,7 +22,8 @@ export function CombatStatsSummary({
     magic: 0,
     ranged: 0,
   };
-  Object.values(loadout).forEach((item) => {
+  Object.entries(loadout).forEach(([slot, item]) => {
+    if (slot === 'spec') return;
     const def = item?.combat_stats?.defence_bonuses;
     if (!def) return;
     totalDefence.stab += def.stab || 0;

--- a/frontend/src/components/features/calculator/EquipmentLoadout.tsx
+++ b/frontend/src/components/features/calculator/EquipmentLoadout.tsx
@@ -296,8 +296,9 @@ export function EquipmentLoadout({ onEquipmentUpdate }: EquipmentLoadoutProps) {
       prayer: 0,
     };
 
-    // Loop through all equipped items
-    for (const item of Object.values(gear)) {
+    // Loop through all equipped items, ignoring the special attack weapon slot
+    for (const [slot, item] of Object.entries(gear)) {
+      if (slot === 'spec') continue;
       if (!item?.combat_stats) continue;
       if (process.env.NODE_ENV !== 'production') {
         console.debug(`[DEBUG] Adding stats from item: ${item.name}`);

--- a/frontend/src/components/features/calculator/PassiveEffectCalculator.tsx
+++ b/frontend/src/components/features/calculator/PassiveEffectCalculator.tsx
@@ -59,7 +59,9 @@ export function calculatePassiveEffectBonuses(
   const combatStyle = params.combat_style;
   
   // Check for equipped items
-  const equippedItems = Object.values(equipment).filter(item => item !== null) as Item[];
+  const equippedItems = Object.entries(equipment)
+    .filter(([slot, item]) => slot !== 'spec' && item !== null)
+    .map(([, item]) => item as Item);
   
   // Process each item for passive effects
   equippedItems.forEach(item => {

--- a/frontend/src/components/features/calculator/PassiveEffectsDisplay.tsx
+++ b/frontend/src/components/features/calculator/PassiveEffectsDisplay.tsx
@@ -50,16 +50,18 @@ export function PassiveEffectsDisplay({ loadout, target }: PassiveEffectsDisplay
     ];
 
     // Get equipped items with passive effects - enhanced detection
-    const itemsWithPassiveEffects = Object.values(loadout)
-      .filter(item => {
+    const itemsWithPassiveEffects = Object.entries(loadout)
+      .filter(([slot, item]) => {
+        if (slot === 'spec') return false;
         if (!item) return false;
-        
+
         // Check database flag OR known item names
-        return item.has_passive_effect || 
-              KNOWN_PASSIVE_ITEMS.some(keyword => 
+        return item.has_passive_effect ||
+              KNOWN_PASSIVE_ITEMS.some(keyword =>
                 item.name.toLowerCase().includes(keyword)
               );
-      }) as Item[];
+      })
+      .map(([, item]) => item) as Item[];
     
     if (process.env.NODE_ENV !== 'production') {
       console.log('[DEBUG] Items with passive effects:', itemsWithPassiveEffects);

--- a/frontend/src/hooks/useDpsCalculator.ts
+++ b/frontend/src/hooks/useDpsCalculator.ts
@@ -90,6 +90,21 @@ export function useDpsCalculator() {
         cleaned.target_magic_defence = Number(cleaned.target_magic_defence);
         cleaned.attack_speed = Number(cleaned.attack_speed);
       }
+      if (!cleaned.special_rotation) {
+        delete cleaned.special_rotation;
+      }
+      if (!cleaned.special_attack_cost) {
+        delete cleaned.special_attack_cost;
+      }
+      if (cleaned.special_multiplier === 1.0) {
+        delete cleaned.special_multiplier;
+      }
+      if (cleaned.special_accuracy_multiplier === 1.0) {
+        delete cleaned.special_accuracy_multiplier;
+      }
+      if (cleaned.special_hit_count === 1) {
+        delete cleaned.special_hit_count;
+      }
       return cleaned;
     },
     []
@@ -122,6 +137,11 @@ export function useDpsCalculator() {
       }
       if (specItem) {
         (clean as any).weapon_name = specItem.name.toLowerCase();
+        delete (clean as any).special_attack_cost;
+        delete (clean as any).special_multiplier;
+        delete (clean as any).special_accuracy_multiplier;
+        delete (clean as any).special_hit_count;
+        delete (clean as any).guaranteed_hit;
       }
     }
     calculateMutation.mutate(clean);


### PR DESCRIPTION
## Summary
- ignore special attack slot when tallying equipment totals
- ensure defence totals skip spec weapon
- prevent passive effect logic from using spec weapon
- improved sanitization of special attack parameters so spec weapon DPS is applied

## Testing
- `npm test` *(fails: jest not found)*
- `python -m unittest backend/app/testing/UnitTest.py` *(fails: ModuleNotFoundError: cachetools)*


------
https://chatgpt.com/codex/tasks/task_e_6849202d0bc4832e842981ab6a0c5eb3