### PR TITLE
Add assistant placeholder page

### DIFF
--- a/frontend/src/__tests__/assistant.test.tsx
+++ b/frontend/src/__tests__/assistant.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import AssistantPage from '../app/assistant/page';
+
+describe('assistant page', () => {
+  it('renders heading', () => {
+    render(<AssistantPage />);
+    expect(screen.getByRole('heading', { name: /chat assistant/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/assistant/page.tsx
+++ b/frontend/src/app/assistant/page.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+export default function AssistantPage() {
+  return (
+    <main id="main" className="container mx-auto py-8 px-4 pb-16">
+      <h1 className="text-4xl font-bold mb-6 text-center">Chat Assistant</h1>
+      <p className="text-center text-muted-foreground mb-8 max-w-2xl mx-auto">
+        This area will eventually let you chat with a bot to plan your next move and generate shareable seeds.
+      </p>
+      <div className="border rounded p-8 text-center">
+        <p className="text-lg">Coming soon...</p>
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -45,6 +45,14 @@ export default function Home() {
               </CardHeader>
             </Card>
           </Link>
+          <Link href="/assistant">
+            <Card className="hover:border-primary transition-colors">
+              <CardHeader>
+                <CardTitle>Assistant</CardTitle>
+                <CardDescription>Chat-based planner</CardDescription>
+              </CardHeader>
+            </Card>
+          </Link>
         </div>
       </main>
     </>

--- a/frontend/src/components/layout/Navigation.tsx
+++ b/frontend/src/components/layout/Navigation.tsx
@@ -75,6 +75,15 @@ export function Navigation() {
               Import
             </Link>
             <Link
+              href="/assistant"
+              className={cn(
+                'text-sm transition-colors hover:text-primary',
+                pathname === '/assistant' ? 'text-foreground font-medium' : 'text-muted-foreground'
+              )}
+            >
+              Assistant
+            </Link>
+            <Link
               href="/news"
               className={cn(
                 'text-sm transition-colors hover:text-primary',


### PR DESCRIPTION
## Summary
- add new `/assistant` route with placeholder page
- include Assistant card on home page
- link Assistant in the navigation bar
- add test covering the new page

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68495262640c832eb59ee8e1d90d374e