### PR TITLE
Update BIS component and buttons

### DIFF
--- a/frontend/src/app/best-in-slot/page.tsx
+++ b/frontend/src/app/best-in-slot/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { BasicDpsCalculator } from '@/components/features/calculator/BasicDpsCalculator';
+import { BestInSlotCalculator } from '@/components/features/calculator/BestInSlotCalculator';
 
 export default function BestInSlotPage() {
   return (
@@ -11,7 +11,7 @@ export default function BestInSlotPage() {
       <p className="text-center text-muted-foreground mb-8 max-w-2xl mx-auto">
         Quickly determine the optimal gear for your stats and target.
       </p>
-      <BasicDpsCalculator />
+      <BestInSlotCalculator />
     </main>
   );
 }

--- a/frontend/src/components/features/calculator/BestInSlotCalculator.tsx
+++ b/frontend/src/components/features/calculator/BestInSlotCalculator.tsx
@@ -2,7 +2,7 @@
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Info } from 'lucide-react';
-import { useEffect } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { useReferenceDataStore } from '@/store/reference-data-store';
 import { BossSelector } from './BossSelector';
 import { CombinedEquipmentDisplay } from './CombinedEquipmentDisplay';
@@ -11,32 +11,89 @@ import { CalculatorForms } from './CalculatorForms';
 import { CombatStyleTabs } from './CombatStyleTabs';
 import { DpsResultDisplay } from './DpsResultDisplay';
 import { useDpsCalculator } from '@/hooks/useDpsCalculator';
+import { calculatorApi } from '@/services/api';
+import { useToast } from '@/hooks/use-toast';
 
 /**
- * BasicDpsCalculator - A stripped-down DPS Calculator containing only
- * the components necessary for item and target selection.
+ * BestInSlotCalculator - A stripped-down DPS Calculator focused on
+ * suggesting optimal equipment setups.
  * This component improves on the original by:
  * - Creating a consistent layout with proper alignment
  * - Balancing the height between columns
  * - Using a logical grouping of related components
  * - Providing better visual hierarchy and readability
  */
