### PR TITLE
Add news page

### DIFF
--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -64,6 +64,12 @@ The React frontend is found in `frontend/src` and relies on:
 
 A simple about page exists at `frontend/src/app/about/page.tsx` and describes the project, its data sources and technologies used. It links back to the home page.
 
+## News Page
+
+The news page located at `frontend/src/app/news/page.tsx` stores articles in
+`localStorage`. Users can submit a title and content through a simple form to
+create new posts that persist across reloads in the browser.
+
 ## API Pagination
 
 The `/items` and `/bosses` endpoints accept optional `page` and `page_size` query parameters. These correspond to SQL `OFFSET`/`FETCH` clauses in the database service.

--- a/frontend/src/__tests__/news.test.tsx
+++ b/frontend/src/__tests__/news.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import NewsPage from '../app/news/page';
+
+describe('news page', () => {
+  it('renders heading', () => {
+    render(<NewsPage />);
+    expect(screen.getByRole('heading', { name: /news/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/news/page.tsx
+++ b/frontend/src/app/news/page.tsx
@@ -1,0 +1,72 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+
+interface Article {
+  id: number;
+  title: string;
+  content: string;
+}
+
+export default function NewsPage() {
+  const [articles, setArticles] = useState<Article[]>([]);
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
+
+  useEffect(() => {
+    const stored = localStorage.getItem('newsArticles');
+    if (stored) {
+      try {
+        setArticles(JSON.parse(stored));
+      } catch {
+        setArticles([]);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem('newsArticles', JSON.stringify(articles));
+  }, [articles]);
+
+  const addArticle = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!title.trim() || !content.trim()) return;
+    setArticles(prev => [
+      ...prev,
+      { id: Date.now(), title: title.trim(), content: content.trim() },
+    ]);
+    setTitle('');
+    setContent('');
+  };
+
+  return (
+    <main id="main" className="container mx-auto py-8 px-4">
+      <h1 className="text-4xl font-bold mb-8 text-center">News</h1>
+      <form onSubmit={addArticle} className="space-y-4 mb-8 max-w-xl mx-auto">
+        <Input
+          value={title}
+          onChange={e => setTitle(e.target.value)}
+          placeholder="Title"
+        />
+        <textarea
+          className="w-full h-32 p-2 rounded border"
+          value={content}
+          onChange={e => setContent(e.target.value)}
+          placeholder="Content"
+        />
+        <Button type="submit" className="w-full">
+          Post Article
+        </Button>
+      </form>
+      <ul className="space-y-6 max-w-xl mx-auto">
+        {articles.map(article => (
+          <li key={article.id} className="border p-4 rounded">
+            <h2 className="text-xl font-semibold mb-2">{article.title}</h2>
+            <p>{article.content}</p>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/frontend/src/components/layout/Navigation.tsx
+++ b/frontend/src/components/layout/Navigation.tsx
@@ -66,6 +66,15 @@ export function Navigation() {
               Best in Slot
             </Link>
             <Link
+              href="/news"
+              className={cn(
+                'text-sm transition-colors hover:text-primary',
+                pathname === '/news' ? 'text-foreground font-medium' : 'text-muted-foreground'
+              )}
+            >
+              News
+            </Link>
+            <Link
               href="/about"
               className={cn(
                 'text-sm transition-colors hover:text-primary',


### PR DESCRIPTION
## Summary
- add a simple news page where users can write articles
- link to the news page from navigation
- document the new page in the developer guide
- test rendering of the news page

## Testing
- `npm test --silent`
- `python -m unittest discover app/testing` *(fails: ODBC Driver 17 for SQL Server not found)*

------
https://chatgpt.com/codex/tasks/task_e_684947666b40832eb8061c997fc9c83d