### PR TITLE
Improve API error handling and add tests

### DIFF
--- a/frontend/src/__tests__/api-wrappers.test.ts
+++ b/frontend/src/__tests__/api-wrappers.test.ts
@@ -1,0 +1,32 @@
+import { calculatorApi, itemsApi } from '../services/api';
+import axios from 'axios';
+
+jest.mock('axios', () => {
+  const post = jest.fn();
+  const get = jest.fn();
+  return {
+    __esModule: true,
+    default: { create: jest.fn(() => ({ post, get })) },
+    post,
+    get,
+  };
+});
+
+const mockedAxios: any = axios as any;
+
+beforeEach(() => {
+  mockedAxios.post.mockReset && mockedAxios.post.mockReset();
+  mockedAxios.get.mockReset && mockedAxios.get.mockReset();
+});
+
+describe('API wrapper error handling', () => {
+  it('returns structured error from calculateDps', async () => {
+    mockedAxios.post.mockRejectedValueOnce({ message: 'fail', response: { status: 500 } });
+    await expect(calculatorApi.calculateDps({} as any)).rejects.toEqual({ message: 'fail', status: 500 });
+  });
+
+  it('returns structured error from getItemById', async () => {
+    mockedAxios.get.mockRejectedValueOnce({ message: 'not found', response: { status: 404 } });
+    await expect(itemsApi.getItemById(1)).rejects.toEqual({ message: 'not found', status: 404 });
+  });
+});

--- a/frontend/src/components/features/calculator/BossSelector.tsx
+++ b/frontend/src/components/features/calculator/BossSelector.tsx
@@ -73,6 +73,7 @@ export function BossSelector({ onSelectBoss, onSelectForm }: BossSelectorProps) 
     enabled: debouncedSearch.length > 0,
     staleTime: Infinity,
     onSuccess: (d) => addBosses(d),
+    onError: (e: any) => toast.error(`Boss search failed: ${e.message}`),
   });
 
   // Fetch specific boss details when a boss is selected
@@ -82,6 +83,7 @@ export function BossSelector({ onSelectBoss, onSelectForm }: BossSelectorProps) 
     enabled: !!selectedBoss && !storeBossForms[selectedBoss!.id],
     staleTime: Infinity,
     onSuccess: (d) => addBossForms(d.id, d.forms || []),
+    onError: (e: any) => toast.error(`Failed to load boss: ${e.message}`),
   });
 
   const combinedBossDetails = selectedBoss

--- a/frontend/src/components/features/calculator/DirectBossSelector.tsx
+++ b/frontend/src/components/features/calculator/DirectBossSelector.tsx
@@ -66,6 +66,7 @@ export function DirectBossSelector({ onSelectBoss, onSelectForm, className }: Di
     enabled: debouncedQuery.length > 0,
     staleTime: Infinity,
     onSuccess: (d) => addBosses(d),
+    onError: (e: any) => toast.error(`Boss search failed: ${e.message}`),
   });
 
   // Fetch specific boss details when a boss is selected
@@ -75,6 +76,7 @@ export function DirectBossSelector({ onSelectBoss, onSelectForm, className }: Di
     enabled: !!selectedBoss && !storeBossForms[selectedBoss!.id],
     staleTime: Infinity,
     onSuccess: (d) => addBossForms(d.id, d.forms || []),
+    onError: (e: any) => toast.error(`Failed to load boss: ${e.message}`),
   });
 
   const combinedBossDetails = selectedBoss

