### PR TITLE
Simplify home hero

### DIFF
--- a/frontend/src/components/layout/HomeHero.tsx
+++ b/frontend/src/components/layout/HomeHero.tsx
@@ -1,5 +1,3 @@
-import Link from 'next/link';
-
 export default function HomeHero() {
   return (
     <section className="relative bg-[url('/images/hitsplat.2f589c5c.webp')] bg-cover bg-center py-24 mb-12 text-center">
@@ -8,16 +6,6 @@ export default function HomeHero() {
         <h1 className="text-5xl md:text-6xl font-title text-primary drop-shadow-md mb-6">
           ScapeLab Tools
         </h1>
-        <p className="text-lg md:text-xl text-muted-foreground max-w-2xl mx-auto mb-8">
-          Optimize your Old School RuneScape experience with our calculators and simulations.
-        </p>
-        <div className="flex flex-wrap justify-center gap-4">
-          <Link href="/calculator" className="btn-primary inline-block">Calculator</Link>
-          <Link href="/best-in-slot" className="btn-primary inline-block">Best in Slot</Link>
-          <Link href="/simulate" className="btn-primary inline-block">Simulation</Link>
-          <Link href="/import" className="btn-primary inline-block">Import</Link>
-          <Link href="/about" className="btn-primary inline-block">About</Link>
-        </div>
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary
- remove tagline and yellow buttons from the hero section on the home page

## Testing
- `npm test` within `frontend`
- `python -m unittest discover backend/app/testing` *(fails: FAIL: test_bis (test_api.TestApiRoutes.test_bis) ...)*

------
https://chatgpt.com/codex/tasks/task_e_6849546d548c832e8fc06a2d821022f5