### PR TITLE
Add loading overlay for reference data

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -376,3 +376,18 @@ select {
   border-radius: var(--radius);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
+/* Logo fading animation for loading overlay */
+@keyframes logo-fade-1 {
+  0%, 50% { opacity: 1; }
+  25% { opacity: 0; }
+}
+@keyframes logo-fade-2 {
+  0%, 50% { opacity: 0; }
+  25% { opacity: 1; }
+}
+.logo-fade-1 {
+  animation: logo-fade-1 4s linear infinite;
+}
+.logo-fade-2 {
+  animation: logo-fade-2 4s linear infinite;
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,5 +1,6 @@
 import HomeHero from '@/components/layout/HomeHero';
 import { InitReferenceData } from '@/components/layout/InitReferenceData';
+import { ReferenceDataOverlay } from '@/components/layout/ReferenceDataOverlay';
 import Link from 'next/link';
 import { Card, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import type { Metadata } from 'next';
@@ -31,6 +32,7 @@ export default function Home() {
     <>
       <HomeHero />
       <InitReferenceData />
+      <ReferenceDataOverlay />
       <main id="main" className="container mx-auto py-8 px-4 pb-16 text-center">
         <p className="text-lg">Choose a tool from the navigation above or the buttons below to get started.</p>
 

--- a/frontend/src/components/layout/ReferenceDataOverlay.tsx
+++ b/frontend/src/components/layout/ReferenceDataOverlay.tsx
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react';
+import { useReferenceDataStore } from '@/store/reference-data-store';
+
+export function ReferenceDataOverlay() {
+  const loading = useReferenceDataStore((s) => s.loading);
+  const initialized = useReferenceDataStore((s) => s.initialized);
+  const error = useReferenceDataStore((s) => s.error);
+
+  const shouldShow = loading || (!initialized && !error);
+  const [visible, setVisible] = useState(shouldShow);
+
+  useEffect(() => {
+    if (shouldShow) {
+      setVisible(true);
+    } else {
+      const t = setTimeout(() => setVisible(false), 300);
+      return () => clearTimeout(t);
+    }
+  }, [shouldShow]);
+
+  if (!visible) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-background">
+      <div className="text-center">
+        <div className="relative w-48 h-48 mx-auto logo-fade-container">
+          <img
+            src="/images/logo_transparent.png"
+            alt="ScapeLab logo"
+            className="absolute inset-0 w-full h-full object-contain logo-fade-1"
+          />
+          <img
+            src="/images/logo_transparent_v2.png"
+            alt="ScapeLab logo"
+            className="absolute inset-0 w-full h-full object-contain logo-fade-2"
+          />
+        </div>
+        <p className="mt-4 text-lg">{error ? 'Failed to load game data' : 'Loading game data...'}</p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `ReferenceDataOverlay` component that fades between logo images while game data loads
- include overlay on home page
- define fade animations in global styles

## Testing
- `npm test`
- `python -m unittest discover backend/app/testing` *(fails: ModuleNotFoundError etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68495d966c48832e9cfb7801d336934d