### PR TITLE
Handle partial final attack in DPS sim

### DIFF
--- a/backend/app/calculators/__init__.py
+++ b/backend/app/calculators/__init__.py
@@ -133,13 +133,31 @@ class DpsCalculator:
 
         while time < duration - 1e-9:
             if energy >= cost:
-                special_total += special_damage
-                energy = max(0.0, energy - cost)
+                damage = special_damage
                 step = special_speed
+                energy = max(0.0, energy - cost)
+                special = True
                 special_count += 1
             else:
-                regular_total += regular_damage
+                damage = regular_damage
                 step = attack_speed
+                special = False
+
+            if time + step > duration:
+                frac = (duration - time) / step
+                damage *= frac
+                energy = min(100.0, energy + regen_rate * step * frac)
+                if special:
+                    special_total += damage
+                else:
+                    regular_total += damage
+                time = duration
+                break
+
+            if special:
+                special_total += damage
+            else:
+                regular_total += damage
 
             time += step
             energy = min(100.0, energy + regen_rate * step)

--- a/backend/app/testing/UnitTest.py
+++ b/backend/app/testing/UnitTest.py
@@ -132,6 +132,35 @@ class TestDpsCalculator(unittest.TestCase):
         result = DpsCalculator.calculate_dps(params)
         self.assertEqual(result["special_attacks"], 1)
 
+    def test_partial_final_attack(self):
+        """DPS should scale the final attack when it doesn't fully fit."""
+        params = {
+            "combat_style": "melee",
+            "strength_level": 99,
+            "strength_boost": 0,
+            "strength_prayer": 1.0,
+            "attack_level": 99,
+            "attack_boost": 0,
+            "attack_prayer": 1.0,
+            "melee_strength_bonus": 80,
+            "melee_attack_bonus": 80,
+            "attack_style_bonus_strength": 3,
+            "attack_style_bonus_attack": 0,
+            "attack_speed": 2.0,
+            "target_defence_level": 100,
+            "target_defence_bonus": 50,
+            "duration": 5.0,
+            "special_energy_cost": 1000,
+        }
+
+        avg_hit = MeleeCalculator.calculate_dps(params)["average_hit"]
+        expected_total = 2 * avg_hit + 0.5 * avg_hit
+        expected_dps = expected_total / 5.0
+
+        result = DpsCalculator.calculate_dps(params)
+
+        self.assertAlmostEqual(result["dps"], expected_dps, places=5)
+
 
 class TestMeleeCalculator(unittest.TestCase):
     """Test the Melee Calculator functionality."""


### PR DESCRIPTION
## Summary
- ensure partial final attacks are scaled in DPS simulation
- test that DPS simulation doesn't over-count when the last attack is cut short

## Testing
- `PYTHONPATH=backend pytest backend/app/testing/UnitTest.py::TestDpsCalculator::test_partial_final_attack -q`
- `PYTHONPATH=backend pytest backend/app/testing/UnitTest.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6849426551a8832e8f4519429827718a