### PR TITLE
Fix toFixed errors on null values

### DIFF
--- a/frontend/src/components/features/calculator/CombatStatsSummary.tsx
+++ b/frontend/src/components/features/calculator/CombatStatsSummary.tsx
@@ -1,4 +1,5 @@
 import { CalculatorParams, Item } from '@/types/calculator';
+import { safeFixed } from '@/utils/format';
 
 interface CombatStatsSummaryProps {
   params: CalculatorParams;
@@ -55,7 +56,7 @@ export function CombatStatsSummary({
         <div>
           <span className="text-muted-foreground">Attack Speed:</span>{' '}
           <span className="font-medium">
-            {params.attack_speed.toFixed(1)}s
+            {safeFixed(params.attack_speed, 1)}s
             {selectedAttackStyle === 'rapid' && (
               <span className="text-green-600 dark:text-green-400 ml-1">(Faster)</span>
             )}

--- a/frontend/src/components/features/calculator/DpsDebug.tsx
+++ b/frontend/src/components/features/calculator/DpsDebug.tsx
@@ -1,3 +1,5 @@
+import { safeFixed } from '@/utils/format';
+
 type DpsDebugProps = {
   params: {
     combat_style: 'melee' | 'ranged' | 'magic';
@@ -113,10 +115,10 @@ export default function DpsDebug({ params, output }: DpsDebugProps) {
       <p>  Defence Roll: {output.def_roll}</p>
 
       <br />
-      <p>→ <strong>Hit Chance:</strong> {output.hit_chance.toFixed(4)}</p>
-      <p>→ <strong>Average Hit:</strong> {output.avg_hit.toFixed(4)}</p>
+      <p>→ <strong>Hit Chance:</strong> {safeFixed(output.hit_chance, 4)}</p>
+      <p>→ <strong>Average Hit:</strong> {safeFixed(output.avg_hit, 4)}</p>
       <p>→ <strong>Attack Speed:</strong> {params.attack_speed}s</p>
-      <p>→ <strong>DPS:</strong> {output.dps.toFixed(4)}</p>
+      <p>→ <strong>DPS:</strong> {safeFixed(output.dps, 4)}</p>
       <p className="mt-2 font-bold">=============================</p>
     </div>
   );

--- a/frontend/src/components/features/calculator/DpsResultDisplay.tsx
+++ b/frontend/src/components/features/calculator/DpsResultDisplay.tsx
@@ -2,6 +2,7 @@
 import { Card, CardContent } from '@/components/ui/card';
 import { Calculator } from 'lucide-react';
 import { CalculatorParams, DpsResult } from '@/types/calculator';
+import { safeFixed } from '@/utils/format';
 
 interface DpsResultDisplayProps {
   params: CalculatorParams;
@@ -21,12 +22,12 @@ export function DpsResultDisplay({ params, results, appliedPassiveEffects }: Dps
           <CardContent className="pt-6">
             <div className="text-sm font-medium text-muted-foreground">Total DPS</div>
             <div className="text-3xl font-bold text-primary">
-              {(results.dps + (results.special_attack_dps ?? 0)).toFixed(2)}
+              {safeFixed(results.dps + (results.special_attack_dps ?? 0), 2)}
             </div>
             {results.special_attack_dps !== undefined && (
               <div className="text-xs text-muted-foreground">
-                Base {results.dps.toFixed(2)} + Special{' '}
-                {results.special_attack_dps.toFixed(2)}
+                Base {safeFixed(results.dps, 2)} + Special{' '}
+                {safeFixed(results.special_attack_dps, 2)}
               </div>
             )}
           </CardContent>
@@ -40,7 +41,7 @@ export function DpsResultDisplay({ params, results, appliedPassiveEffects }: Dps
         <Card className="bg-muted/30 border">
           <CardContent className="pt-6">
             <div className="text-sm font-medium text-muted-foreground">Hit Chance</div>
-            <div className="text-3xl font-bold text-primary">{(results.hit_chance * 100).toFixed(1)}%</div>
+            <div className="text-3xl font-bold text-primary">{safeFixed(results.hit_chance * 100, 1)}%</div>
           </CardContent>
         </Card>
         {results.special_attack_dps !== undefined && (

--- a/frontend/src/components/features/calculator/EquipmentDisplay.tsx
+++ b/frontend/src/components/features/calculator/EquipmentDisplay.tsx
@@ -13,6 +13,7 @@ import {
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { useCalculatorStore } from '@/store/calculator-store';
 import { Item } from '@/types/calculator';
+import { safeFixed } from '@/utils/format';
 
 // Equipment slot layout
 const EQUIPMENT_SLOTS = {
@@ -432,7 +433,7 @@ export function EquipmentDisplay({ loadout, totals }: EquipmentDisplayProps) {
                 <div>
                   <span className="text-muted-foreground">Speed:</span>{' '}
                   <span className="font-medium">
-                    {params.attack_speed.toFixed(1)}s
+                    {safeFixed(params.attack_speed, 1)}s
                     {selectedAttackStyle === 'rapid' && (
                       <span className="text-green-600 dark:text-green-400 ml-1">(Faster)</span>
                     )}

--- a/frontend/src/components/features/calculator/MagicForm.tsx
+++ b/frontend/src/components/features/calculator/MagicForm.tsx
@@ -16,6 +16,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { useCombatForm } from '@/hooks/useCombatForm';
 import { MagicCalculatorParams } from '@/types/calculator';
 import { useEffect } from 'react';
+import { safeFixed } from '@/utils/format';
 
 // Magic form schema for validation
 const magicFormSchema = z.object({
@@ -141,7 +142,7 @@ export function MagicForm() {
               name="magic_prayer"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Prayer Bonus: {((field.value * 100) - 100).toFixed(0)}%</FormLabel>
+                  <FormLabel>Prayer Bonus: {safeFixed(field.value * 100 - 100, 0)}%</FormLabel>
                   <FormControl>
                     <Slider
                       min={1}
@@ -390,7 +391,7 @@ export function MagicForm() {
               name="shadow_bonus"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Tumeken&apos;s Shadow Bonus: {(field.value * 100).toFixed(0)}%</FormLabel>
+                  <FormLabel>Tumeken&apos;s Shadow Bonus: {safeFixed(field.value * 100, 0)}%</FormLabel>
                   <FormControl>
                     <Slider
                       min={0}
@@ -415,7 +416,7 @@ export function MagicForm() {
               name="virtus_bonus"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Virtus Set Bonus: {(field.value * 100).toFixed(0)}%</FormLabel>
+                  <FormLabel>Virtus Set Bonus: {safeFixed(field.value * 100, 0)}%</FormLabel>
                   <FormControl>
                     <Slider
                       min={0}
@@ -440,7 +441,7 @@ export function MagicForm() {
               name="tome_bonus"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Tome of Fire Bonus: {(field.value * 100).toFixed(0)}%</FormLabel>
+                  <FormLabel>Tome of Fire Bonus: {safeFixed(field.value * 100, 0)}%</FormLabel>
                   <FormControl>
                     <Slider
                       min={0}

--- a/frontend/src/components/features/calculator/PassiveEffectsDisplay.tsx
+++ b/frontend/src/components/features/calculator/PassiveEffectsDisplay.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { Card, CardContent } from '@/components/ui/card';
 import { useCalculatorStore } from '@/store/calculator-store';
 import { Item, BossForm } from '@/types/calculator';
+import { safeFixed } from '@/utils/format';
 import calculatePassiveEffectBonuses from './PassiveEffectCalculator';
 import { Badge } from '@/components/ui/badge';
 import {
@@ -94,11 +95,11 @@ export function PassiveEffectsDisplay({ loadout, target }: PassiveEffectsDisplay
       const parts: string[] = [];
       
       if (formattedAccuracy !== 0) {
-        parts.push(`+${formattedAccuracy.toFixed(1)}% accuracy`);
+        parts.push(`+${safeFixed(formattedAccuracy, 1)}% accuracy`);
       }
       
       if (formattedDamage !== 0) {
-        parts.push(`+${formattedDamage.toFixed(1)}% damage`);
+        parts.push(`+${safeFixed(formattedDamage, 1)}% damage`);
       }
       
       if ((bonuses.maxHit || 0) > 0) {

--- a/frontend/src/components/features/calculator/PrayerPotionSelector.tsx
+++ b/frontend/src/components/features/calculator/PrayerPotionSelector.tsx
@@ -7,6 +7,7 @@ import { ToggleBox } from '@/components/ui/toggle-box';
 import { Label } from '@/components/ui/label';
 import { useCalculatorStore } from '@/store/calculator-store';
 import { Info } from 'lucide-react';
+import { safeFixed } from '@/utils/format';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 
 // Define prayer and potion options for each combat style
@@ -337,11 +338,11 @@ export function PrayerPotionSelector({ className }: { className?: string }) {
               <>
                 <div className="flex justify-between">
                   <span>Attack Prayer:</span>
-                  <span className="font-medium">+{((params.attack_prayer * 100) - 100).toFixed(0)}%</span>
+                  <span className="font-medium">+{safeFixed(params.attack_prayer * 100 - 100, 0)}%</span>
                 </div>
                 <div className="flex justify-between">
                   <span>Strength Prayer:</span>
-                  <span className="font-medium">+{((params.strength_prayer * 100) - 100).toFixed(0)}%</span>
+                  <span className="font-medium">+{safeFixed(params.strength_prayer * 100 - 100, 0)}%</span>
                 </div>
                 <div className="flex justify-between">
                   <span>Attack Potion:</span>
@@ -358,7 +359,7 @@ export function PrayerPotionSelector({ className }: { className?: string }) {
               <>
                 <div className="flex justify-between">
                   <span>Ranged Prayer:</span>
-                  <span className="font-medium">+{((params.ranged_prayer * 100) - 100).toFixed(0)}%</span>
+                  <span className="font-medium">+{safeFixed(params.ranged_prayer * 100 - 100, 0)}%</span>
                 </div>
                 <div className="flex justify-between">
                   <span>Ranged Potion:</span>
@@ -371,7 +372,7 @@ export function PrayerPotionSelector({ className }: { className?: string }) {
               <>
                 <div className="flex justify-between">
                   <span>Magic Prayer:</span>
-                  <span className="font-medium">+{((params.magic_prayer * 100) - 100).toFixed(0)}%</span>
+                  <span className="font-medium">+{safeFixed(params.magic_prayer * 100 - 100, 0)}%</span>
                 </div>
                 <div className="flex justify-between">
                   <span>Magic Potion:</span>

--- a/frontend/src/components/features/calculator/PresetSelector.tsx
+++ b/frontend/src/components/features/calculator/PresetSelector.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Save, Trash2, ClipboardCopy, ArrowUp, ArrowDown } from 'lucide-react';
+import { safeFixed } from '@/utils/format';
 import {
   Dialog,
   DialogContent,
@@ -170,7 +171,7 @@ export function PresetSelector({ onPresetLoad, className }: PresetSelectorProps)
     } else if (params.combat_style === 'ranged') {
       return `RNG: ${params.ranged_level}, ATK Bonus: ${params.ranged_attack_bonus}, STR Bonus: ${params.ranged_strength_bonus}`;
     } else if (params.combat_style === 'magic') {
-      return `MAG: ${params.magic_level}, ATK Bonus: ${params.magic_attack_bonus}, DMG Bonus: ${(params.magic_damage_bonus * 100).toFixed(0)}%`;
+      return `MAG: ${params.magic_level}, ATK Bonus: ${params.magic_attack_bonus}, DMG Bonus: ${safeFixed(params.magic_damage_bonus * 100, 0)}%`;
     }
     return '';
   };

--- a/frontend/src/components/features/calculator/RangedForm.tsx
+++ b/frontend/src/components/features/calculator/RangedForm.tsx
@@ -1,14 +1,15 @@
 'use client';
 
 import { z } from 'zod';
-import { 
-  Form, 
-  FormControl, 
-  FormDescription, 
-  FormField, 
-  FormItem, 
-  FormLabel 
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel
 } from '@/components/ui/form';
+import { safeFixed } from '@/utils/format';
 import { Input } from '@/components/ui/input';
 import { Slider } from '@/components/ui/slider';
 import { Switch } from '@/components/ui/switch';
@@ -106,7 +107,7 @@ export function RangedForm() {
               name="ranged_prayer"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Prayer Bonus: {(field.value * 100 - 100).toFixed(0)}%</FormLabel>
+                  <FormLabel>Prayer Bonus: {safeFixed(field.value * 100 - 100, 0)}%</FormLabel>
                   <FormControl>
                     <Slider
                       min={1}

--- a/frontend/src/components/features/simulation/MultiBossSimulation.tsx
+++ b/frontend/src/components/features/simulation/MultiBossSimulation.tsx
@@ -34,6 +34,7 @@ import {
 } from '@/components/ui/table';
 import { bossesApi, calculatorApi } from '@/services/api';
 import { useCalculatorStore } from '@/store/calculator-store';
+import { safeFixed } from '@/utils/format';
 import { useReferenceDataStore } from '@/store/reference-data-store';
 import { useDebounce } from '@/hooks/useDebounce';
 import { useToast } from '@/hooks/use-toast';
@@ -337,9 +338,9 @@ export function MultiBossSimulation() {
                     )}
                     {boss.name}
                   </TableCell>
-                  <TableCell className="text-right">{result.dps.toFixed(2)}</TableCell>
+                  <TableCell className="text-right">{safeFixed(result.dps, 2)}</TableCell>
                   <TableCell className="text-right">{result.max_hit}</TableCell>
-                  <TableCell className="text-right">{(result.hit_chance * 100).toFixed(1)}%</TableCell>
+                  <TableCell className="text-right">{safeFixed(result.hit_chance * 100, 1)}%</TableCell>
                 </TableRow>
               ))}
             </TableBody>

--- a/frontend/src/hooks/useDpsCalculator.ts
+++ b/frontend/src/hooks/useDpsCalculator.ts
@@ -5,6 +5,7 @@ import { useCalculatorStore } from '@/store/calculator-store';
 import { CalculatorParams, Item, BossForm, CombatStyle } from '@/types/calculator';
 import calculatePassiveEffectBonuses from '@/components/features/calculator/PassiveEffectCalculator';
 import { useToast } from './use-toast';
+import { safeFixed } from '@/utils/format';
 
 export function useDpsCalculator() {
   const { toast } = useToast();
@@ -56,7 +57,7 @@ export function useDpsCalculator() {
     onSuccess: (data) => {
       setResults(data);
       toast.success(
-        `DPS Calculated: Max hit: ${data.max_hit}, DPS: ${data.dps.toFixed(2)}`
+        `DPS Calculated: Max hit: ${data.max_hit}, DPS: ${safeFixed(data.dps, 2)}`
       );
     },
     onError: (error: any) => {

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -1,0 +1,6 @@
+export function safeFixed(value: number | null | undefined, digits = 0): string {
+  if (typeof value !== 'number' || isNaN(value)) {
+    return (0).toFixed(digits);
+  }
+  return value.toFixed(digits);
+}


### PR DESCRIPTION
## Summary
- add `safeFixed` helper
- guard all displayed numbers with `safeFixed`

## Testing
- `npm run lint` *(fails: `next` not found)*
- `python -m unittest discover backend/app/testing` *(fails: ModuleNotFoundError: httpx)*

------
https://chatgpt.com/codex/tasks/task_e_68492cb819e0832ea80170b1eddd761e