### PR TITLE
Improve BIS item selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Additional documentation can be found in the `docs/` folder:
 
     docs/ARCHITECTURE.md - High level component diagram
     docs/WIREFRAME.md    - Basic UI wireframe
+    docs/BEST_IN_SLOT_FINDER.md - How the BIS algorithm works
 
 Technical Documentation
 Frontend Architecture

--- a/backend/app/services/bis_service.py
+++ b/backend/app/services/bis_service.py
@@ -9,6 +9,9 @@ def suggest_bis(params: Dict[str, Any]) -> Dict[str, Any]:
     items = item_repository.get_all_items(combat_only=True, tradeable_only=False)
     best_per_slot: Dict[str, Dict[str, Any]] = {}
 
+    style = params.get("combat_style", "melee").lower()
+    atk_type = params.get("attack_type", "slash").lower()
+
     for item in items:
         slot = item.get("slot")
         if not slot:
@@ -18,22 +21,39 @@ def suggest_bis(params: Dict[str, Any]) -> Dict[str, Any]:
         attack_bonuses = stats.get("attack_bonuses", {})
         other_bonuses = stats.get("other_bonuses", {})
 
+        # Skip items that provide no relevant bonuses for the chosen style
+        if style == "melee":
+            atk_bonus = attack_bonuses.get(atk_type, 0)
+            str_bonus = other_bonuses.get("strength", 0)
+            if atk_bonus <= 0 and str_bonus <= 0:
+                continue
+        elif style == "ranged":
+            atk_bonus = attack_bonuses.get("ranged", 0)
+            str_bonus = other_bonuses.get("ranged strength", 0)
+            if atk_bonus <= 0 and str_bonus <= 0:
+                continue
+        else:
+            atk_bonus = attack_bonuses.get("magic", 0)
+            dmg_bonus = other_bonuses.get("magic damage", "0")
+            if isinstance(dmg_bonus, str) and dmg_bonus.endswith("%"):
+                dmg_bonus = float(dmg_bonus.strip("%")) / 100
+            if atk_bonus <= 0 and float(dmg_bonus or 0) <= 0:
+                continue
+
         test_params = params.copy()
 
-        style = params.get("combat_style", "melee")
         if style == "melee":
-            test_params["melee_strength_bonus"] = other_bonuses.get("strength", 0)
-            atk_type = params.get("attack_type", "slash").lower()
-            test_params["melee_attack_bonus"] = attack_bonuses.get(atk_type, 0)
+            test_params["melee_strength_bonus"] = str_bonus
+            test_params["melee_attack_bonus"] = atk_bonus
         elif style == "ranged":
-            test_params["ranged_strength_bonus"] = other_bonuses.get("ranged strength", 0)
-            test_params["ranged_attack_bonus"] = attack_bonuses.get("ranged", 0)
+            test_params["ranged_strength_bonus"] = str_bonus
+            test_params["ranged_attack_bonus"] = atk_bonus
         else:  # magic
             dmg_bonus = other_bonuses.get("magic damage", "0")
             if isinstance(dmg_bonus, str) and dmg_bonus.endswith("%"):
                 dmg_bonus = float(dmg_bonus.strip("%")) / 100
             test_params["magic_damage_bonus"] = float(dmg_bonus or 0)
-            test_params["magic_attack_bonus"] = attack_bonuses.get("magic", 0)
+            test_params["magic_attack_bonus"] = atk_bonus
 
         result = calculation_service.calculate_dps(test_params)
         dps = result.get("dps", 0)
@@ -50,6 +70,9 @@ async def suggest_bis_async(params: Dict[str, Any]) -> Dict[str, Any]:
     items = await item_repository.get_all_items_async(combat_only=True, tradeable_only=False)
     best_per_slot: Dict[str, Dict[str, Any]] = {}
 
+    style = params.get("combat_style", "melee").lower()
+    atk_type = params.get("attack_type", "slash").lower()
+
     for item in items:
         slot = item.get("slot")
         if not slot:
@@ -59,22 +82,36 @@ async def suggest_bis_async(params: Dict[str, Any]) -> Dict[str, Any]:
         attack_bonuses = stats.get("attack_bonuses", {})
         other_bonuses = stats.get("other_bonuses", {})
 
-        test_params = params.copy()
-
-        style = params.get("combat_style", "melee")
+        # Skip items that provide no relevant bonuses for the chosen style
         if style == "melee":
-            test_params["melee_strength_bonus"] = other_bonuses.get("strength", 0)
-            atk_type = params.get("attack_type", "slash").lower()
-            test_params["melee_attack_bonus"] = attack_bonuses.get(atk_type, 0)
+            atk_bonus = attack_bonuses.get(atk_type, 0)
+            str_bonus = other_bonuses.get("strength", 0)
+            if atk_bonus <= 0 and str_bonus <= 0:
+                continue
         elif style == "ranged":
-            test_params["ranged_strength_bonus"] = other_bonuses.get("ranged strength", 0)
-            test_params["ranged_attack_bonus"] = attack_bonuses.get("ranged", 0)
+            atk_bonus = attack_bonuses.get("ranged", 0)
+            str_bonus = other_bonuses.get("ranged strength", 0)
+            if atk_bonus <= 0 and str_bonus <= 0:
+                continue
         else:
