### PR TITLE
Add not-found page and navigation tests

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -51,6 +51,7 @@
         "eslint-config-prettier": "^10.1.5",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
+        "next-router-mock": "^1.0.2",
         "prettier": "^3.5.3",
         "tailwindcss": "^4",
         "ts-jest": "^29.1.1",
@@ -9976,6 +9977,17 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-router-mock": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/next-router-mock/-/next-router-mock-1.0.2.tgz",
+      "integrity": "sha512-9bEA4Sytj1N6xp7UlE4L++QmuU2ZcNTs33Fx8ypNToMlIA7zEotNc0RP0POPP+C3PHWz61U66V6qRDqUg0b3Lg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "next": ">=10.0.0",
+        "react": ">=17.0.0"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -53,6 +53,7 @@
     "eslint-config-prettier": "^10.1.5",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
+    "next-router-mock": "^1.0.2",
     "prettier": "^3.5.3",
     "tailwindcss": "^4",
     "ts-jest": "^29.1.1",

--- a/frontend/src/__tests__/navigation.test.tsx
+++ b/frontend/src/__tests__/navigation.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react';
+import mockRouter from 'next-router-mock';
+import { usePathname } from 'next/navigation';
+import NotFound from '../app/not-found';
+
+jest.mock('next/navigation', () => require('next-router-mock/navigation'));
+
+function TestApp() {
+  const pathname = usePathname();
+  if (pathname === '/') {
+    return <div>home</div>;
+  }
+  return <NotFound />;
+}
+
+describe('app routing', () => {
+  it('renders 404 page for unknown routes', () => {
+    mockRouter.push('/does-not-exist');
+    render(<TestApp />);
+    expect(screen.getByRole('heading', { name: /page not found/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/not-found.tsx
+++ b/frontend/src/app/not-found.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect } from 'react';
+import { usePathname } from 'next/navigation';
+
+export default function NotFound() {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    // Optionally send this path to analytics service
+    console.warn('Page not found:', pathname);
+  }, [pathname]);
+
+  return (
+    <main id="main" className="container mx-auto py-8 px-4 text-center">
+      <h1 className="text-4xl font-bold mb-4">Page Not Found</h1>
+      <p className="text-muted-foreground mb-8">
+        Sorry, we couldn&apos;t find the page you were looking for.
+      </p>
+      <Link
+        href="/"
+        className="bg-primary text-primary-foreground hover:bg-primary/90 py-2 px-4 rounded"
+      >
+        Go back home
+      </Link>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add `not-found.tsx` page to Next.js app with return home link
- log unknown path for analytics
- include navigation test using `next-router-mock`
- add dependency `next-router-mock`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684920ecb740832eadb5bea1b4de8078