### PR TITLE
Adjust equipment card layout

### DIFF
--- a/frontend/src/components/features/calculator/BestInSlotCalculator.tsx
+++ b/frontend/src/components/features/calculator/BestInSlotCalculator.tsx
@@ -5,7 +5,7 @@ import { Info } from 'lucide-react';
 import { useEffect, useState, useCallback } from 'react';
 import { useReferenceDataStore } from '@/store/reference-data-store';
 import { BossSelector } from './BossSelector';
-import { LoadoutTabs } from './LoadoutTabs';
+import { EquipmentPanel } from './EquipmentPanel';
 import { PrayerPotionSelector } from './PrayerPotionSelector';
 import { CalculatorForms } from './CalculatorForms';
 import { CombatStyleTabs } from './CombatStyleTabs';
@@ -142,7 +142,7 @@ export function BestInSlotCalculator() {
         {/* Left column */}
         <div className="space-y-6 flex flex-col">
           {/* Character equipment section */}
-          <LoadoutTabs
+          <EquipmentPanel
             onEquipmentUpdate={handleEquipmentUpdate}
             bossForm={currentBossForm}
           />

--- a/frontend/src/components/features/calculator/EquipmentPanel.tsx
+++ b/frontend/src/components/features/calculator/EquipmentPanel.tsx
@@ -1,15 +1,8 @@
 'use client';
 
-import { CombinedEquipmentDisplay } from '@/components/features/calculator/CombinedEquipmentDisplay';
-import { Alert, AlertDescription } from '@/components/ui/alert';
-import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { useToast } from '@/hooks/use-toast';
-import { useCalculatorStore } from '@/store/calculator-store';
-import { BossForm, Item, Preset } from '@/types/calculator';
-import { useState } from 'react';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { encodeSeed } from '@/utils/seed';
+import { BossForm, Item } from '@/types/calculator';
+import { LoadoutTabs } from './LoadoutTabs';
 
 interface EquipmentPanelProps {
   onEquipmentUpdate?: (loadout: Record<string, Item | null>) => void;
@@ -17,78 +10,9 @@ interface EquipmentPanelProps {
 }
 
 /**
- * Equipment panel that wraps the CombinedEquipmentDisplay with a consistent card style
- * and adds reset functionality
+ * Equipment panel that wraps the LoadoutTabs with a consistent card style
  */
 export function EquipmentPanel({ onEquipmentUpdate, bossForm }: EquipmentPanelProps) {
-  const { toast } = useToast();
-  const [currentLoadout, setCurrentLoadout] = useState<Record<string, Item | null>>({});
-  const [activePreset, setActivePreset] = useState('current');
-  const {
-    resetParams,
-    resetLocks,
-    presets,
-    addPreset,
-    setLoadout,
-    setParams,
-    switchCombatStyle,
-    params,
-    loadout,
-  } = useCalculatorStore();
-
-  const handleResetEquipment = () => {
-    // Reset the local loadout state
-    setCurrentLoadout({});
-    
-    // Reset the calculator parameters
-    resetParams();
-    resetLocks();
-    
-    // Notify parent that equipment was reset
-    if (onEquipmentUpdate) {
-      onEquipmentUpdate({});
-    }
-    
-    toast.success("Equipment reset to defaults");
-  };
-
-  const handleEquipmentUpdate = (loadout: Record<string, Item | null>) => {
-    setCurrentLoadout(loadout);
-
-    if (onEquipmentUpdate) {
-      onEquipmentUpdate(loadout);
-    }
-  };
-
-  const handlePresetChange = (id: string) => {
-    setActivePreset(id);
-    if (id === 'current') return;
-    const preset = presets.find((p) => p.id === id);
-    if (preset) {
-      switchCombatStyle(preset.params.combat_style as any);
-      setParams(preset.params);
-      setLoadout(preset.equipment || {});
-      setCurrentLoadout(preset.equipment || {});
-    }
-  };
-
-  const handleAddPreset = () => {
-    const name = prompt('Preset name?');
-    if (!name) return;
-    const newPreset: Preset = {
-      id: Date.now().toString(),
-      name,
-      combatStyle: params.combat_style,
-      timestamp: Date.now(),
-      params: { ...params },
-      equipment: { ...loadout },
-      seed: encodeSeed(params, loadout as any),
-    };
-    addPreset(newPreset);
-    setActivePreset(newPreset.id);
-    toast.success('Preset saved');
-  };
-
   return (
     <Card className="w-full h-full">
       <CardHeader className="flex flex-row items-center justify-between pb-2">
@@ -97,40 +21,11 @@ export function EquipmentPanel({ onEquipmentUpdate, bossForm }: EquipmentPanelPr
           <CardDescription>Configure your gear and attack style</CardDescription>
         </div>
       </CardHeader>
-
       <CardContent>
-        <Tabs value={activePreset} onValueChange={handlePresetChange} className="w-full">
-          <TabsList className="mb-4 flex gap-2">
-            <TabsTrigger value="current">Current</TabsTrigger>
-            {presets.slice(0, 6).map((p) => (
-              <TabsTrigger key={p.id} value={p.id}>{p.name}</TabsTrigger>
-            ))}
-            <Button variant="outline" size="sm" onClick={handleAddPreset}">Add preset</Button>
-          </TabsList>
-          <TabsContent value={activePreset} className="w-full">
-            {Object.keys(currentLoadout).length > 0 && (
-              <div className="flex justify-center mb-2">
-                <Button variant="outline" size="sm" onClick={handleResetEquipment}">
-                  Reset Equipment
-                </Button>
-              </div>
-            )}
-            {Object.keys(currentLoadout).length === 0 && (
-              <Alert className="mb-4">
-                <AlertDescription>
-                  Select equipment to calculate DPS with specific gear bonuses.
-                </AlertDescription>
-              </Alert>
-            )}
-
-            <CombinedEquipmentDisplay
-              onEquipmentUpdate={handleEquipmentUpdate}
-              bossForm={bossForm}
-              showSuggestButton={false}
-            />
-          </TabsContent>
-        </Tabs>
+        <LoadoutTabs bossForm={bossForm} onEquipmentUpdate={onEquipmentUpdate} />
       </CardContent>
     </Card>
   );
 }
+
+export default EquipmentPanel;

--- a/frontend/src/components/features/calculator/improved/MiddleColumns.tsx
+++ b/frontend/src/components/features/calculator/improved/MiddleColumns.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { Card, CardContent } from '@/components/ui/card';
 import { BossSelector } from '../BossSelector';
-import { LoadoutTabs } from '../LoadoutTabs';
+import { EquipmentPanel } from '../EquipmentPanel';
 import { PrayerPotionSelector } from '../PrayerPotionSelector';
 import RaidScalingPanel, { RaidScalingConfig } from '../../simulation/RaidScalingPanel';
 import { DefenceReductionPanel } from '../DefenceReductionPanel';
@@ -27,7 +27,7 @@ export function MiddleColumns({
   return (
     <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
       <div className="space-y-6 flex flex-col">
-        <LoadoutTabs
+        <EquipmentPanel
           onEquipmentUpdate={onEquipmentUpdate}
           bossForm={currentBossForm}
         />


### PR DESCRIPTION
## Summary
- wrap `LoadoutTabs` inside the `EquipmentPanel` card
- use new `EquipmentPanel` in Best in Slot and improved calculator layouts

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684953b58578832e8320a71cde1601d8