### PR TITLE
Initialize data on home and show load errors

### DIFF
--- a/frontend/src/__tests__/alt-text.test.tsx
+++ b/frontend/src/__tests__/alt-text.test.tsx
@@ -38,6 +38,7 @@ describe('image alt text', () => {
       progress: 1,
       initialized: true,
       loading: false,
+      error: false,
       timestamp: 0,
       initData: jest.fn(),
       addBosses: jest.fn(),

--- a/frontend/src/__tests__/reference-data-store.test.ts
+++ b/frontend/src/__tests__/reference-data-store.test.ts
@@ -32,6 +32,7 @@ describe('reference data store', () => {
         initialized: false,
         loading: false,
         progress: 0,
+        error: false,
       });
     });
     mockedBossApi.getAllBosses.mockReset();

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,4 +1,5 @@
 import HomeHero from '@/components/layout/HomeHero';
+import { InitReferenceData } from '@/components/layout/InitReferenceData';
 import Link from 'next/link';
 import { Card, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 
@@ -6,6 +7,7 @@ export default function Home() {
   return (
     <>
       <HomeHero />
+      <InitReferenceData />
       <main id="main" className="container mx-auto py-8 px-4 pb-16 text-center">
         <p className="text-xl text-muted-foreground mb-8 max-w-2xl mx-auto">
           Welcome to ScapeLab, a suite of tools to help optimize your Old School RuneScape gameplay.

--- a/frontend/src/components/layout/InitReferenceData.tsx
+++ b/frontend/src/components/layout/InitReferenceData.tsx
@@ -1,0 +1,13 @@
+'use client';
+import { useEffect } from 'react';
+import { useReferenceDataStore } from '@/store/reference-data-store';
+
+export function InitReferenceData() {
+  const initData = useReferenceDataStore((s) => s.initData);
+
+  useEffect(() => {
+    initData();
+  }, [initData]);
+
+  return null;
+}

--- a/frontend/src/components/layout/ReferenceDataBanner.tsx
+++ b/frontend/src/components/layout/ReferenceDataBanner.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import { Loader2, Check } from 'lucide-react';
+import { Loader2, Check, X } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { useReferenceDataStore } from '@/store/reference-data-store';
 
 export function ReferenceDataBanner() {
   const loading = useReferenceDataStore((s) => s.loading);
   const initialized = useReferenceDataStore((s) => s.initialized);
+  const error = useReferenceDataStore((s) => s.error);
   const progress = useReferenceDataStore((s) => s.progress);
 
   const [visible, setVisible] = useState(loading || !initialized);
@@ -14,32 +15,51 @@ export function ReferenceDataBanner() {
   useEffect(() => {
     if (loading) {
       setVisible(true);
-    } else if (initialized) {
+    } else if (initialized && !error) {
       setVisible(true);
       const t = setTimeout(() => setVisible(false), 3000);
       return () => clearTimeout(t);
+    } else if (error) {
+      setVisible(true);
     }
-  }, [loading, initialized]);
+  }, [loading, initialized, error]);
 
   if (!visible) return null;
 
-  const done = initialized && !loading;
+  const done = initialized && !loading && !error;
+
+  const bannerClass = done
+    ? 'bg-green-600 text-green-50'
+    : error
+    ? 'bg-red-600 text-red-50'
+    : 'bg-muted text-muted-foreground';
 
   return (
     <div
-      className={`w-full text-sm py-1 flex flex-col items-center justify-center gap-1 ${done ? 'bg-green-600 text-green-50' : 'bg-muted text-muted-foreground'}`}
+      className={`w-full text-sm py-1 flex flex-col items-center justify-center gap-1 ${bannerClass}`}
     >
       <div className="flex items-center gap-2">
         {done ? (
           <Check className="h-4 w-4" />
+        ) : error ? (
+          <X className="h-4 w-4" />
         ) : (
           <Loader2 className="h-4 w-4 animate-spin" />
         )}
-        <span>{done ? 'Game data loaded' : 'Loading game data...'}</span>
+        <span>
+          {done
+            ? 'Game data loaded'
+            : error
+            ? 'Failed to load game data'
+            : 'Loading game data...'}
+        </span>
       </div>
       {!done && (
         <div className="w-48 h-1 bg-gray-500 rounded">
-          <div className="h-full bg-green-500 rounded" style={{ width: `${Math.round(progress * 100)}%` }} />
+          <div
+            className={`h-full rounded ${error ? 'bg-red-500' : 'bg-green-500'}`}
+            style={{ width: `${Math.round(progress * 100)}%` }}
+          />
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- trigger `initData` when visiting the home page
- track load failures in the reference-data store
- display a red banner when data loading fails
- adjust tests for new `error` flag

## Testing
- `npm test --prefix frontend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684956a6b010832e9798e3d3fcd54cc0