### PR TITLE
Rebrand application as ScapeLab

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 MIT License
-Copyright (c) 2025 OSRS DPS Calculator Contributors
+Copyright (c) 2025 ScapeLab Contributors
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-OSRS DPS Calculator
+ScapeLab DPS Calculator
 
 A comprehensive damage-per-second calculator for Old School RuneScape with accurate combat formulas, equipment comparison, and boss statistics.
 
 
 Overview
 
-The OSRS DPS Calculator is a powerful tool for Old School RuneScape players to optimize their combat gear and strategies. By accurately implementing the game's combat formulas, this calculator helps players compare different equipment setups, account for special effects, and calculate expected damage against various bosses.
+The ScapeLab DPS Calculator is a powerful tool for Old School RuneScape players to optimize their combat gear and strategies. By accurately implementing the game's combat formulas, this calculator helps players compare different equipment setups, account for special effects, and calculate expected damage against various bosses.
 Key Features
 
     All Combat Styles: Full support for Melee, Ranged, and Magic calculations
@@ -391,4 +391,4 @@ This project is licensed under the MIT License - see the LICENSE file for detail
     Jagex for creating Old School RuneScape
     The OSRS community for verifying formulas and mechanics
 
-OSRS DPS Calculator is not affiliated with Jagex Ltd. Old School RuneScape and Jagex are trademarks of Jagex Ltd.
+ScapeLab is not affiliated with Jagex Ltd. Old School RuneScape and Jagex are trademarks of Jagex Ltd.

--- a/backend/app/README.md
+++ b/backend/app/README.md
@@ -1,4 +1,4 @@
-OSRS DPS Calculator API
+ScapeLab DPS Calculator API
 An API for calculating damage-per-second (DPS) in Old School RuneScape based on equipment, stats, and target information.
 Features
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -25,7 +25,7 @@ from .services import bis_service
 
 # Create the FastAPI app
 app = FastAPI(
-    title="OSRS DPS Calculator API",
+    title="ScapeLab DPS Calculator API",
     description="API for calculating DPS in Old School RuneScape",
     version="1.0.0"
 )
