### PR TITLE
Update hero text and remove Assistant button

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -7,9 +7,6 @@ export default function Home() {
     <>
       <HomeHero />
       <main id="main" className="container mx-auto py-8 px-4 pb-16 text-center">
-        <p className="text-xl text-muted-foreground mb-8 max-w-2xl mx-auto">
-          Welcome to ScapeLab, a suite of tools to help optimize your Old School RuneScape gameplay.
-        </p>
         <p className="text-lg">Choose a tool from the navigation above or the buttons below to get started.</p>
 
         <div className="mt-12 grid gap-6 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
@@ -42,14 +39,6 @@ export default function Home() {
               <CardHeader>
                 <CardTitle>Import</CardTitle>
                 <CardDescription>Load saved setups</CardDescription>
-              </CardHeader>
-            </Card>
-          </Link>
-          <Link href="/assistant">
-            <Card className="hover:border-primary transition-colors">
-              <CardHeader>
-                <CardTitle>Assistant</CardTitle>
-                <CardDescription>Chat-based planner</CardDescription>
               </CardHeader>
             </Card>
           </Link>

--- a/frontend/src/components/layout/HomeHero.tsx
+++ b/frontend/src/components/layout/HomeHero.tsx
@@ -6,6 +6,9 @@ export default function HomeHero() {
         <h1 className="text-5xl md:text-6xl font-title text-primary drop-shadow-md mb-6">
           ScapeLab Tools
         </h1>
+        <p className="text-xl text-muted-foreground mb-6 max-w-2xl mx-auto">
+          Welcome to ScapeLab, a suite of tools to help optimize your Old School RuneScape gameplay.
+        </p>
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary
- display the welcome tagline inside `HomeHero`
- drop tagline from main content
- remove the Assistant card from the home page

## Testing
- `npm test`
- `pytest -q` *(fails: ODBC Driver for SQL Server not found)*

------
https://chatgpt.com/codex/tasks/task_e_684956650314832ea52ac11e534f4920