-export function BasicDpsCalculator() {
+export function BestInSlotCalculator() {
   const {
     params,
     results,
     activeTab,
     appliedPassiveEffects,
-    handleCalculate,
     handleReset,
     handleTabChange,
     handleEquipmentUpdate,
     handleBossUpdate,
-    isCalculating,
-    currentLoadout,
     currentBossForm,
   } = useDpsCalculator();
   const initData = useReferenceDataStore((s) => s.initData);
+  const { toast } = useToast();
+  const [isSuggesting, setIsSuggesting] = useState(false);
+
+  const sanitizeParams = useCallback((p: any): any => {
+    const { selected_spell, ...cleaned } = p as any;
+    if (!cleaned.target_defence_type) {
+      if (p.combat_style === 'melee') {
+        cleaned.target_defence_type = `defence_${cleaned.attack_type || 'slash'}`;
+      } else if (p.combat_style === 'ranged') {
+        cleaned.target_defence_type = 'defence_ranged_standard';
+      } else if (p.combat_style === 'magic') {
+        cleaned.target_defence_type = 'defence_magic';
+      }
+    }
+    if (p.combat_style === 'magic') {
+      delete cleaned.attack_style_bonus_attack;
+      delete cleaned.attack_style_bonus_strength;
+      cleaned.magic_level = Number(cleaned.magic_level);
+      cleaned.magic_boost = Number(cleaned.magic_boost);
+      cleaned.magic_prayer = Number(cleaned.magic_prayer);
+      cleaned.base_spell_max_hit = Number(cleaned.base_spell_max_hit);
+      cleaned.magic_attack_bonus = Number(cleaned.magic_attack_bonus);
+      cleaned.magic_damage_bonus = Number(cleaned.magic_damage_bonus);
+      cleaned.target_magic_level = Number(cleaned.target_magic_level);
+      cleaned.target_magic_defence = Number(cleaned.target_magic_defence);
+      cleaned.attack_speed = Number(cleaned.attack_speed);
+    }
+    if (!cleaned.special_attack_cost) delete cleaned.special_attack_cost;
+    if (cleaned.special_multiplier === 1.0) delete cleaned.special_multiplier;
+    if (cleaned.special_accuracy_multiplier === 1.0)
+      delete cleaned.special_accuracy_multiplier;
+    if (cleaned.special_hit_count === 1) delete cleaned.special_hit_count;
+    if (cleaned.special_attack_speed === undefined)
+      delete cleaned.special_attack_speed;
+    if (cleaned.special_damage_multiplier === undefined)
+      delete cleaned.special_damage_multiplier;
+    if (cleaned.special_accuracy_modifier === undefined)
+      delete cleaned.special_accuracy_modifier;
+    if (cleaned.special_energy_cost === undefined) delete cleaned.special_energy_cost;
+    if (cleaned.special_regen_rate === 10 / 30) delete cleaned.special_regen_rate;
+    if (cleaned.initial_special_energy === 100) delete cleaned.initial_special_energy;
+    return cleaned;
+  }, []);
+
+  const handleSuggestBis = async () => {
+    setIsSuggesting(true);
+    try {
+      toast.info('Fetching best-in-slot setup...');
+      const clean = sanitizeParams(params);
+      const setup = await calculatorApi.getBis(clean);
+      handleEquipmentUpdate(setup);
+      toast.success('Best-in-slot setup applied');
+    } catch (e: any) {
+      toast.error(`Failed to fetch BIS: ${e.message}`);
+    } finally {
+      setIsSuggesting(false);
+    }
+  };
 
   useEffect(() => {
     initData();
@@ -67,8 +124,8 @@ export function BasicDpsCalculator() {
           <CalculatorForms
             activeTab={activeTab}
             onTabChange={handleTabChange}
-            onCalculate={handleCalculate}
-            isCalculating={isCalculating}
+            onSuggestBis={handleSuggestBis}
+            isCalculating={isSuggesting}
           />
 
           {results && (
@@ -88,6 +145,7 @@ export function BasicDpsCalculator() {
           <CombinedEquipmentDisplay
             onEquipmentUpdate={handleEquipmentUpdate}
             bossForm={currentBossForm}
+            showSuggestButton={false}
           />
           {/* Prayer/Potion selector */}
           <PrayerPotionSelector className="flex-grow" />
@@ -103,4 +161,4 @@ export function BasicDpsCalculator() {
   );
 }
 
-export default BasicDpsCalculator;
+export default BestInSlotCalculator;

--- a/frontend/src/components/features/calculator/CalculatorForms.tsx
+++ b/frontend/src/components/features/calculator/CalculatorForms.tsx
@@ -14,7 +14,8 @@ import { CombatStyle } from '@/types/calculator';
 interface CalculatorFormsProps {
   activeTab: CombatStyle;
   onTabChange: (style: CombatStyle) => void;
-  onCalculate: () => void;
+  onCalculate?: () => void;
+  onSuggestBis?: () => void;
   isCalculating: boolean;
 }
 
@@ -22,6 +23,7 @@ export function CalculatorForms({
   activeTab,
   onTabChange,
   onCalculate,
+  onSuggestBis,
   isCalculating,
 }: CalculatorFormsProps) {
   const [showManual, setShowManual] = useState(false);
@@ -62,11 +64,17 @@ export function CalculatorForms({
       )}
       <div className="mt-6 flex justify-center">
         <Button
-          onClick={onCalculate}
+          onClick={onSuggestBis ?? onCalculate}
           disabled={isCalculating}
           className="w-full max-w-md text-base py-2"
         >
-          {isCalculating ? 'Calculating...' : 'Calculate DPS'}
+          {isCalculating
+            ? onSuggestBis
+              ? 'Fetching...'
+              : 'Calculating...'
+            : onSuggestBis
+            ? 'Suggest BIS'
+            : 'Calculate DPS'}
         </Button>
       </div>
     </div>

--- a/frontend/src/components/features/calculator/CombinedEquipmentDisplay.tsx
+++ b/frontend/src/components/features/calculator/CombinedEquipmentDisplay.tsx
@@ -51,9 +51,15 @@ interface CombinedEquipmentDisplayProps {
   onEquipmentUpdate?: (loadout: Record<string, Item | null>) => void;
   bossForm?: BossForm | null;
   loadoutPreset?: Record<string, Item | null>;
+  showSuggestButton?: boolean;
 }
 
-export function CombinedEquipmentDisplay({ onEquipmentUpdate, bossForm, loadoutPreset }: CombinedEquipmentDisplayProps) {
+export function CombinedEquipmentDisplay({
+  onEquipmentUpdate,
+  bossForm,
+  loadoutPreset,
+  showSuggestButton = false,
+}: CombinedEquipmentDisplayProps) {
   const { params, setParams, gearLocked, loadout, setLoadout, resetParams, resetLocks, switchCombatStyle } = useCalculatorStore();
   // Start with 1H + Shield by default
   const [show2hOption, setShow2hOption] = useState(false);
@@ -468,9 +474,11 @@ export function CombinedEquipmentDisplay({ onEquipmentUpdate, bossForm, loadoutP
               Reset Equipment
             </Button>
           )}
-          <Button size="sm" onClick={handleSuggestBis} disabled={isSuggesting}>
-            {isSuggesting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}Suggest BIS
-          </Button>
+          {showSuggestButton && (
+            <Button size="sm" onClick={handleSuggestBis} disabled={isSuggesting}>
+              {isSuggesting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}Suggest BIS
+            </Button>
+          )}
         </div>
 
         {gearLocked && (

--- a/frontend/src/components/features/calculator/EquipmentPanel.tsx
+++ b/frontend/src/components/features/calculator/EquipmentPanel.tsx
@@ -126,6 +126,7 @@ export function EquipmentPanel({ onEquipmentUpdate, bossForm }: EquipmentPanelPr
             <CombinedEquipmentDisplay
               onEquipmentUpdate={handleEquipmentUpdate}
               bossForm={bossForm}
+              showSuggestButton={false}
             />
           </TabsContent>
         </Tabs>

--- a/frontend/src/components/features/calculator/improved/MiddleColumns.tsx
+++ b/frontend/src/components/features/calculator/improved/MiddleColumns.tsx
@@ -27,7 +27,11 @@ export function MiddleColumns({
   return (
     <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
       <div className="space-y-6 flex flex-col">
-        <CombinedEquipmentDisplay onEquipmentUpdate={onEquipmentUpdate} bossForm={currentBossForm} />
+        <CombinedEquipmentDisplay
+          onEquipmentUpdate={onEquipmentUpdate}
+          bossForm={currentBossForm}
+          showSuggestButton={false}
+        />
         <PrayerPotionSelector className="flex-grow" />
       </div>
       <div className="space-y-6 flex flex-col flex-grow">


### PR DESCRIPTION
## Summary
- rename `BasicDpsCalculator` to `BestInSlotCalculator`
- swap Calculate DPS button with Suggest BIS button on the BIS finder page
- add optional Suggest BIS support to `CalculatorForms`
- hide Suggest BIS button in regular calculator views

## Testing
- `npx next lint` *(fails: needs packages)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68494e75cf2c832ea4fb60bf2c5b0cbf