### PR TITLE
Improve alt text for boss and item icons

### DIFF
--- a/frontend/src/__tests__/alt-text.test.tsx
+++ b/frontend/src/__tests__/alt-text.test.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { BossSelector } from '../components/features/calculator/BossSelector';
+import { ItemSelector } from '../components/features/calculator/ItemSelector';
+import { useCalculatorStore } from '../store/calculator-store';
+import { useReferenceDataStore } from '../store/reference-data-store';
+
+jest.mock('../services/api');
+
+const wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const client = new QueryClient();
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+};
+
+beforeAll(() => {
+  global.ResizeObserver = global.ResizeObserver || class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+  if (!HTMLElement.prototype.scrollIntoView) {
+    HTMLElement.prototype.scrollIntoView = function () {};
+  }
+});
+
+describe('image alt text', () => {
+  beforeEach(() => {
+    useCalculatorStore.setState({
+      selectedBoss: null,
+      selectedBossForm: null,
+    } as any);
+    useReferenceDataStore.setState({
+      bosses: [],
+      bossForms: {},
+      items: [],
+      initialized: true,
+      loading: false,
+      timestamp: 0,
+      initData: jest.fn(),
+      addBosses: jest.fn(),
+      addBossForms: jest.fn(),
+      addItems: jest.fn(),
+    });
+  });
+
+  it('renders boss icon with descriptive alt text', () => {
+    const boss = { id: 1, name: 'Zulrah', icon_url: '/zulrah.png' } as any;
+    useCalculatorStore.getState().setSelectedBoss(boss);
+    useReferenceDataStore.setState({ bosses: [boss], bossForms: { 1: [] } });
+
+    render(<BossSelector />, { wrapper });
+    expect(screen.getByAltText('Zulrah icon')).toBeInTheDocument();
+  });
+
+  it('renders item icon with descriptive alt text in list', async () => {
+    const item = {
+      id: 2,
+      name: 'Dragon scimitar',
+      icons: ['/dragon.png'],
+      slot: 'weapon',
+      has_special_attack: false,
+      has_passive_effect: false,
+    } as any;
+    useReferenceDataStore.setState({ items: [item] });
+
+    render(<ItemSelector />, { wrapper });
+    await userEvent.click(screen.getByRole('combobox'));
+    expect(screen.getByAltText('Dragon scimitar icon')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/features/calculator/BossSelector.tsx
+++ b/frontend/src/components/features/calculator/BossSelector.tsx
@@ -353,7 +353,7 @@ export function BossSelector({ onSelectBoss, onSelectForm }: BossSelectorProps) 
                 {selectedBoss && (
                   <img
                     src={bossIcons[selectedBoss.id]}
-                    alt="icon"
+                    alt={`${selectedBoss.name} icon`}
                     className="w-4 h-4 mr-2 inline-block"
                   />
                 )}
@@ -388,7 +388,7 @@ export function BossSelector({ onSelectBoss, onSelectForm }: BossSelectorProps) 
                         >
                           <img
                             src={bossIcons[boss.id]}
-                            alt="icon"
+                            alt={`${boss.name} icon`}
                             className="w-4 h-4 mr-2 inline-block"
                           />
                           {boss.name}
@@ -439,7 +439,7 @@ export function BossSelector({ onSelectBoss, onSelectForm }: BossSelectorProps) 
                     <SelectItem key={form.id} value={form.id.toString()}>
                       <img
                         src={form.icons?.[0]}
-                        alt="icon"
+                        alt={`${form.form_name} icon`}
                         className="w-4 h-4 mr-2 inline-block"
                       />
                       {form.form_name} (Combat Lvl: {form.combat_level || 'Unknown'})
@@ -462,7 +462,7 @@ export function BossSelector({ onSelectBoss, onSelectForm }: BossSelectorProps) 
             {(selectedForm.icons?.[0] || selectedForm.image_url) && (
               <img
                 src={selectedForm.icons?.[0] || selectedForm.image_url}
-                alt="icon"
+                alt={`${selectedForm.form_name} image`}
                 className="w-24 h-auto object-contain"
               />
             )}

--- a/frontend/src/components/features/calculator/DirectBossSelector.tsx
+++ b/frontend/src/components/features/calculator/DirectBossSelector.tsx
@@ -256,7 +256,7 @@ export function DirectBossSelector({ onSelectBoss, onSelectForm, className }: Di
             {selectedBoss && (
               <img
                 src={bossIcons[selectedBoss.id]}
-                alt="icon"
+                alt={`${selectedBoss.name} icon`}
                 className="w-5 h-5 absolute top-2 left-2"
               />
             )}
@@ -290,7 +290,7 @@ export function DirectBossSelector({ onSelectBoss, onSelectForm, className }: Di
                         >
                           <img
                             src={bossIcons[boss.id]}
-                            alt="icon"
+                            alt={`${boss.name} icon`}
                             className="w-4 h-4 mr-2 inline-block"
                           />
                           <span>{boss.name}</span>
@@ -359,7 +359,7 @@ export function DirectBossSelector({ onSelectBoss, onSelectForm, className }: Di
             {(selectedForm.icons?.[0] || selectedForm.image_url) && (
               <img
                 src={selectedForm.icons?.[0] || selectedForm.image_url}
-                alt="icon"
+                alt={`${selectedForm.form_name} image`}
                 className="w-28 h-auto mb-2 object-contain"
               />
             )}

--- a/frontend/src/components/features/calculator/ItemSelector.tsx
+++ b/frontend/src/components/features/calculator/ItemSelector.tsx
@@ -170,7 +170,7 @@ export function ItemSelector({ slot, specialOnly, onSelectItem }: ItemSelectorPr
                 {selectedItem && (
                   <img
                     src={selectedItem.icons?.[0] || (selectedItem as any)?.image_url}
-                    alt="icon"
+                    alt={`${selectedItem.name} icon`}
                     className="w-4 h-4 mr-2 inline-block"
                   />
                 )}
@@ -203,7 +203,7 @@ export function ItemSelector({ slot, specialOnly, onSelectItem }: ItemSelectorPr
                         >
                           <img
                             src={item.icons?.[0] || (item as any)?.image_url}
-                            alt="icon"
+                            alt={`${item.name} icon`}
                             className="w-4 h-4 mr-2 inline-block"
                           />
                           {item.name}

--- a/frontend/src/components/features/simulation/MultiBossSimulation.tsx
+++ b/frontend/src/components/features/simulation/MultiBossSimulation.tsx
@@ -276,7 +276,11 @@ export function MultiBossSimulation() {
                       filteredBosses.map((boss) => (
                         <CommandItem key={boss.id} value={boss.name} onSelect={() => addBoss(boss)}>
                           {bossIcons[boss.id] && (
-                            <img src={bossIcons[boss.id]} alt="icon" className="w-4 h-4 mr-2 inline-block" />
+                            <img
+                              src={bossIcons[boss.id]}
+                              alt={`${boss.name} icon`}
+                              className="w-4 h-4 mr-2 inline-block"
+                            />
                           )}
                           {boss.name}
                         </CommandItem>
@@ -321,7 +325,11 @@ export function MultiBossSimulation() {
                 <TableRow key={boss.id}>
                   <TableCell className="font-medium">
                     {bossIcons[boss.id] && (
-                      <img src={bossIcons[boss.id]} alt="icon" className="w-4 h-4 mr-1 inline-block" />
+                      <img
+                        src={bossIcons[boss.id]}
+                        alt={`${boss.name} icon`}
+                        className="w-4 h-4 mr-1 inline-block"
+                      />
                     )}
                     {boss.name}
                   </TableCell>


### PR DESCRIPTION
## Summary
- add descriptive alt attributes in simulation and selectors
- verify alt text via new test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684920e7af64832ea12134e0e3ac1102