### PR TITLE
Fix vertical growth of potion selector

### DIFF
--- a/frontend/src/components/features/calculator/BestInSlotCalculator.tsx
+++ b/frontend/src/components/features/calculator/BestInSlotCalculator.tsx
@@ -151,7 +151,7 @@ export function BestInSlotCalculator() {
         {/* Right column */}
         <div className="space-y-6 flex flex-col flex-grow">
           {/* Prayer/Potion selector */}
-          <PrayerPotionSelector className="flex-grow" />
+          <PrayerPotionSelector />
           {/* Target selection section */}
           <BossSelector onSelectForm={handleBossUpdate} />
         </div>

--- a/frontend/src/components/features/calculator/improved/MiddleColumns.tsx
+++ b/frontend/src/components/features/calculator/improved/MiddleColumns.tsx
@@ -33,7 +33,7 @@ export function MiddleColumns({
         />
       </div>
       <div className="space-y-6 flex flex-col flex-grow">
-        <PrayerPotionSelector className="flex-grow" />
+        <PrayerPotionSelector />
         <BossSelector onSelectForm={onSelectForm} />
         {selectedRaid && (
           <RaidScalingPanel raid={selectedRaid} config={raidConfig} onChange={onRaidConfigChange} />


### PR DESCRIPTION
## Summary
- don't grow PrayerPotionSelector card in layout

## Testing
- `npm test`
- `python -m unittest discover app/testing` *(fails: ODBC driver missing)*

------
https://chatgpt.com/codex/tasks/task_e_68495954151c832eb88a3a1e7fc7145a