### PR TITLE
Add dedicated home page with navigation

### DIFF
--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -62,7 +62,7 @@ The React frontend is found in `frontend/src` and relies on:
 
 ## About Page
 
-A simple about page exists at `frontend/src/app/about/page.tsx` and describes the project, its data sources and technologies used. It links back to the main calculator page.
+A simple about page exists at `frontend/src/app/about/page.tsx` and describes the project, its data sources and technologies used. It links back to the home page.
 
 ## API Pagination
 

--- a/frontend/src/app/about/page.tsx
+++ b/frontend/src/app/about/page.tsx
@@ -62,11 +62,11 @@ export default function AboutPage() {
         </p>
         
         <div className="mt-8">
-          <Link 
+          <Link
             href="/"
             className="bg-primary text-primary-foreground hover:bg-primary/90 py-2 px-4 rounded"
           >
-            Return to Calculator
+            Return Home
           </Link>
         </div>
       </div>

--- a/frontend/src/app/calculator/page.tsx
+++ b/frontend/src/app/calculator/page.tsx
@@ -1,0 +1,9 @@
+import { ImprovedDpsCalculator } from '@/components/features/calculator/ImprovedDpsCalculator';
+
+export default function CalculatorPage() {
+  return (
+    <main id="main" className="container mx-auto py-8 px-4 pb-16">
+      <ImprovedDpsCalculator />
+    </main>
+  );
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,13 +1,14 @@
-// Home page with hero section and embedded calculator
-import { ImprovedDpsCalculator } from '@/components/features/calculator/ImprovedDpsCalculator';
 import HomeHero from '@/components/layout/HomeHero';
 
 export default function Home() {
   return (
     <>
       <HomeHero />
-      <main id="main" className="container mx-auto py-8 px-4 pb-16">
-        <ImprovedDpsCalculator />
+      <main id="main" className="container mx-auto py-8 px-4 pb-16 text-center">
+        <p className="text-xl text-muted-foreground mb-8 max-w-2xl mx-auto">
+          Welcome to ScapeLab, a suite of tools to help optimize your Old School RuneScape gameplay.
+        </p>
+        <p className="text-lg">Choose a tool from the navigation above or the buttons below to get started.</p>
       </main>
     </>
   );

--- a/frontend/src/components/layout/HomeHero.tsx
+++ b/frontend/src/components/layout/HomeHero.tsx
@@ -6,14 +6,17 @@ export default function HomeHero() {
       <div className="absolute inset-0 bg-black/60" aria-hidden="true" />
       <div className="relative container mx-auto px-4">
         <h1 className="text-5xl md:text-6xl font-title text-primary drop-shadow-md mb-6">
-          OSRS DPS Calculator
+          ScapeLab Tools
         </h1>
         <p className="text-lg md:text-xl text-muted-foreground max-w-2xl mx-auto mb-8">
-          Optimize your damage output with accurate Old School RuneScape combat calculations.
+          Optimize your Old School RuneScape experience with our calculators and simulations.
         </p>
-        <Link href="#main" className="btn-primary inline-block">
-          Launch Calculator
-        </Link>
+        <div className="flex flex-wrap justify-center gap-4">
+          <Link href="/calculator" className="btn-primary inline-block">Calculator</Link>
+          <Link href="/simulate" className="btn-primary inline-block">Simulation</Link>
+          <Link href="/import" className="btn-primary inline-block">Import</Link>
+          <Link href="/about" className="btn-primary inline-block">About</Link>
+        </div>
       </div>
     </section>
   );

--- a/frontend/src/components/layout/Navigation.tsx
+++ b/frontend/src/components/layout/Navigation.tsx
@@ -27,6 +27,15 @@ export function Navigation() {
                 pathname === '/' ? 'text-foreground font-medium' : 'text-muted-foreground'
               )}
             >
+              Home
+            </Link>
+            <Link
+              href="/calculator"
+              className={cn(
+                'text-sm transition-colors hover:text-primary',
+                pathname === '/calculator' ? 'text-foreground font-medium' : 'text-muted-foreground'
+              )}
+            >
               Calculator
             </Link>
             <Link


### PR DESCRIPTION
## Summary
- split calculator into separate page
- update navigation with Home and Calculator links
- show multiple buttons in hero section
- update about page link
- clarify docs about link to home page

## Testing
- `npm test --prefix frontend`
- `npm run lint --prefix frontend` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_684944499d78832eaa9ea1f9b692c9cd