### PR TITLE
Adjust prayer/potion placement

### DIFF
--- a/frontend/src/components/features/calculator/BestInSlotCalculator.tsx
+++ b/frontend/src/components/features/calculator/BestInSlotCalculator.tsx
@@ -146,12 +146,12 @@ export function BestInSlotCalculator() {
             onEquipmentUpdate={handleEquipmentUpdate}
             bossForm={currentBossForm}
           />
-          {/* Prayer/Potion selector */}
-          <PrayerPotionSelector className="flex-grow" />
         </div>
 
         {/* Right column */}
         <div className="space-y-6 flex flex-col flex-grow">
+          {/* Prayer/Potion selector */}
+          <PrayerPotionSelector className="flex-grow" />
           {/* Target selection section */}
           <BossSelector onSelectForm={handleBossUpdate} />
         </div>

--- a/frontend/src/components/features/calculator/improved/MiddleColumns.tsx
+++ b/frontend/src/components/features/calculator/improved/MiddleColumns.tsx
@@ -31,9 +31,9 @@ export function MiddleColumns({
           onEquipmentUpdate={onEquipmentUpdate}
           bossForm={currentBossForm}
         />
-        <PrayerPotionSelector className="flex-grow" />
       </div>
       <div className="space-y-6 flex flex-col flex-grow">
+        <PrayerPotionSelector className="flex-grow" />
         <BossSelector onSelectForm={onSelectForm} />
         {selectedRaid && (
           <RaidScalingPanel raid={selectedRaid} config={raidConfig} onChange={onRaidConfigChange} />


### PR DESCRIPTION
## Summary
- move the PrayerPotionSelector into the right column for the Improved DPS Calculator
- adjust layout on Best in Slot calculator to show the prayer/potion panel before selecting a target

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6849577bd838832eb190904b2d45708e