### PR TITLE
Enable custom initial special energy

### DIFF
--- a/backend/app/calculators/__init__.py
+++ b/backend/app/calculators/__init__.py
@@ -125,7 +125,7 @@ class DpsCalculator:
 
         duration = params.get("duration", 60.0)
 
-        energy = 100.0
+        energy = params.get("initial_special_energy", 100.0)
         time = 0.0
         special_count = 0
         regular_total = 0.0

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -159,6 +159,7 @@ class DpsParameters(BaseModel):
     special_regen_rate: float = 10 / 30
     lightbearer: Optional[bool] = None
     surge_potion: Optional[bool] = None
+    initial_special_energy: Optional[float] = 100.0
     duration: Optional[float] = None
 
     # Melee parameters

--- a/backend/app/testing/UnitTest.py
+++ b/backend/app/testing/UnitTest.py
@@ -103,6 +103,35 @@ class TestDpsCalculator(unittest.TestCase):
             places=5,
         )
 
+    def test_initial_special_energy(self):
+        """Initial special energy should influence special attack count."""
+        params = {
+            "combat_style": "melee",
+            "strength_level": 99,
+            "strength_boost": 0,
+            "strength_prayer": 1.0,
+            "attack_level": 99,
+            "attack_boost": 0,
+            "attack_prayer": 1.0,
+            "melee_strength_bonus": 80,
+            "melee_attack_bonus": 80,
+            "attack_style_bonus_strength": 3,
+            "attack_style_bonus_attack": 0,
+            "attack_speed": 2.4,
+            "target_defence_level": 100,
+            "target_defence_bonus": 50,
+            "special_damage_multiplier": 1.2,
+            "special_accuracy_modifier": 1.0,
+            "special_energy_cost": 50,
+            "special_attack_speed": 3.0,
+            "special_regen_rate": 10 / 30,
+            "duration": 60,
+            "initial_special_energy": 50.0,
+        }
+
+        result = DpsCalculator.calculate_dps(params)
+        self.assertEqual(result["special_attacks"], 1)
+
 
 class TestMeleeCalculator(unittest.TestCase):
     """Test the Melee Calculator functionality."""

--- a/frontend/src/components/features/calculator/CombinedEquipmentDisplay.tsx
+++ b/frontend/src/components/features/calculator/CombinedEquipmentDisplay.tsx
@@ -103,6 +103,7 @@ export function CombinedEquipmentDisplay({ onEquipmentUpdate, bossForm, loadoutP
     if (cleaned.special_accuracy_modifier === undefined) delete cleaned.special_accuracy_modifier;
     if (cleaned.special_energy_cost === undefined) delete cleaned.special_energy_cost;
     if (cleaned.special_regen_rate === 10 / 30) delete cleaned.special_regen_rate;
+    if (cleaned.initial_special_energy === 100) delete cleaned.initial_special_energy;
     return cleaned;
   }, []);
 

--- a/frontend/src/components/features/calculator/SpecialAttackForm.tsx
+++ b/frontend/src/components/features/calculator/SpecialAttackForm.tsx
@@ -71,6 +71,17 @@ export default function SpecialAttackForm() {
             }
           />
         </div>
+        <div>
+          <Label>Initial Energy</Label>
+          <Input
+            type="number"
+            step="1"
+            value={params.initial_special_energy ?? 100}
+            onChange={(e) =>
+              setParams({ initial_special_energy: parseFloat(e.target.value) })
+            }
+          />
+        </div>
       </CardContent>
     </Card>
   );

--- a/frontend/src/components/features/simulation/MultiBossSimulation.tsx
+++ b/frontend/src/components/features/simulation/MultiBossSimulation.tsx
@@ -157,6 +157,7 @@ export function MultiBossSimulation() {
       delete cleaned.special_accuracy_modifier;
     if (cleaned.special_energy_cost === undefined) delete cleaned.special_energy_cost;
     if (cleaned.special_regen_rate === 10 / 30) delete cleaned.special_regen_rate;
+    if (cleaned.initial_special_energy === 100) delete cleaned.initial_special_energy;
     return cleaned;
   };
 

--- a/frontend/src/hooks/useDpsCalculator.ts
+++ b/frontend/src/hooks/useDpsCalculator.ts
@@ -121,6 +121,9 @@ export function useDpsCalculator() {
       if (cleaned.special_regen_rate === 10 / 30) {
         delete cleaned.special_regen_rate;
       }
+      if (cleaned.initial_special_energy === 100) {
+        delete cleaned.initial_special_energy;
+      }
       return cleaned;
     },
     []

--- a/frontend/src/store/calculator-store.ts
+++ b/frontend/src/store/calculator-store.ts
@@ -73,6 +73,7 @@ const defaultMeleeParams: MeleeCalculatorParams = {
   special_regen_rate: 10 / 30,
   lightbearer: false,
   surge_potion: false,
+  initial_special_energy: 100,
   duration: 60,
   target_defence_level: 200,
   target_defence_bonus: 30,
@@ -100,6 +101,7 @@ const defaultRangedParams: RangedCalculatorParams = {
   special_regen_rate: 10 / 30,
   lightbearer: false,
   surge_potion: false,
+  initial_special_energy: 100,
   duration: 60,
   target_defence_level: 200,
   target_defence_bonus: 150,
@@ -143,6 +145,7 @@ const defaultMagicParams: MagicCalculatorParams = {
   special_regen_rate: 10 / 30,
   lightbearer: false,
   surge_potion: false,
+  initial_special_energy: 100,
   duration: 60
 };
 

--- a/frontend/src/types/calculator.ts
+++ b/frontend/src/types/calculator.ts
@@ -54,6 +54,7 @@ export interface BaseCalculatorParams {
   special_regen_rate?: number;
   lightbearer?: boolean;
   surge_potion?: boolean;
+  initial_special_energy?: number;
   duration?: number;
 }
 


### PR DESCRIPTION
## Summary
- allow setting `initial_special_energy` on DPS calculations
- expose the new field in frontend types, store defaults, and calculator forms
- sanitize `initial_special_energy` in calculation hooks
- test initial energy usage

## Testing
- `python -m unittest discover backend/app/testing` *(fails: ModuleNotFoundError and other errors)*
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68493fe111d0832ea72c70f90c3e234b