### PR TITLE
Persist full reference data

### DIFF
--- a/frontend/src/components/features/calculator/PassiveEffectOptions.tsx
+++ b/frontend/src/components/features/calculator/PassiveEffectOptions.tsx
@@ -3,20 +3,13 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Collapsible, CollapsibleTrigger, CollapsibleContent } from '@/components/ui/collapsible';
 import { Sparkles, ChevronDown, ChevronUp } from 'lucide-react';
-import { useEffect, useState } from 'react';
-import { passiveEffectsApi } from '@/services/api';
+import { useState } from 'react';
+import { useReferenceDataStore } from '@/store/reference-data-store';
 import { PassiveEffect } from '@/types/calculator';
 
 export function PassiveEffectOptions() {
-  const [effects, setEffects] = useState<Record<string, PassiveEffect>>({});
+  const effects = useReferenceDataStore((s) => s.passiveEffects);
   const [isOpen, setIsOpen] = useState(false);
-
-  useEffect(() => {
-    passiveEffectsApi
-      .getAll()
-      .then(setEffects)
-      .catch(() => setEffects({}));
-  }, []);
 
   return (
     <Collapsible open={isOpen} onOpenChange={setIsOpen} className="w-full">

--- a/frontend/src/components/features/calculator/SpecialAttackOptions.tsx
+++ b/frontend/src/components/features/calculator/SpecialAttackOptions.tsx
@@ -3,20 +3,13 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Collapsible, CollapsibleTrigger, CollapsibleContent } from '@/components/ui/collapsible';
 import { Swords, ChevronDown, ChevronUp } from 'lucide-react';
-import { useEffect, useState } from 'react';
-import { specialAttacksApi } from '@/services/api';
+import { useState } from 'react';
+import { useReferenceDataStore } from '@/store/reference-data-store';
 import { SpecialAttack } from '@/types/calculator';
 
 export function SpecialAttackOptions() {
-  const [attacks, setAttacks] = useState<Record<string, SpecialAttack>>({});
+  const attacks = useReferenceDataStore((s) => s.specialAttacks);
   const [isOpen, setIsOpen] = useState(false);
-
-  useEffect(() => {
-    specialAttacksApi
-      .getAll()
-      .then(setAttacks)
-      .catch(() => setAttacks({}));
-  }, []);
 
   return (
     <Collapsible open={isOpen} onOpenChange={setIsOpen} className="w-full">


### PR DESCRIPTION
## Summary
- extend reference data store to include bosses, items, boss forms, special attacks and passive effects
- load special attack and passive effect reference data
- persist entire reference data instead of only IDs and names
- source special/passage effects from store instead of API
- update tests for new store shape

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68492c6ca08c832e8de30bb1f644e764