### PR TITLE
Add per-page SEO metadata

### DIFF
--- a/frontend/src/app/about/page.tsx
+++ b/frontend/src/app/about/page.tsx
@@ -1,4 +1,27 @@
 import Link from 'next/link';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'About ScapeLab',
+  description: 'Learn about the ScapeLab project and its open source tools.',
+  alternates: {
+    canonical: '/about',
+  },
+  openGraph: {
+    title: 'About ScapeLab',
+    description: 'Learn about the ScapeLab project and its open source tools.',
+    url: '/about',
+    siteName: 'ScapeLab',
+    images: ['/favicon.ico'],
+    locale: 'en_US',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'About ScapeLab',
+    description: 'Learn about the ScapeLab project and its open source tools.',
+  },
+};
 
 export default function AboutPage() {
   return (

--- a/frontend/src/app/assistant/page.tsx
+++ b/frontend/src/app/assistant/page.tsx
@@ -1,4 +1,27 @@
 'use client';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Chat Assistant',
+  description: 'Interact with a bot to plan your setups and generate seeds.',
+  alternates: {
+    canonical: '/assistant',
+  },
+  openGraph: {
+    title: 'Chat Assistant',
+    description: 'Interact with a bot to plan your setups and generate seeds.',
+    url: '/assistant',
+    siteName: 'ScapeLab',
+    images: ['/favicon.ico'],
+    locale: 'en_US',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Chat Assistant',
+    description: 'Interact with a bot to plan your setups and generate seeds.',
+  },
+};
 
 export default function AssistantPage() {
   return (

--- a/frontend/src/app/best-in-slot/page.tsx
+++ b/frontend/src/app/best-in-slot/page.tsx
@@ -1,6 +1,29 @@
 'use client';
 
 import { BestInSlotCalculator } from '@/components/features/calculator/BestInSlotCalculator';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Best in Slot Finder',
+  description: 'Determine the optimal gear setup for your stats and target.',
+  alternates: {
+    canonical: '/best-in-slot',
+  },
+  openGraph: {
+    title: 'Best in Slot Finder',
+    description: 'Determine the optimal gear setup for your stats and target.',
+    url: '/best-in-slot',
+    siteName: 'ScapeLab',
+    images: ['/favicon.ico'],
+    locale: 'en_US',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Best in Slot Finder',
+    description: 'Determine the optimal gear setup for your stats and target.',
+  },
+};
 
 export default function BestInSlotPage() {
   return (

--- a/frontend/src/app/calculator/page.tsx
+++ b/frontend/src/app/calculator/page.tsx
@@ -1,4 +1,27 @@
 import { ImprovedDpsCalculator } from '@/components/features/calculator/ImprovedDpsCalculator';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'DPS Calculator',
+  description: 'Calculate max hits and DPS for any Old School RuneScape setup.',
+  alternates: {
+    canonical: '/calculator',
+  },
+  openGraph: {
+    title: 'DPS Calculator',
+    description: 'Calculate max hits and DPS for any Old School RuneScape setup.',
+    url: '/calculator',
+    siteName: 'ScapeLab',
+    images: ['/favicon.ico'],
+    locale: 'en_US',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'DPS Calculator',
+    description: 'Calculate max hits and DPS for any Old School RuneScape setup.',
+  },
+};
 
 export default function CalculatorPage() {
   return (

--- a/frontend/src/app/effects/page.tsx
+++ b/frontend/src/app/effects/page.tsx
@@ -1,6 +1,29 @@
 'use client';
 import { SpecialAttackOptions } from '@/components/features/calculator/SpecialAttackOptions';
 import { PassiveEffectOptions } from '@/components/features/calculator/PassiveEffectOptions';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Special Attacks & Passive Effects',
+  description: 'Browse every supported special attack and passive item effect.',
+  alternates: {
+    canonical: '/effects',
+  },
+  openGraph: {
+    title: 'Special Attacks & Passive Effects',
+    description: 'Browse every supported special attack and passive item effect.',
+    url: '/effects',
+    siteName: 'ScapeLab',
+    images: ['/favicon.ico'],
+    locale: 'en_US',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Special Attacks & Passive Effects',
+    description: 'Browse every supported special attack and passive item effect.',
+  },
+};
 
 export default function EffectsPage() {
   return (

--- a/frontend/src/app/import/page.tsx
+++ b/frontend/src/app/import/page.tsx
@@ -3,6 +3,29 @@ import { useState } from 'react';
 import { useCalculatorStore } from '@/store/calculator-store';
 import { itemsApi } from '@/services/api';
 import { Item } from '@/types/calculator';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Import Profile',
+  description: 'Load a saved combat profile using a shareable seed.',
+  alternates: {
+    canonical: '/import',
+  },
+  openGraph: {
+    title: 'Import Profile',
+    description: 'Load a saved combat profile using a shareable seed.',
+    url: '/import',
+    siteName: 'ScapeLab',
+    images: ['/favicon.ico'],
+    locale: 'en_US',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Import Profile',
+    description: 'Load a saved combat profile using a shareable seed.',
+  },
+};
 
 export default function ImportPage() {
   const placeholderParams = {

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -7,9 +7,12 @@ import { ThemeToggle } from '@/components/theme/ThemeToggle';
 import './globals.css';
 import type { Metadata } from "next";
 
+const siteUrl = new URL('https://scapelab.app');
+
 export const metadata: Metadata = {
   title: "ScapeLab",
   description: "Tools for optimizing your Old School RuneScape gameplay",
+  metadataBase: siteUrl,
 };
 
 export default function RootLayout({

--- a/frontend/src/app/news/page.tsx
+++ b/frontend/src/app/news/page.tsx
@@ -2,6 +2,29 @@
 import { useEffect, useState } from 'react';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'News',
+  description: 'Read community news and announcements for ScapeLab.',
+  alternates: {
+    canonical: '/news',
+  },
+  openGraph: {
+    title: 'News',
+    description: 'Read community news and announcements for ScapeLab.',
+    url: '/news',
+    siteName: 'ScapeLab',
+    images: ['/favicon.ico'],
+    locale: 'en_US',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'News',
+    description: 'Read community news and announcements for ScapeLab.',
+  },
+};
 
 interface Article {
   id: number;

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -2,6 +2,29 @@ import HomeHero from '@/components/layout/HomeHero';
 import { InitReferenceData } from '@/components/layout/InitReferenceData';
 import Link from 'next/link';
 import { Card, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Home | ScapeLab',
+  description: 'Tools for optimizing your Old School RuneScape gameplay',
+  alternates: {
+    canonical: '/',
+  },
+  openGraph: {
+    title: 'Home - ScapeLab',
+    description: 'Tools for optimizing your Old School RuneScape gameplay',
+    url: '/',
+    siteName: 'ScapeLab',
+    images: ['/favicon.ico'],
+    locale: 'en_US',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Home | ScapeLab',
+    description: 'Tools for optimizing your Old School RuneScape gameplay',
+  },
+};
 
 export default function Home() {
   return (

--- a/frontend/src/app/presets/page.tsx
+++ b/frontend/src/app/presets/page.tsx
@@ -1,6 +1,29 @@
 'use client';
 import { PresetSelector } from '@/components/features/calculator/PresetSelector';
 import { Visualizations } from '@/components/features/calculator/Visualizations';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Presets & Visualizations',
+  description: 'Manage saved loadouts and visualize their performance.',
+  alternates: {
+    canonical: '/presets',
+  },
+  openGraph: {
+    title: 'Presets & Visualizations',
+    description: 'Manage saved loadouts and visualize their performance.',
+    url: '/presets',
+    siteName: 'ScapeLab',
+    images: ['/favicon.ico'],
+    locale: 'en_US',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Presets & Visualizations',
+    description: 'Manage saved loadouts and visualize their performance.',
+  },
+};
 
 export default function PresetsPage() {
   return (

--- a/frontend/src/app/report-bug/page.tsx
+++ b/frontend/src/app/report-bug/page.tsx
@@ -1,6 +1,29 @@
 'use client';
 
 import { useState } from 'react';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Report a Bug',
+  description: 'Found an issue? Submit a bug report to help improve ScapeLab.',
+  alternates: {
+    canonical: '/report-bug',
+  },
+  openGraph: {
+    title: 'Report a Bug',
+    description: 'Found an issue? Submit a bug report to help improve ScapeLab.',
+    url: '/report-bug',
+    siteName: 'ScapeLab',
+    images: ['/favicon.ico'],
+    locale: 'en_US',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Report a Bug',
+    description: 'Found an issue? Submit a bug report to help improve ScapeLab.',
+  },
+};
 
 export default function ReportBugPage() {
   const [title, setTitle] = useState('');

--- a/frontend/src/app/simulate/page.tsx
+++ b/frontend/src/app/simulate/page.tsx
@@ -1,6 +1,29 @@
 'use client';
 
 import MultiBossSimulation from '@/components/features/simulation/MultiBossSimulation';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Multi-Boss Simulation',
+  description: 'Run combat simulations against multiple bosses with your gear.',
+  alternates: {
+    canonical: '/simulate',
+  },
+  openGraph: {
+    title: 'Multi-Boss Simulation',
+    description: 'Run combat simulations against multiple bosses with your gear.',
+    url: '/simulate',
+    siteName: 'ScapeLab',
+    images: ['/favicon.ico'],
+    locale: 'en_US',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Multi-Boss Simulation',
+    description: 'Run combat simulations against multiple bosses with your gear.',
+  },
+};
 
 export default function SimulatePage() {
   return (


### PR DESCRIPTION
## Summary
- define `metadataBase` in the app layout
- add `metadata` exports to all page components

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684959c6cf5c832e97cf70cb5106227d