### PR TITLE
Center equipment header and tabs

### DIFF
--- a/frontend/src/components/features/calculator/EquipmentPanel.tsx
+++ b/frontend/src/components/features/calculator/EquipmentPanel.tsx
@@ -15,11 +15,9 @@ interface EquipmentPanelProps {
 export function EquipmentPanel({ onEquipmentUpdate, bossForm }: EquipmentPanelProps) {
   return (
     <Card className="w-full h-full">
-      <CardHeader className="flex flex-row items-center justify-between pb-2">
-        <div>
-          <CardTitle>Equipment</CardTitle>
-          <CardDescription>Configure your gear and attack style</CardDescription>
-        </div>
+      <CardHeader className="items-center pb-2 text-center">
+        <CardTitle>Equipment</CardTitle>
+        <CardDescription>Configure your gear and attack style</CardDescription>
       </CardHeader>
       <CardContent>
         <LoadoutTabs bossForm={bossForm} onEquipmentUpdate={onEquipmentUpdate} />

--- a/frontend/src/components/features/calculator/LoadoutTabs.tsx
+++ b/frontend/src/components/features/calculator/LoadoutTabs.tsx
@@ -48,7 +48,7 @@ export function LoadoutTabs({ bossForm, onEquipmentUpdate }: { bossForm?: BossFo
 
   return (
     <Tabs value={activePreset} onValueChange={handlePresetChange} className="w-full">
-      <TabsList className="mb-4 flex gap-2 flex-wrap">
+      <TabsList className="mb-4 flex gap-2 flex-wrap justify-center w-full">
         <TabsTrigger value="current">Current</TabsTrigger>
         {presets.slice(0, 6).map((p) => (
           <TabsTrigger key={p.id} value={p.id}>{p.name}</TabsTrigger>


### PR DESCRIPTION
## Summary
- center equipment panel header text
- center equipment loadout tabs

## Testing
- `npm test --prefix frontend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849562543ec832e90d54663fc15b279