### PR TITLE
Add special effects page

### DIFF
--- a/frontend/src/app/effects/page.tsx
+++ b/frontend/src/app/effects/page.tsx
@@ -1,0 +1,18 @@
+'use client';
+import { SpecialAttackOptions } from '@/components/features/calculator/SpecialAttackOptions';
+import { PassiveEffectOptions } from '@/components/features/calculator/PassiveEffectOptions';
+
+export default function EffectsPage() {
+  return (
+    <main id="main" className="container mx-auto py-8 px-4 pb-16 space-y-6">
+      <h1 className="text-4xl font-bold mb-6 text-center">
+        Special Attacks &amp; Passive Effects
+      </h1>
+      <p className="text-center text-muted-foreground mb-8 max-w-2xl mx-auto">
+        Browse all supported special attacks and passive item effects.
+      </p>
+      <SpecialAttackOptions />
+      <PassiveEffectOptions />
+    </main>
+  );
+}

--- a/frontend/src/components/features/calculator/EquipmentLoadout.tsx
+++ b/frontend/src/components/features/calculator/EquipmentLoadout.tsx
@@ -14,7 +14,6 @@ import { Alert, AlertDescription } from '@/components/ui/alert';
 import { useToast } from '@/hooks/use-toast';
 import { useCalculatorStore } from '@/store/calculator-store';
 import { EquipmentDisplay } from '@/components/features/calculator/EquipmentDisplay';
-import PassiveEffectsDisplay from './PassiveEffectsDisplay';
 import { ItemSelector } from './ItemSelector';
 import { Item, ItemSummary } from '@/types/calculator';
 import { itemsApi } from '@/services/api';
@@ -488,8 +487,6 @@ export function EquipmentLoadout({ onEquipmentUpdate }: EquipmentLoadoutProps) {
             <EquipmentDisplay loadout={loadout} totals={totals} />
           </div>
 
-          {/* Display passive effects if any items have them */}
-          <PassiveEffectsDisplay loadout={loadout} target={selectedBossForm} />
 
           <div className="grid grid-cols-2 md:grid-cols-3 gap-2 mb-6">
             {getDisplaySlots().map(({ name, slot, icon }) => (

--- a/frontend/src/components/features/calculator/ImprovedDpsCalculator.tsx
+++ b/frontend/src/components/features/calculator/ImprovedDpsCalculator.tsx
@@ -1,13 +1,11 @@
 'use client';
 import { useEffect, useState } from 'react';
 import { useReferenceDataStore } from '@/store/reference-data-store';
-import PassiveEffectsDisplay from './PassiveEffectsDisplay';
 import { useDpsCalculator } from '@/hooks/useDpsCalculator';
 import { Raid, RAID_NAME_TO_ID } from '@/types/raid';
 import { useCalculatorStore } from '@/store/calculator-store';
 import { Header } from './improved/Header';
 import { MiddleColumns } from './improved/MiddleColumns';
-import { BottomPanels } from './improved/BottomPanels';
 import { RaidScalingConfig } from '../simulation/RaidScalingPanel';
 
 /**
@@ -58,13 +56,6 @@ export function ImprovedDpsCalculator() {
         appliedPassiveEffects={appliedPassiveEffects}
       />
 
-      {Object.keys(currentLoadout).length > 0 && (
-        <PassiveEffectsDisplay
-          loadout={currentLoadout}
-          target={currentBossForm}
-        />
-      )}
-
       <MiddleColumns
         onEquipmentUpdate={handleEquipmentUpdate}
         onSelectForm={handleBossUpdate}
@@ -74,8 +65,6 @@ export function ImprovedDpsCalculator() {
         onRaidConfigChange={setRaidConfig}
       />
 
-      <BottomPanels />
-      
     </div>
   );
 }

--- a/frontend/src/components/features/calculator/improved/BottomPanels.tsx
+++ b/frontend/src/components/features/calculator/improved/BottomPanels.tsx
@@ -1,16 +1,6 @@
 'use client';
-import { useToast } from '@/hooks/use-toast';
-import { SpecialAttackOptions } from '../SpecialAttackOptions';
-import { PassiveEffectOptions } from '../PassiveEffectOptions';
-
 export function BottomPanels() {
-  const { toast } = useToast();
-  return (
-    <>
-      <SpecialAttackOptions />
-      <PassiveEffectOptions />
-    </>
-  );
+  return null;
 }
 
 export default BottomPanels;

--- a/frontend/src/components/layout/Navigation.tsx
+++ b/frontend/src/components/layout/Navigation.tsx
@@ -75,6 +75,15 @@ export function Navigation() {
               Import
             </Link>
             <Link
+              href="/effects"
+              className={cn(
+                'text-sm transition-colors hover:text-primary',
+                pathname === '/effects' ? 'text-foreground font-medium' : 'text-muted-foreground'
+              )}
+            >
+              Effects
+            </Link>
+            <Link
               href="/assistant"
               className={cn(
                 'text-sm transition-colors hover:text-primary',


### PR DESCRIPTION
## Summary
- add new `/effects` page with special attack and passive effect lists
- remove special/pasive panels from the DPS calculator UI
- drop passive effect display from equipment loadouts
- link new page in navigation

## Testing
- `npm test` *(fails: jest not found)*
- `python -m unittest discover` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_684953d1c2cc832e9b5cf71f520ce6de