+            atk_bonus = attack_bonuses.get("magic", 0)
             dmg_bonus = other_bonuses.get("magic damage", "0")
             if isinstance(dmg_bonus, str) and dmg_bonus.endswith("%"):
                 dmg_bonus = float(dmg_bonus.strip("%")) / 100
+            if atk_bonus <= 0 and float(dmg_bonus or 0) <= 0:
+                continue
+
+        test_params = params.copy()
+
+        if style == "melee":
+            test_params["melee_strength_bonus"] = str_bonus
+            test_params["melee_attack_bonus"] = atk_bonus
+        elif style == "ranged":
+            test_params["ranged_strength_bonus"] = str_bonus
+            test_params["ranged_attack_bonus"] = atk_bonus
+        else:
             test_params["magic_damage_bonus"] = float(dmg_bonus or 0)
-            test_params["magic_attack_bonus"] = attack_bonuses.get("magic", 0)
+            test_params["magic_attack_bonus"] = atk_bonus
 
         result = calculation_service.calculate_dps(test_params)
         dps = result.get("dps", 0)

--- a/docs/BEST_IN_SLOT_FINDER.md
+++ b/docs/BEST_IN_SLOT_FINDER.md
@@ -1,0 +1,63 @@
+# Best in Slot Finder
+
+This page explains the logic behind the Best in Slot (BIS) feature and ways it could be improved.
+
+The backend implements BIS in `backend/app/services/bis_service.py`.
+For each item it calculates DPS with that item equipped and keeps the best result per slot:
+
+```python
+from typing import Dict, Any
+from ..repositories import item_repository
+from . import calculation_service
+
+
+def suggest_bis(params: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a naive best-in-slot setup for the given parameters."""
+    items = item_repository.get_all_items(combat_only=True, tradeable_only=False)
+    best_per_slot: Dict[str, Dict[str, Any]] = {}
+
+    for item in items:
+        slot = item.get("slot")
+        if not slot:
+            continue
+
+        stats = item.get("combat_stats") or {}
+        attack_bonuses = stats.get("attack_bonuses", {})
+        other_bonuses = stats.get("other_bonuses", {})
+
+        test_params = params.copy()
+
+        style = params.get("combat_style", "melee")
+        if style == "melee":
+            test_params["melee_strength_bonus"] = other_bonuses.get("strength", 0)
+            atk_type = params.get("attack_type", "slash").lower()
+            test_params["melee_attack_bonus"] = attack_bonuses.get(atk_type, 0)
+        elif style == "ranged":
+            test_params["ranged_strength_bonus"] = other_bonuses.get("ranged strength", 0)
+            test_params["ranged_attack_bonus"] = attack_bonuses.get("ranged", 0)
+        else:  # magic
+            dmg_bonus = other_bonuses.get("magic damage", "0")
+            if isinstance(dmg_bonus, str) and dmg_bonus.endswith("%"):
+                dmg_bonus = float(dmg_bonus.strip("%")) / 100
+            test_params["magic_damage_bonus"] = float(dmg_bonus or 0)
+            test_params["magic_attack_bonus"] = attack_bonuses.get("magic", 0)
+
+        result = calculation_service.calculate_dps(test_params)
+        dps = result.get("dps", 0)
+
+        current_best = best_per_slot.get(slot)
+        if not current_best or dps > current_best["dps"]:
+            best_per_slot[slot] = {"item": item, "dps": dps}
+
+    return {slot: info["item"] for slot, info in best_per_slot.items()}
+```
+
+This simple approach selects the highest DPS item for each slot independently. It ignores set bonuses, special attack synergy and other restrictions.
+
+## Possible Improvements
+
+- Evaluate gear synergies or set bonuses.
+- Filter items by player requirements such as levels or quest completion.
+- Include special attacks and passive effects in the ranking.
+- Offer multiple ranked options rather than a single item per slot.
+

--- a/frontend/src/app/best-in-slot/page.tsx
+++ b/frontend/src/app/best-in-slot/page.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import { ImprovedDpsCalculator } from '@/components/features/calculator/ImprovedDpsCalculator';
+
+export default function BestInSlotPage() {
+  return (
+    <main id="main" className="container mx-auto py-8 px-4 pb-16">
+      <h1 className="text-4xl font-bold mb-6 text-center">Best in Slot Finder</h1>
+      <p className="text-center text-muted-foreground mb-8 max-w-2xl mx-auto">
+        Quickly determine the optimal gear for your stats and target.
+      </p>
+      <ImprovedDpsCalculator />
+    </main>
+  );
+}

--- a/frontend/src/components/layout/Navigation.tsx
+++ b/frontend/src/components/layout/Navigation.tsx
@@ -48,6 +48,15 @@ export function Navigation() {
               Import
             </Link>
             <Link
+              href="/best-in-slot"
+              className={cn(
+                'text-sm transition-colors hover:text-primary',
+                pathname === '/best-in-slot' ? 'text-foreground font-medium' : 'text-muted-foreground'
+              )}
+            >
+              Best in Slot
+            </Link>
+            <Link
               href="/about"
               className={cn(
                 'text-sm transition-colors hover:text-primary',


### PR DESCRIPTION
## Summary
- filter BIS suggestions to ignore items without relevant bonuses

## Testing
- `python -m unittest discover backend/app/testing` *(fails: ModuleNotFoundError httpx, cachetools)*
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68494249e6ac832e88510be4239641bf