### PR TITLE
Add theme toggle with persistence

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -7,6 +7,7 @@ Select target bosses and their different forms/phases
 Choose equipment to automatically update stats
 View detailed results with max hit, hit chance, and DPS
 Modular component structure with custom hooks
+Light and dark theme toggle with saved preference
 
 Technologies Used
 
@@ -55,3 +56,7 @@ Components can be explored in Storybook:
 ```bash
 npm run storybook
 ```
+
+### Theme
+
+Use the sun/moon button in the header to switch between light and dark modes. Your choice is saved in localStorage so it persists between visits.

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Providers } from '@/app/providers';
 import { Navigation } from '@/components/layout/Navigation';
 import { Footer } from '@/components/layout/Footer';
 import { ReferenceDataBanner } from '@/components/layout/ReferenceDataBanner';
+import { ThemeToggle } from '@/components/theme/ThemeToggle';
 import './globals.css';
 import type { Metadata } from "next";
 
@@ -22,6 +23,9 @@ export default function RootLayout({
         <a href="#main" className="sr-only focus:not-sr-only absolute left-2 top-2 z-50 bg-primary text-primary-foreground px-2 py-1 rounded">Skip to content</a>
         <Providers>
           <Navigation />
+          <div className="absolute right-2 top-2 z-50">
+            <ThemeToggle />
+          </div>
           <ReferenceDataBanner />
           <div className="flex-grow mb-24"> {/* Added sufficient bottom margin to prevent footer overlap */}
             {children}

--- a/frontend/src/app/providers.tsx
+++ b/frontend/src/app/providers.tsx
@@ -4,12 +4,15 @@ import { ReactNode } from 'react';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { queryClient } from '@/lib/react-query';
 import { SonnerProvider } from '@/components/ui/sonner-provider';
+import { ThemeProvider } from '@/context/theme-context';
 
 export function Providers({ children }: { children: ReactNode }) {
   return (
-    <QueryClientProvider client={queryClient}>
-      {children}
-      <SonnerProvider />
-    </QueryClientProvider>
+    <ThemeProvider>
+      <QueryClientProvider client={queryClient}>
+        {children}
+        <SonnerProvider />
+      </QueryClientProvider>
+    </ThemeProvider>
   );
 }

--- a/frontend/src/components/theme/ThemeToggle.tsx
+++ b/frontend/src/components/theme/ThemeToggle.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import { Moon, Sun } from 'lucide-react';
+import { useTheme } from '@/context/theme-context';
+import { Button } from '@/components/ui/button';
+
+export function ThemeToggle() {
+  const { theme, toggleTheme } = useTheme();
+  const isDark = theme === 'dark';
+
+  return (
+    <Button variant="ghost" size="icon" aria-label="Toggle theme" onClick={toggleTheme}>
+      {isDark ? <Sun className="h-5 w-5" /> : <Moon className="h-5 w-5" />}
+    </Button>
+  );
+}

--- a/frontend/src/context/theme-context.tsx
+++ b/frontend/src/context/theme-context.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { createContext, useContext, useEffect, useState } from 'react';
+import { safeStorage } from '@/utils/safeStorage';
+
+export type Theme = 'light' | 'dark';
+
+interface ThemeContextValue {
+  theme: Theme;
+  toggleTheme: () => void;
+  setTheme: (theme: Theme) => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+const STORAGE_KEY = 'osrs-theme';
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setThemeState] = useState<Theme>('light');
+
+  useEffect(() => {
+    const stored = safeStorage.getItem(STORAGE_KEY) as Theme | null;
+    const initial = stored === 'dark' ? 'dark' : 'light';
+    setThemeState(initial);
+    document.documentElement.classList.toggle('dark', initial === 'dark');
+  }, []);
+
+  const applyTheme = (value: Theme) => {
+    safeStorage.setItem(STORAGE_KEY, value);
+    setThemeState(value);
+    document.documentElement.classList.toggle('dark', value === 'dark');
+  };
+
+  const toggleTheme = () => applyTheme(theme === 'light' ? 'dark' : 'light');
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme, setTheme: applyTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) throw new Error('useTheme must be used within ThemeProvider');
+  return ctx;
+}


### PR DESCRIPTION
## Summary
- add theme context using `safeStorage`
- expose theme provider in main app providers
- place a ThemeToggle button in the layout
- document theme support in the frontend README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684920f7e900832ebf6590f1661b879b