@@ -62,7 +62,7 @@ if os.path.isdir(IMAGES_DIR):
 def read_root():
     """Get a welcome message and basic API information."""
     return {
-        "message": "Welcome to the OSRS DPS Calculator API",
+        "message": "Welcome to the ScapeLab DPS Calculator API",
         "version": "1.0.0",
         "endpoints": {
             "GET /": "This welcome message",

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,5 +1,5 @@
-OSRS DPS Calculator Frontend
-A Next.js-based frontend for the OSRS DPS Calculator. This application provides a user interface for calculating damage-per-second for different combat styles in Old School RuneScape.
+ScapeLab DPS Calculator Frontend
+A Next.js-based frontend for the ScapeLab DPS Calculator. This application provides a user interface for calculating damage-per-second for different combat styles in Old School RuneScape.
 Features
 
 Calculate DPS for all combat styles: Melee, Ranged, and Magic

--- a/frontend/src/app/about/page.tsx
+++ b/frontend/src/app/about/page.tsx
@@ -3,12 +3,12 @@ import Link from 'next/link';
 export default function AboutPage() {
   return (
     <main id="main" className="container mx-auto py-8 px-4">
-      <h1 className="text-4xl font-bold mb-8">About OSRS DPS Calculator</h1>
+      <h1 className="text-4xl font-bold mb-8 text-center">About ScapeLab</h1>
       
       <div className="prose dark:prose-invert max-w-3xl">
-        <p className="lead">
-          The OSRS DPS Calculator is a tool designed to help Old School RuneScape players 
-          optimize their gear and stats for maximum damage output against various bosses and monsters.
+        <p className="lead text-center">
+          ScapeLab provides tools for Old School RuneScape players to optimize their gear and stats
+          for maximum damage output against a variety of bosses and monsters.
         </p>
         
         <h2>How It Works</h2>
@@ -50,11 +50,15 @@ export default function AboutPage() {
           <li>Frontend: Next.js, React, TanStack Query, Zustand, shadcn/ui</li>
           <li>Backend: FastAPI, Python, SQLite</li>
         </ul>
-        
+
         <h2>Feedback & Contributions</h2>
         <p>
           This is an open-source project. If you&apos;d like to contribute or provide feedback,
           please visit our GitHub repository.
+        </p>
+
+        <p className="mt-6 text-center font-semibold">
+          ScapeLab is built by players, for players.
         </p>
         
         <div className="mt-8">

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -8,8 +8,8 @@ import './globals.css';
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "OSRS DPS Calculator",
-  description: "Calculate DPS for Old School RuneScape combat styles and gear",
+  title: "ScapeLab",
+  description: "Tools for optimizing your Old School RuneScape gameplay",
 };
 
 export default function RootLayout({

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -5,7 +5,7 @@ export default function Home() {
   return (
     <main id="main" className="container mx-auto py-8 px-4 pb-16"> {/* Added extra bottom padding */}
       <h1 className="text-4xl font-bold text-center mb-8">
-        OSRS DPS Calculator
+        ScapeLab DPS Calculator
       </h1>
       <p className="text-center text-muted-foreground mb-8 max-w-2xl mx-auto">
         Calculate damage-per-second for Old School RuneScape combat styles.

--- a/frontend/src/components/features/calculator/ImprovedDpsCalculator.tsx
+++ b/frontend/src/components/features/calculator/ImprovedDpsCalculator.tsx
@@ -23,7 +23,7 @@ import { Raid, RAID_NAME_TO_ID } from '@/types/raid';
 import { useCalculatorStore } from '@/store/calculator-store';
 
 /**
- * ImprovedDpsCalculator - A redesigned OSRS DPS Calculator with better UI flow
+ * ImprovedDpsCalculator - A redesigned ScapeLab DPS Calculator with better UI flow
  * This component improves on the original by:
  * - Creating a consistent layout with proper alignment
  * - Balancing the height between columns

--- a/frontend/src/components/layout/Footer.tsx
+++ b/frontend/src/components/layout/Footer.tsx
@@ -7,7 +7,7 @@ export function Footer() {
         <div className="flex flex-col md:flex-row justify-between items-center">
           <div className="mb-4 md:mb-0 text-center md:text-left">
             <p className="text-sm text-muted-foreground">
-              © {currentYear} OSRS DPS Calculator. Not affiliated with Jagex Ltd.
+              © {currentYear} ScapeLab. Not affiliated with Jagex Ltd.
             </p>
             <p className="text-xs text-muted-foreground mt-1">
               Old School RuneScape and Jagex are trademarks of Jagex Ltd.

--- a/frontend/src/components/layout/Navigation.tsx
+++ b/frontend/src/components/layout/Navigation.tsx
@@ -16,12 +16,12 @@ export function Navigation() {
             href="/"
             className="text-xl font-bold font-title"
           >
-            OSRS DPS Calculator
+            ScapeLab
           </Link>
           
           <div className="hidden md:flex space-x-4">
-            <Link 
-              href="/" 
+            <Link
+              href="/"
               className={cn(
                 'text-sm transition-colors hover:text-primary',
                 pathname === '/' ? 'text-foreground font-medium' : 'text-muted-foreground'
@@ -30,13 +30,13 @@ export function Navigation() {
               Calculator
             </Link>
             <Link
-              href="/about"
+              href="/simulate"
               className={cn(
                 'text-sm transition-colors hover:text-primary',
-                pathname === '/about' ? 'text-foreground font-medium' : 'text-muted-foreground'
+                pathname === '/simulate' ? 'text-foreground font-medium' : 'text-muted-foreground'
               )}
             >
-              About
+              Simulate
             </Link>
             <Link
               href="/import"
@@ -48,13 +48,13 @@ export function Navigation() {
               Import
             </Link>
             <Link
-              href="/simulate"
+              href="/about"
               className={cn(
                 'text-sm transition-colors hover:text-primary',
-                pathname === '/simulate' ? 'text-foreground font-medium' : 'text-muted-foreground'
+                pathname === '/about' ? 'text-foreground font-medium' : 'text-muted-foreground'
               )}
             >
-              Simulate
+              About
             </Link>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- rename project references to **ScapeLab**
- redesign and style the About page
- reorder navigation links to `Calculator`, `Simulate`, `Import`, `About`
- update footer copyright
- adjust metadata and headings

## Testing
- `python -m unittest discover backend/app/testing` *(fails: FAIL: test_bosses, test_cache_headers, test_items)*
- `npm test` in `frontend`
- `npm run lint` *(fails with TypeScript ESLint errors)*

------
https://chatgpt.com/codex/tasks/task_e_684940f2e6f4832e860b5d3cb333a7f5