### PR TITLE
Improve navigation and home/about pages

### DIFF
--- a/frontend/src/app/about/page.tsx
+++ b/frontend/src/app/about/page.tsx
@@ -4,8 +4,8 @@ export default function AboutPage() {
   return (
     <main id="main" className="container mx-auto py-8 px-4">
       <h1 className="text-4xl font-bold mb-8 text-center">About ScapeLab</h1>
-      
-      <div className="prose dark:prose-invert max-w-3xl">
+
+      <div className="prose dark:prose-invert max-w-3xl mx-auto bg-muted/50 p-6 rounded-lg shadow">
         <p className="lead text-center">
           ScapeLab is an open-source DPS calculator and gear optimizer for Old School RuneScape.
           Use it to compare different loadouts and plan for maximum damage against any boss or monster.

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,4 +1,6 @@
 import HomeHero from '@/components/layout/HomeHero';
+import Link from 'next/link';
+import { Card, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 
 export default function Home() {
   return (
@@ -9,6 +11,41 @@ export default function Home() {
           Welcome to ScapeLab, a suite of tools to help optimize your Old School RuneScape gameplay.
         </p>
         <p className="text-lg">Choose a tool from the navigation above or the buttons below to get started.</p>
+
+        <div className="mt-12 grid gap-6 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+          <Link href="/calculator">
+            <Card className="hover:border-primary transition-colors">
+              <CardHeader>
+                <CardTitle>Calculator</CardTitle>
+                <CardDescription>DPS and max hit calculations</CardDescription>
+              </CardHeader>
+            </Card>
+          </Link>
+          <Link href="/best-in-slot">
+            <Card className="hover:border-primary transition-colors">
+              <CardHeader>
+                <CardTitle>Best in Slot</CardTitle>
+                <CardDescription>Find optimal gear</CardDescription>
+              </CardHeader>
+            </Card>
+          </Link>
+          <Link href="/simulate">
+            <Card className="hover:border-primary transition-colors">
+              <CardHeader>
+                <CardTitle>Simulation</CardTitle>
+                <CardDescription>Run combat scenarios</CardDescription>
+              </CardHeader>
+            </Card>
+          </Link>
+          <Link href="/import">
+            <Card className="hover:border-primary transition-colors">
+              <CardHeader>
+                <CardTitle>Import</CardTitle>
+                <CardDescription>Load saved setups</CardDescription>
+              </CardHeader>
+            </Card>
+          </Link>
+        </div>
       </main>
     </>
   );

--- a/frontend/src/components/layout/HomeHero.tsx
+++ b/frontend/src/components/layout/HomeHero.tsx
@@ -13,6 +13,7 @@ export default function HomeHero() {
         </p>
         <div className="flex flex-wrap justify-center gap-4">
           <Link href="/calculator" className="btn-primary inline-block">Calculator</Link>
+          <Link href="/best-in-slot" className="btn-primary inline-block">Best in Slot</Link>
           <Link href="/simulate" className="btn-primary inline-block">Simulation</Link>
           <Link href="/import" className="btn-primary inline-block">Import</Link>
           <Link href="/about" className="btn-primary inline-block">About</Link>

--- a/frontend/src/components/layout/Navigation.tsx
+++ b/frontend/src/components/layout/Navigation.tsx
@@ -39,6 +39,15 @@ export function Navigation() {
               Calculator
             </Link>
             <Link
+              href="/best-in-slot"
+              className={cn(
+                'text-sm transition-colors hover:text-primary',
+                pathname === '/best-in-slot' ? 'text-foreground font-medium' : 'text-muted-foreground'
+              )}
+            >
+              Best in Slot
+            </Link>
+            <Link
               href="/simulate"
               className={cn(
                 'text-sm transition-colors hover:text-primary',
@@ -55,15 +64,6 @@ export function Navigation() {
               )}
             >
               Import
-            </Link>
-            <Link
-              href="/best-in-slot"
-              className={cn(
-                'text-sm transition-colors hover:text-primary',
-                pathname === '/best-in-slot' ? 'text-foreground font-medium' : 'text-muted-foreground'
-              )}
-            >
-              Best in Slot
             </Link>
             <Link
               href="/news"


### PR DESCRIPTION
## Summary
- reorder nav links for a more intuitive flow
- add Best in Slot link to the home hero
- showcase primary tools on the home page with cards
- style the about page content in a subtle card

## Testing
- `npm install`
- `npm test --silent`
- `python -m unittest discover backend/app/testing` *(fails: ODBC Driver missing)*

------
https://chatgpt.com/codex/tasks/task_e_68494eb02de0832e952aa51ae4988e6f