### PR TITLE
Center equipment panel text

### DIFF
--- a/frontend/src/components/features/calculator/EquipmentPanel.tsx
+++ b/frontend/src/components/features/calculator/EquipmentPanel.tsx
@@ -15,7 +15,7 @@ interface EquipmentPanelProps {
 export function EquipmentPanel({ onEquipmentUpdate, bossForm }: EquipmentPanelProps) {
   return (
     <Card className="w-full h-full">
-      <CardHeader className="items-center pb-2 text-center">
+      <CardHeader className="flex flex-col items-center pb-2 text-center">
         <CardTitle>Equipment</CardTitle>
         <CardDescription>Configure your gear and attack style</CardDescription>
       </CardHeader>

--- a/frontend/src/components/features/calculator/LoadoutTabs.tsx
+++ b/frontend/src/components/features/calculator/LoadoutTabs.tsx
@@ -47,11 +47,17 @@ export function LoadoutTabs({ bossForm, onEquipmentUpdate }: { bossForm?: BossFo
   };
 
   return (
-    <Tabs value={activePreset} onValueChange={handlePresetChange} className="w-full">
-      <TabsList className="mb-4 flex gap-2 flex-wrap justify-center w-full">
-        <TabsTrigger value="current">Current</TabsTrigger>
+    <Tabs
+      value={activePreset}
+      onValueChange={handlePresetChange}
+      className="w-full flex flex-col items-center"
+    >
+      <TabsList className="mb-4 flex gap-2 flex-wrap justify-center w-full text-center">
+        <TabsTrigger value="current" className="text-center">Current</TabsTrigger>
         {presets.slice(0, 6).map((p) => (
-          <TabsTrigger key={p.id} value={p.id}>{p.name}</TabsTrigger>
+          <TabsTrigger key={p.id} value={p.id} className="text-center">
+            {p.name}
+          </TabsTrigger>
         ))}
         {presets.length < 6 && (
           <Button variant="outline" size="sm" onClick={handleAddPreset}>+</Button>


### PR DESCRIPTION
## Summary
- center the equipment panel header text
- ensure LoadoutTabs align content centrally

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68495724b4d4832ea84137d55b6473c5