### PR TITLE
Use presets for visualizations

### DIFF
--- a/frontend/src/components/features/calculator/EquipmentPanel.tsx
+++ b/frontend/src/components/features/calculator/EquipmentPanel.tsx
@@ -27,8 +27,8 @@ export function EquipmentPanel({ onEquipmentUpdate, bossForm }: EquipmentPanelPr
   const {
     resetParams,
     resetLocks,
-    loadoutPresets,
-    addLoadoutPreset,
+    presets,
+    addPreset,
     setLoadout,
     setParams,
     switchCombatStyle,
@@ -63,7 +63,7 @@ export function EquipmentPanel({ onEquipmentUpdate, bossForm }: EquipmentPanelPr
   const handlePresetChange = (id: string) => {
     setActivePreset(id);
     if (id === 'current') return;
-    const preset = loadoutPresets.find((p) => p.id === id);
+    const preset = presets.find((p) => p.id === id);
     if (preset) {
       switchCombatStyle(preset.params.combat_style as any);
       setParams(preset.params);
@@ -84,7 +84,7 @@ export function EquipmentPanel({ onEquipmentUpdate, bossForm }: EquipmentPanelPr
       equipment: { ...loadout },
       seed: encodeSeed(params, loadout as any),
     };
-    addLoadoutPreset(newPreset);
+    addPreset(newPreset);
     setActivePreset(newPreset.id);
     toast.success('Preset saved');
   };
@@ -102,7 +102,7 @@ export function EquipmentPanel({ onEquipmentUpdate, bossForm }: EquipmentPanelPr
         <Tabs value={activePreset} onValueChange={handlePresetChange} className="w-full">
           <TabsList className="mb-4 flex gap-2">
             <TabsTrigger value="current">Current</TabsTrigger>
-            {loadoutPresets.slice(0, 6).map((p) => (
+            {presets.slice(0, 6).map((p) => (
               <TabsTrigger key={p.id} value={p.id}>{p.name}</TabsTrigger>
             ))}
             <Button variant="outline" size="sm" onClick={handleAddPreset}">Add preset</Button>

--- a/frontend/src/components/features/calculator/ImprovedDpsCalculator.tsx
+++ b/frontend/src/components/features/calculator/ImprovedDpsCalculator.tsx
@@ -134,7 +134,7 @@ export function ImprovedDpsCalculator() {
           </Card>
 
         </div>
-        {/* Bottom row: DPS comparison and loadout presets */}
+        {/* Bottom row: DPS comparison and presets */}
         <Visualizations />
         <PresetSelector
           className="flex-grow"

--- a/frontend/src/components/features/calculator/PresetSelector.tsx
+++ b/frontend/src/components/features/calculator/PresetSelector.tsx
@@ -50,10 +50,10 @@ export function PresetSelector({ onPresetLoad, className }: PresetSelectorProps)
     setParams,
     setLoadout,
     switchCombatStyle,
-    addLoadoutPreset,
-    setLoadoutPresets,
-    removeLoadoutPreset,
-    reorderLoadoutPresets,
+    addPreset,
+    setPresets: setStorePresets,
+    removePreset,
+    reorderPresets,
   } = useCalculatorStore();
   const { toast } = useToast();
   const [hasMounted, setHasMounted] = useState(false);
@@ -70,7 +70,7 @@ export function PresetSelector({ onPresetLoad, className }: PresetSelectorProps)
       const savedPresets = localStorage.getItem('osrs-dps-presets');
       const loaded = savedPresets ? JSON.parse(savedPresets) : [];
       setPresets(loaded);
-      setLoadoutPresets(loaded);
+      setStorePresets(loaded);
     }
   }, []);
 
@@ -96,8 +96,8 @@ export function PresetSelector({ onPresetLoad, className }: PresetSelectorProps)
 
     const updatedPresets = [...presets, newPreset];
     setPresets(updatedPresets);
-    setLoadoutPresets(updatedPresets);
-    addLoadoutPreset(newPreset);
+    setStorePresets(updatedPresets);
+    addPreset(newPreset);
     if (typeof window !== 'undefined') {
       localStorage.setItem('osrs-dps-presets', JSON.stringify(updatedPresets));
     }
@@ -137,8 +137,8 @@ export function PresetSelector({ onPresetLoad, className }: PresetSelectorProps)
   const deletePreset = (presetId: string) => {
     const updatedPresets = presets.filter(preset => preset.id !== presetId);
     setPresets(updatedPresets);
-    setLoadoutPresets(updatedPresets);
-    removeLoadoutPreset(presetId);
+    setStorePresets(updatedPresets);
+    removePreset(presetId);
     if (typeof window !== 'undefined') {
       localStorage.setItem('osrs-dps-presets', JSON.stringify(updatedPresets));
     }
@@ -153,8 +153,8 @@ export function PresetSelector({ onPresetLoad, className }: PresetSelectorProps)
     const [moved] = updated.splice(index, 1);
     updated.splice(newIndex, 0, moved);
     setPresets(updated);
-    setLoadoutPresets(updated);
-    reorderLoadoutPresets(index, newIndex);
+    setStorePresets(updated);
+    reorderPresets(index, newIndex);
     if (typeof window !== 'undefined') {
       localStorage.setItem('osrs-dps-presets', JSON.stringify(updated));
     }
@@ -188,7 +188,7 @@ export function PresetSelector({ onPresetLoad, className }: PresetSelectorProps)
   return (
     <Card className={cn('w-full flex flex-col', className)}>
       <CardHeader>
-        <CardTitle>Loadout Presets</CardTitle>
+        <CardTitle>Presets</CardTitle>
         <CardDescription>Save and load your equipment setups</CardDescription>
       </CardHeader>
       <CardContent>
@@ -206,7 +206,7 @@ export function PresetSelector({ onPresetLoad, className }: PresetSelectorProps)
                 </DialogTrigger>
                 <DialogContent>
                   <DialogHeader>
-                    <DialogTitle>Save Loadout Preset</DialogTitle>
+                    <DialogTitle>Save Preset</DialogTitle>
                     <DialogDescription>
                       Give your preset a name to save your current setup
                     </DialogDescription>
@@ -284,7 +284,7 @@ export function PresetSelector({ onPresetLoad, className }: PresetSelectorProps)
                 </DialogTrigger>
                 <DialogContent>
                   <DialogHeader>
-                    <DialogTitle>Save Loadout Preset</DialogTitle>
+                    <DialogTitle>Save Preset</DialogTitle>
                     <DialogDescription>
                       Give your preset a name to save your current setup
                     </DialogDescription>

--- a/frontend/src/components/features/calculator/Visualizations.tsx
+++ b/frontend/src/components/features/calculator/Visualizations.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import {
   ResponsiveContainer,
   BarChart,
@@ -11,36 +11,41 @@ import {
   Legend,
 } from "recharts";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useCalculatorStore } from "@/store/calculator-store";
+import { calculatorApi } from "@/services/api";
 
 export function Visualizations() {
-  const {
-    params,
-    results,
-    comparisonResults,
-    addComparisonResult,
-    clearComparisonResults,
-  } = useCalculatorStore();
+  const { presets } = useCalculatorStore();
+  const [data, setData] = useState<Array<{ name: string; dps: number; maxHit: number; hitChance: number }>>([]);
 
-  const [label, setLabel] = useState("Setup 1");
+  useEffect(() => {
+    const loadData = async () => {
+      const results = await Promise.all(
+        presets.map(async (p) => {
+          try {
+            const res = await calculatorApi.calculateDps(p.params);
+            return {
+              name: p.name,
+              dps: res.dps,
+              maxHit: res.max_hit,
+              hitChance: res.hit_chance * 100,
+            };
+          } catch {
+            return null;
+          }
+        })
+      );
+      setData(results.filter(Boolean) as any);
+    };
+    if (presets.length > 0) {
+      loadData();
+    } else {
+      setData([]);
+    }
+  }, [presets]);
 
-  const handleAdd = () => {
-    if (!results) return;
-    addComparisonResult(label || `Setup ${comparisonResults.length + 1}`, { ...params }, { ...results });
-    setLabel("");
-  };
-
-  const data = comparisonResults.map((c) => ({
-    name: c.label,
-    dps: c.results.dps,
-    maxHit: c.results.max_hit,
-    hitChance: c.results.hit_chance * 100,
-  }));
-
-  if (comparisonResults.length === 0) {
+  if (presets.length === 0) {
     return (
       <Card>
         <CardHeader>
@@ -48,20 +53,9 @@ export function Visualizations() {
         </CardHeader>
         <CardContent>
           <p className="text-muted-foreground text-sm mb-4 text-center">
-            Save setups to visualize their performance.
+            Save presets to visualize their performance.
           </p>
-          <div className="flex gap-2 justify-center">
-            <Input
-              value={label}
-              onChange={(e) => setLabel(e.target.value)}
-              placeholder="Enter setup name..."
-              className="max-w-xs"
-              disabled={!results}
-            />
-            <Button onClick={handleAdd} disabled={!results}>
-              Save Current Setup
-            </Button>
-          </div>
+          
         </CardContent>
       </Card>
     );
@@ -73,23 +67,7 @@ export function Visualizations() {
         <CardTitle className="text-center">Visualizations</CardTitle>
       </CardHeader>
       <CardContent>
-        <div className="flex justify-end mb-2">
-          <Button variant="outline" size="sm" onClick={clearComparisonResults}>
-            Clear All
-          </Button>
-        </div>
-        <div className="flex gap-2 mb-4 justify-center">
-          <Input
-            value={label}
-            onChange={(e) => setLabel(e.target.value)}
-            placeholder="Enter setup name..."
-            className="max-w-xs"
-            disabled={!results}
-          />
-          <Button onClick={handleAdd} disabled={!results}>
-            Add Current Setup
-          </Button>
-        </div>
+        <div className="mb-4" />
         <Tabs defaultValue="dps" className="w-full">
           <TabsList>
             <TabsTrigger value="dps">DPS</TabsTrigger>

--- a/frontend/src/store/calculator-store.ts
+++ b/frontend/src/store/calculator-store.ts
@@ -26,7 +26,7 @@ interface CalculatorState {
   loadout: Record<string, Item | null>;
   selectedBoss: Boss | null;
   selectedBossForm: BossForm | null;
-  loadoutPresets: Preset[];
+  presets: Preset[];
 
   setParams: (params: Partial<CalculatorParams>) => void;
   switchCombatStyle: (style: 'melee' | 'ranged' | 'magic') => void;
@@ -43,9 +43,10 @@ interface CalculatorState {
   setLoadout: (loadout: Record<string, Item | null>) => void;
   setSelectedBoss: (boss: Boss | null) => void;
   setSelectedBossForm: (form: BossForm | null) => void;
-  setLoadoutPresets: (presets: Preset[]) => void;
-  addLoadoutPreset: (preset: Preset) => void;
-  removeLoadoutPreset: (id: string) => void;
+  setPresets: (presets: Preset[]) => void;
+  addPreset: (preset: Preset) => void;
+  removePreset: (id: string) => void;
+  reorderPresets: (fromIndex: number, toIndex: number) => void;
 }
 
 const defaultMeleeParams: MeleeCalculatorParams = {
@@ -160,7 +161,7 @@ export const useCalculatorStore = create<CalculatorState>()(
       loadout: {},
       selectedBoss: null,
       selectedBossForm: null,
-      loadoutPresets: [],
+      presets: [],
 
       setParams: (newParams: Partial<CalculatorParams>) => set((state): Partial<CalculatorState> => {
         const currentStyle = state.params.combat_style;
@@ -251,17 +252,17 @@ export const useCalculatorStore = create<CalculatorState>()(
       setLoadout: (loadout) => set({ loadout }),
       setSelectedBoss: (boss) => set({ selectedBoss: boss }),
       setSelectedBossForm: (form) => set({ selectedBossForm: form }),
-      setLoadoutPresets: (presets) => set({ loadoutPresets: presets }),
-      addLoadoutPreset: (preset) =>
-        set((state) => ({ loadoutPresets: [...state.loadoutPresets, preset] })),
-      removeLoadoutPreset: (id) =>
-        set((state) => ({ loadoutPresets: state.loadoutPresets.filter((p) => p.id !== id) })),
-      reorderLoadoutPresets: (fromIndex, toIndex) =>
+      setPresets: (presets) => set({ presets }),
+      addPreset: (preset) =>
+        set((state) => ({ presets: [...state.presets, preset] })),
+      removePreset: (id) =>
+        set((state) => ({ presets: state.presets.filter((p) => p.id !== id) })),
+      reorderPresets: (fromIndex, toIndex) =>
         set((state) => {
-          const updated = [...state.loadoutPresets];
+          const updated = [...state.presets];
           const [moved] = updated.splice(fromIndex, 1);
           updated.splice(toIndex, 0, moved);
-          return { loadoutPresets: updated };
+          return { presets: updated };
         })
     }),
     {
@@ -274,7 +275,7 @@ export const useCalculatorStore = create<CalculatorState>()(
         loadout: state.loadout,
         selectedBoss: state.selectedBoss,
         selectedBossForm: state.selectedBossForm,
-        loadoutPresets: state.loadoutPresets,
+        presets: state.presets,
       })
     }
   )


### PR DESCRIPTION
## Summary
- rename `loadoutPresets` store property to `presets`
- update `EquipmentPanel` and `PresetSelector` to use new preset APIs
- remove comparison setup saving from `Visualizations` and display charts for saved presets
- adjust wording in calculator UI

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849415452d0832ebb64b29967d69921