### PR TITLE
Display boss magic and ranged weaknesses

### DIFF
--- a/frontend/src/components/features/calculator/BossSelector.tsx
+++ b/frontend/src/components/features/calculator/BossSelector.tsx
@@ -90,6 +90,16 @@ export function BossSelector({ onSelectBoss, onSelectForm }: BossSelectorProps) 
     ? { ...selectedBoss, forms: storeBossForms[selectedBoss.id] ?? bossDetails?.forms }
     : null;
 
+  const rangedWeakness = selectedForm &&
+    typeof selectedForm.defence_ranged_light === 'number' &&
+    typeof selectedForm.defence_ranged_heavy === 'number'
+      ? selectedForm.defence_ranged_light < selectedForm.defence_ranged_heavy
+        ? 'Light'
+        : selectedForm.defence_ranged_heavy < selectedForm.defence_ranged_light
+          ? 'Heavy'
+          : undefined
+      : undefined;
+
   // Fetch icons for all bosses when list loads
   useEffect(() => {
     if (!storeBosses) return;
@@ -486,6 +496,21 @@ export function BossSelector({ onSelectBoss, onSelectForm }: BossSelectorProps) 
                 <span className="text-muted-foreground">Magic Level:</span>{' '}
                 <span className="font-medium">{selectedForm.magic_level || 'Unknown'}</span>
               </div>
+              {selectedForm.elemental_weakness_type && (
+                <div>
+                  <span className="text-muted-foreground">Magic Weakness:</span>{' '}
+                  <span className="font-medium">
+                    {selectedForm.elemental_weakness_type}
+                    {selectedForm.elemental_weakness_percent ? ` (${selectedForm.elemental_weakness_percent}%)` : ''}
+                  </span>
+                </div>
+              )}
+              {rangedWeakness && (
+                <div>
+                  <span className="text-muted-foreground">Ranged Weakness:</span>{' '}
+                  <span className="font-medium">{rangedWeakness}</span>
+                </div>
+              )}
               
               <div className="col-span-2 mt-1">
                 <h5 className="text-xs font-semibold mb-1">Defence Bonuses</h5>

--- a/frontend/src/components/features/calculator/DirectBossSelector.tsx
+++ b/frontend/src/components/features/calculator/DirectBossSelector.tsx
@@ -83,6 +83,16 @@ export function DirectBossSelector({ onSelectBoss, onSelectForm, className }: Di
     ? { ...selectedBoss, forms: storeBossForms[selectedBoss.id] ?? bossDetails?.forms }
     : null;
 
+  const rangedWeakness = selectedForm &&
+    typeof selectedForm.defence_ranged_light === 'number' &&
+    typeof selectedForm.defence_ranged_heavy === 'number'
+      ? selectedForm.defence_ranged_light < selectedForm.defence_ranged_heavy
+        ? 'Light'
+        : selectedForm.defence_ranged_heavy < selectedForm.defence_ranged_light
+          ? 'Heavy'
+          : undefined
+      : undefined;
+
   // Fetch icons for all bosses
   useEffect(() => {
     if (!storeBosses) return;
@@ -383,6 +393,21 @@ export function DirectBossSelector({ onSelectBoss, onSelectForm, className }: Di
                 <span className="text-muted-foreground">Magic Level:</span>{' '}
                 <span className="font-medium">{selectedForm.magic_level || 'Unknown'}</span>
               </div>
+              {selectedForm.elemental_weakness_type && (
+                <div>
+                  <span className="text-muted-foreground">Magic Weakness:</span>{' '}
+                  <span className="font-medium">
+                    {selectedForm.elemental_weakness_type}
+                    {selectedForm.elemental_weakness_percent ? ` (${selectedForm.elemental_weakness_percent}%)` : ''}
+                  </span>
+                </div>
+              )}
+              {rangedWeakness && (
+                <div>
+                  <span className="text-muted-foreground">Ranged Weakness:</span>{' '}
+                  <span className="font-medium">{rangedWeakness}</span>
+                </div>
+              )}
               <div className="col-span-2 mt-1">
                 <h5 className="text-xs font-semibold mb-1">Defence Bonuses</h5>
                 <div className="grid grid-cols-3 gap-x-2 gap-y-1">

--- a/frontend/src/types/calculator.ts
+++ b/frontend/src/types/calculator.ts
@@ -213,6 +213,8 @@ export interface BossForm {
   defence_ranged_light?: number;
   defence_ranged_standard?: number;
   defence_ranged_heavy?: number;
+  elemental_weakness_type?: string;
+  elemental_weakness_percent?: number;
   weakness?: CombatStyle | null;
   attack_styles?: string[];
   immunities?: string[];


### PR DESCRIPTION
## Summary
- include elemental and ranged weakness fields in BossForm type
- compute and render weaknesses in `BossSelector` and `DirectBossSelector`

## Testing
- `npm test --silent` *(fails: TypeError: Cannot read properties of undefined)*
- `python -m unittest discover backend/app/testing` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68492851ac94832e9bfa786c343e4d2f