--- a/frontend/src/components/features/calculator/EquipmentGrid.tsx
+++ b/frontend/src/components/features/calculator/EquipmentGrid.tsx
@@ -81,25 +81,30 @@ export function EquipmentGrid({ loadout, show2hOption, combatStyle, onUpdateLoad
       return;
     }
 
-    itemsApi.getItemById(item.id).then((fullItem) => {
-      if (slot !== 'spec' && (!fullItem || !fullItem.combat_stats)) {
-        toast.error(`Failed to load full stats for ${item.name}`);
-        return;
-      }
+    itemsApi
+      .getItemById(item.id)
+      .then((fullItem) => {
+        if (slot !== 'spec' && (!fullItem || !fullItem.combat_stats)) {
+          toast.error(`Failed to load full stats for ${item.name}`);
+          return;
+        }
 
-      if (slot === '2h') {
-        delete updated['mainhand'];
-        delete updated['offhand'];
-        updated['2h'] = fullItem;
-      } else {
-        if (slot === 'mainhand' || slot === 'offhand') delete updated['2h'];
-        updated[slot] = fullItem;
-      }
+        if (slot === '2h') {
+          delete updated['mainhand'];
+          delete updated['offhand'];
+          updated['2h'] = fullItem;
+        } else {
+          if (slot === 'mainhand' || slot === 'offhand') delete updated['2h'];
+          updated[slot] = fullItem;
+        }
 
-      onUpdateLoadout(updated);
-      toast.success(`Equipped ${fullItem.name}`);
-      setIsDialogOpen(false);
-    });
+        onUpdateLoadout(updated);
+        toast.success(`Equipped ${fullItem.name}`);
+        setIsDialogOpen(false);
+      })
+      .catch((e: any) => {
+        toast.error(`Failed to load item: ${e.message}`);
+      });
   };
 
   const renderItemTooltip = (slot: string, item: Item | null) => {

--- a/frontend/src/components/features/calculator/EquipmentLoadout.tsx
+++ b/frontend/src/components/features/calculator/EquipmentLoadout.tsx
@@ -230,13 +230,15 @@ export function EquipmentLoadout({ onEquipmentUpdate }: EquipmentLoadoutProps) {
     }
 
     // Fetch full item details including combat_stats
-    itemsApi.getItemById(item.id).then((fullItem) => {
-      if (!fullItem) {
-        if (process.env.NODE_ENV !== 'production') {
-          console.warn('[DEBUG] Failed to fetch full item details for:', item.id);
+    itemsApi
+      .getItemById(item.id)
+      .then((fullItem) => {
+        if (!fullItem) {
+          if (process.env.NODE_ENV !== 'production') {
+            console.warn('[DEBUG] Failed to fetch full item details for:', item.id);
+          }
+          return;
         }
-        return;
-      }
 
       if (process.env.NODE_ENV !== 'production') {
         console.debug('[DEBUG] Full item details:', fullItem);
@@ -270,8 +272,11 @@ export function EquipmentLoadout({ onEquipmentUpdate }: EquipmentLoadoutProps) {
       setIsDialogOpen(false);
       
       // Show a success toast
-      toast.success(`Equipped ${fullItem.name}`);
-    });
+        toast.success(`Equipped ${fullItem.name}`);
+      })
+      .catch((e: any) => {
+        toast.error(`Failed to load item: ${e.message}`);
+      });
   };
 
   const getTotals = (gear: Record<string, Item | null>) => {

--- a/frontend/src/hooks/useDpsCalculator.ts
+++ b/frontend/src/hooks/useDpsCalculator.ts
@@ -59,8 +59,8 @@ export function useDpsCalculator() {
         `DPS Calculated: Max hit: ${data.max_hit}, DPS: ${data.dps.toFixed(2)}`
       );
     },
-    onError: (error) => {
-      toast.error('Calculation Failed: There was an error calculating DPS.');
+    onError: (error: any) => {
+      toast.error(`Calculation Failed: ${error.message}`);
       console.error('Calculation error:', error);
     },
   });

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -11,6 +11,16 @@ import {
   PassiveEffect
 } from '@/types/calculator';
 
+export interface ApiError {
+  message: string;
+  status?: number;
+}
+
+const handleError = (err: any): ApiError => ({
+  message: err.response?.data?.detail || err.message || 'Unknown error',
+  status: err.response?.status,
+});
+
 const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
 // Log the resolved API URL only during development to help debug environment issues
 if (process.env.NODE_ENV !== 'production') {
@@ -28,20 +38,36 @@ const apiClient = axios.create({
 // Calculator API
 export const calculatorApi = {
   calculateDps: async (params: CalculatorParams): Promise<DpsResult> => {
-    const { data } = await apiClient.post('/calculate/dps', params);
-    return data;
+    try {
+      const { data } = await apiClient.post('/calculate/dps', params);
+      return data;
+    } catch (err: any) {
+      throw handleError(err);
+    }
   },
   importSeed: async (seed: string): Promise<CalculatorParams> => {
-    const { data } = await apiClient.post('/import-seed', { seed });
-    return data;
+    try {
+      const { data } = await apiClient.post('/import-seed', { seed });
+      return data;
+    } catch (err: any) {
+      throw handleError(err);
+    }
   },
   calculateSeed: async (seed: string): Promise<DpsResult> => {
-    const { data } = await apiClient.post('/calculate/seed', { seed });
-    return data;
+    try {
+      const { data } = await apiClient.post('/calculate/seed', { seed });
+      return data;
+    } catch (err: any) {
+      throw handleError(err);
+    }
   },
   getBis: async (params: CalculatorParams): Promise<Record<string, Item>> => {
-    const { data } = await apiClient.post('/bis', params);
-    return data;
+    try {
+      const { data } = await apiClient.post('/bis', params);
+      return data;
+    } catch (err: any) {
+      throw handleError(err);
+    }
   },
 };
 
@@ -51,16 +77,23 @@ export const bossesApi = {
   getAllBosses: async (
     params?: { page?: number; page_size?: number }
   ): Promise<BossSummary[]> => {
-
-    const { data } = await apiClient.get('/bosses', { params });
-    return data;
+    try {
+      const { data } = await apiClient.get('/bosses', { params });
+      return data;
+    } catch (err: any) {
+      throw handleError(err);
+    }
   },
 
   getBossesWithForms: async (
     params?: { page?: number; page_size?: number }
   ): Promise<Boss[]> => {
-    const { data } = await apiClient.get('/bosses/full', { params });
-    return data;
+    try {
+      const { data } = await apiClient.get('/bosses/full', { params });
+      return data;
+    } catch (err: any) {
+      throw handleError(err);
+    }
   },
 
   getBossById: async (id: number): Promise<Boss> => {
@@ -72,13 +105,17 @@ export const bossesApi = {
         const { data } = await apiClient.get(`/boss/form/${id}`);
         return data;
       }
-      throw err;
+      throw handleError(err);
     }
   },
 
   getBossByFormId: async (formId: number): Promise<Boss> => {
-    const { data } = await apiClient.get(`/boss/form/${formId}`);
-    return data;
+    try {
+      const { data } = await apiClient.get(`/boss/form/${formId}`);
+      return data;
+    } catch (err: any) {
+      throw handleError(err);
+    }
   },
 
   getBossForms: async (bossId: number): Promise<BossForm[]> => {
@@ -90,7 +127,7 @@ export const bossesApi = {
         const { data } = await apiClient.get(`/boss/form/${bossId}`);
         return data.forms || [];
       }
-      throw err;
+      throw handleError(err);
     }
   },
 
@@ -99,8 +136,12 @@ export const bossesApi = {
     if (limit !== undefined) {
       params.limit = limit;
     }
-    const { data } = await apiClient.get('/search/bosses', { params });
-    return data;
+    try {
+      const { data } = await apiClient.get('/search/bosses', { params });
+      return data;
+    } catch (err: any) {
+      throw handleError(err);
+    }
   },
 };
 
@@ -116,13 +157,21 @@ export const itemsApi = {
     }
 
   ): Promise<ItemSummary[]> => {
-    const { data } = await apiClient.get('/items', { params });
-    return data;
+    try {
+      const { data } = await apiClient.get('/items', { params });
+      return data;
+    } catch (err: any) {
+      throw handleError(err);
+    }
   },
 
   getItemById: async (id: number): Promise<Item> => {
-    const { data } = await apiClient.get(`/item/${id}`);
-    return data;
+    try {
+      const { data } = await apiClient.get(`/item/${id}`);
+      return data;
+    } catch (err: any) {
+      throw handleError(err);
+    }
   },
 
   searchItems: async (query: string, limit?: number): Promise<ItemSummary[]> => {
@@ -130,21 +179,33 @@ export const itemsApi = {
     if (limit !== undefined) {
       params.limit = limit;
     }
-    const { data } = await apiClient.get('/search/items', { params });
-    return data;
+    try {
+      const { data } = await apiClient.get('/search/items', { params });
+      return data;
+    } catch (err: any) {
+      throw handleError(err);
+    }
   },
 };
 
 export const specialAttacksApi = {
   getAll: async (): Promise<Record<string, SpecialAttack>> => {
-    const { data } = await apiClient.get('/special-attacks');
-    return data;
+    try {
+      const { data } = await apiClient.get('/special-attacks');
+      return data;
+    } catch (err: any) {
+      throw handleError(err);
+    }
   },
 };
 
 export const passiveEffectsApi = {
   getAll: async (): Promise<Record<string, PassiveEffect>> => {
-    const { data } = await apiClient.get('/passive-effects');
-    return data;
+    try {
+      const { data } = await apiClient.get('/passive-effects');
+      return data;
+    } catch (err: any) {
+      throw handleError(err);
+    }
   },
 };


### PR DESCRIPTION
## Summary
- catch errors inside API service methods and throw structured `ApiError`
- show toast notifications when API queries fail
- update DPS calculator error toast message
- add unit tests verifying API error handling

## Testing
- `npx jest` *(fails: Need to install jest)*

------
https://chatgpt.com/codex/tasks/task_e_684920f405e0832e9d930eb55a951dfd