### PR TITLE
Add progress and success banner for data loading

### DIFF
--- a/frontend/src/__tests__/alt-text.test.tsx
+++ b/frontend/src/__tests__/alt-text.test.tsx
@@ -35,6 +35,7 @@ describe('image alt text', () => {
       bosses: [],
       bossForms: {},
       items: [],
+      progress: 1,
       initialized: true,
       loading: false,
       timestamp: 0,

--- a/frontend/src/__tests__/reference-data-store.test.ts
+++ b/frontend/src/__tests__/reference-data-store.test.ts
@@ -31,6 +31,7 @@ describe('reference data store', () => {
         passiveEffects: {},
         initialized: false,
         loading: false,
+        progress: 0,
       });
     });
     mockedBossApi.getAllBosses.mockReset();

--- a/frontend/src/components/layout/ReferenceDataBanner.tsx
+++ b/frontend/src/components/layout/ReferenceDataBanner.tsx
@@ -1,18 +1,47 @@
 'use client';
 
-import { Loader2 } from 'lucide-react';
+import { Loader2, Check } from 'lucide-react';
+import { useEffect, useState } from 'react';
 import { useReferenceDataStore } from '@/store/reference-data-store';
 
 export function ReferenceDataBanner() {
   const loading = useReferenceDataStore((s) => s.loading);
   const initialized = useReferenceDataStore((s) => s.initialized);
+  const progress = useReferenceDataStore((s) => s.progress);
 
-  if (!loading && initialized) return null;
+  const [visible, setVisible] = useState(loading || !initialized);
+
+  useEffect(() => {
+    if (loading) {
+      setVisible(true);
+    } else if (initialized) {
+      setVisible(true);
+      const t = setTimeout(() => setVisible(false), 3000);
+      return () => clearTimeout(t);
+    }
+  }, [loading, initialized]);
+
+  if (!visible) return null;
+
+  const done = initialized && !loading;
 
   return (
-    <div className="w-full bg-muted text-muted-foreground text-sm py-1 flex items-center justify-center gap-2">
-      <Loader2 className="h-4 w-4 animate-spin" />
-      <span>Loading game data...</span>
+    <div
+      className={`w-full text-sm py-1 flex flex-col items-center justify-center gap-1 ${done ? 'bg-green-600 text-green-50' : 'bg-muted text-muted-foreground'}`}
+    >
+      <div className="flex items-center gap-2">
+        {done ? (
+          <Check className="h-4 w-4" />
+        ) : (
+          <Loader2 className="h-4 w-4 animate-spin" />
+        )}
+        <span>{done ? 'Game data loaded' : 'Loading game data...'}</span>
+      </div>
+      {!done && (
+        <div className="w-48 h-1 bg-gray-500 rounded">
+          <div className="h-full bg-green-500 rounded" style={{ width: `${Math.round(progress * 100)}%` }} />
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- show progress and success on reference data loading banner
- track loading progress in reference data store
- update tests for new store property

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684954d688f4832e839c6de04a1836b0