### PR TITLE
Add preset management page

### DIFF
--- a/frontend/src/app/presets/page.tsx
+++ b/frontend/src/app/presets/page.tsx
@@ -1,0 +1,16 @@
+'use client';
+import { PresetSelector } from '@/components/features/calculator/PresetSelector';
+import { Visualizations } from '@/components/features/calculator/Visualizations';
+
+export default function PresetsPage() {
+  return (
+    <main id="main" className="container mx-auto py-8 px-4 pb-16 space-y-6">
+      <h1 className="text-4xl font-bold mb-6 text-center">Presets & Visualizations</h1>
+      <p className="text-center text-muted-foreground mb-8 max-w-2xl mx-auto">
+        Manage your saved setups and view their performance.
+      </p>
+      <PresetSelector className="flex-grow" />
+      <Visualizations />
+    </main>
+  );
+}

--- a/frontend/src/components/features/calculator/BestInSlotCalculator.tsx
+++ b/frontend/src/components/features/calculator/BestInSlotCalculator.tsx
@@ -5,7 +5,7 @@ import { Info } from 'lucide-react';
 import { useEffect, useState, useCallback } from 'react';
 import { useReferenceDataStore } from '@/store/reference-data-store';
 import { BossSelector } from './BossSelector';
-import { CombinedEquipmentDisplay } from './CombinedEquipmentDisplay';
+import { LoadoutTabs } from './LoadoutTabs';
 import { PrayerPotionSelector } from './PrayerPotionSelector';
 import { CalculatorForms } from './CalculatorForms';
 import { CombatStyleTabs } from './CombatStyleTabs';
@@ -142,10 +142,9 @@ export function BestInSlotCalculator() {
         {/* Left column */}
         <div className="space-y-6 flex flex-col">
           {/* Character equipment section */}
-          <CombinedEquipmentDisplay
+          <LoadoutTabs
             onEquipmentUpdate={handleEquipmentUpdate}
             bossForm={currentBossForm}
-            showSuggestButton={false}
           />
           {/* Prayer/Potion selector */}
           <PrayerPotionSelector className="flex-grow" />

--- a/frontend/src/components/features/calculator/improved/BottomPanels.tsx
+++ b/frontend/src/components/features/calculator/improved/BottomPanels.tsx
@@ -1,7 +1,5 @@
 'use client';
 import { useToast } from '@/hooks/use-toast';
-import { Visualizations } from '../Visualizations';
-import { PresetSelector } from '../PresetSelector';
 import { SpecialAttackOptions } from '../SpecialAttackOptions';
 import { PassiveEffectOptions } from '../PassiveEffectOptions';
 
@@ -9,11 +7,6 @@ export function BottomPanels() {
   const { toast } = useToast();
   return (
     <>
-      <Visualizations />
-      <PresetSelector
-        className="flex-grow"
-        onPresetLoad={() => toast.success('Preset loaded successfully!')}
-      />
       <SpecialAttackOptions />
       <PassiveEffectOptions />
     </>

--- a/frontend/src/components/features/calculator/improved/MiddleColumns.tsx
+++ b/frontend/src/components/features/calculator/improved/MiddleColumns.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { Card, CardContent } from '@/components/ui/card';
 import { BossSelector } from '../BossSelector';
-import { CombinedEquipmentDisplay } from '../CombinedEquipmentDisplay';
+import { LoadoutTabs } from '../LoadoutTabs';
 import { PrayerPotionSelector } from '../PrayerPotionSelector';
 import RaidScalingPanel, { RaidScalingConfig } from '../../simulation/RaidScalingPanel';
 import { DefenceReductionPanel } from '../DefenceReductionPanel';
@@ -27,10 +27,9 @@ export function MiddleColumns({
   return (
     <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
       <div className="space-y-6 flex flex-col">
-        <CombinedEquipmentDisplay
+        <LoadoutTabs
           onEquipmentUpdate={onEquipmentUpdate}
           bossForm={currentBossForm}
-          showSuggestButton={false}
         />
         <PrayerPotionSelector className="flex-grow" />
       </div>

--- a/frontend/src/components/layout/Navigation.tsx
+++ b/frontend/src/components/layout/Navigation.tsx
@@ -48,6 +48,15 @@ export function Navigation() {
               Simulate
             </Link>
             <Link
+              href="/presets"
+              className={cn(
+                'text-sm transition-colors hover:text-primary',
+                pathname === '/presets' ? 'text-foreground font-medium' : 'text-muted-foreground'
+              )}
+            >
+              Presets
+            </Link>
+            <Link
               href="/import"
               className={cn(
                 'text-sm transition-colors hover:text-primary',


### PR DESCRIPTION
## Summary
- move visualizations and preset selector to `/presets`
- add LoadoutTabs component for switching presets
- show LoadoutTabs on calculator and BIS pages
- simplify bottom panels
- add navigation link to new page

## Testing
- `npm --prefix frontend test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849510a2ce8832ea98503d21ffe5008