### PR TITLE
Fix weapon label toggle in equipment display

### DIFF
--- a/frontend/src/components/features/calculator/CombinedEquipmentDisplay.tsx
+++ b/frontend/src/components/features/calculator/CombinedEquipmentDisplay.tsx
@@ -444,7 +444,7 @@ export function CombinedEquipmentDisplay({ onEquipmentUpdate, bossForm, loadoutP
               className="mr-2 data-[state=unchecked]:bg-primary"
             />
             <Label htmlFor="use-2h" className="text-sm">
-              {show2hOption ? 'Using 1H' : 'Using 2H'}
+              {show2hOption ? 'Using 2H' : 'Using 1H'}
             </Label>
           </div>
           


### PR DESCRIPTION
## Summary
- fix label text when toggling between 1H and 2H weapon modes

## Testing
- `python app/testing/UnitTest.py`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68494ecb40cc832ea69284013ac01a40