### PR TITLE
Add bug report page and GitHub issue workflow

### DIFF
--- a/.github/workflows/create-bug-issue.yml
+++ b/.github/workflows/create-bug-issue.yml
@@ -1,0 +1,26 @@
+name: Create Issue from Bug Report
+
+on:
+  repository_dispatch:
+    types: [bug_report]
+
+jobs:
+  create_issue:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create issue
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const payload = context.payload.client_payload || {};
+            const title = payload.title || 'Bug report';
+            const body = payload.body || '';
+            const { data: issue } = await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body,
+              labels: ['bug-report']
+            });
+            console.log(`Created issue: ${issue.html_url}`);

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A comprehensive damage-per-second calculator for Old School RuneScape with accur
 
 Overview
 
+    If you encounter a bug or have a suggestion, submit it from the [Report Bug](/report-bug) page. Reports are automatically converted into GitHub issues via a workflow.
 The ScapeLab DPS Calculator is a powerful tool for Old School RuneScape players to optimize their combat gear and strategies. By accurately implementing the game's combat formulas, this calculator helps players compare different equipment setups, account for special effects, and calculate expected damage against various bosses.
 Key Features
 
@@ -373,6 +374,7 @@ Contributions are welcome! Please follow these steps:
     Commit your changes: git commit -m 'Add amazing feature'
     Push to the branch: git push origin feature/amazing-feature
     Open a Pull Request
+    If you encounter a bug or have a suggestion, submit it from the [Report Bug](/report-bug) page. Reports are automatically converted into GitHub issues via a workflow.
 
 For major changes, please open an issue first to discuss what you would like to change.
 Development Guidelines

--- a/frontend/src/app/api/report-bug/route.ts
+++ b/frontend/src/app/api/report-bug/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(request: NextRequest) {
+  const { title, body } = await request.json();
+
+  if (!title || !body) {
+    return NextResponse.json({ error: 'Missing fields' }, { status: 400 });
+  }
+
+  const token = process.env.GITHUB_BUG_TOKEN;
+  const repo = process.env.GITHUB_REPO || 'QualitySushi/osrs-simulator';
+
+  if (!token) {
+    return NextResponse.json({ error: 'GitHub token not configured' }, { status: 500 });
+  }
+
+  const res = await fetch(`https://api.github.com/repos/${repo}/dispatches`, {
+    method: 'POST',
+    headers: {
+      Authorization: `token ${token}`,
+      Accept: 'application/vnd.github+json',
+    },
+    body: JSON.stringify({
+      event_type: 'bug_report',
+      client_payload: { title, body },
+    }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    return NextResponse.json({ error: 'GitHub dispatch failed', details: text }, { status: 500 });
+  }
+
+  return NextResponse.json({ status: 'queued' });
+}

--- a/frontend/src/app/report-bug/page.tsx
+++ b/frontend/src/app/report-bug/page.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { useState } from 'react';
+
+export default function ReportBugPage() {
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [status, setStatus] = useState<'idle' | 'submitting' | 'success' | 'error'>('idle');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setStatus('submitting');
+    try {
+      const res = await fetch('/api/report-bug', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title, body: description }),
+      });
+
+      if (res.ok) {
+        setTitle('');
+        setDescription('');
+        setStatus('success');
+      } else {
+        setStatus('error');
+      }
+    } catch {
+      setStatus('error');
+    }
+  };
+
+  return (
+    <main id="main" className="container mx-auto py-8 px-4">
+      <h1 className="text-2xl font-bold mb-4">Report a Bug</h1>
+      <form onSubmit={handleSubmit} className="space-y-4 max-w-xl">
+        <div>
+          <label className="block mb-1 font-medium">Title</label>
+          <input
+            className="w-full border p-2 rounded"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            required
+          />
+        </div>
+        <div>
+          <label className="block mb-1 font-medium">Description</label>
+          <textarea
+            className="w-full border p-2 rounded"
+            rows={6}
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            required
+          />
+        </div>
+        <button
+          type="submit"
+          className="bg-primary text-primary-foreground px-4 py-2 rounded"
+          disabled={status === 'submitting'}
+        >
+          Submit
+        </button>
+        {status === 'success' && (
+          <p className="text-green-600 mt-2">Thank you! Your report has been submitted.</p>
+        )}
+        {status === 'error' && (
+          <p className="text-red-600 mt-2">There was an error submitting your report.</p>
+        )}
+      </form>
+    </main>
+  );
+}

--- a/frontend/src/components/layout/Navigation.tsx
+++ b/frontend/src/components/layout/Navigation.tsx
@@ -74,6 +74,15 @@ export function Navigation() {
             >
               About
             </Link>
+            <Link
+              href="/report-bug"
+              className={cn(
+                'text-sm transition-colors hover:text-primary',
+                pathname === '/report-bug' ? 'text-foreground font-medium' : 'text-muted-foreground'
+              )}
+            >
+              Report Bug
+            </Link>
           </div>
         </div>
         


### PR DESCRIPTION
## Summary
- add page `/report-bug` with a form to submit bug reports
- add API route that dispatches a `bug_report` event to GitHub
- create workflow to open an issue when a report is dispatched
- link to the new page from the navigation
- mention bug report page in README

## Testing
- `npm run lint` *(fails: numerous pre-existing ESLint errors)*
- `npm test` in `frontend`
- `python -m unittest discover backend/app/testing` *(fails: database and driver missing)*

------
https://chatgpt.com/codex/tasks/task_e_6849474e5158832e94690ca54acf59f1