### PR TITLE
Remove icons in multi-boss dropdown

### DIFF
--- a/frontend/src/components/features/simulation/MultiBossSimulation.tsx
+++ b/frontend/src/components/features/simulation/MultiBossSimulation.tsx
@@ -292,14 +292,11 @@ export function MultiBossSimulation() {
                       </div>
                     ) : (
                       filteredBosses.map((boss) => (
-                        <CommandItem key={boss.id} value={boss.name} onSelect={() => addBoss(boss)}>
-                          {bossIcons[boss.id] && (
-                            <img
-                              src={bossIcons[boss.id]}
-                              alt={`${boss.name} icon`}
-                              className="w-4 h-4 mr-2 inline-block"
-                            />
-                          )}
+                        <CommandItem
+                          key={boss.id}
+                          value={boss.name}
+                          onSelect={() => addBoss(boss)}
+                        >
                           {boss.name}
                         </CommandItem>
                       ))


### PR DESCRIPTION
## Summary
- remove boss icon images from `MultiBossSimulation` dropdown

## Testing
- `npm test --prefix frontend` *(fails: jest not found)*
- `pytest backend` *(fails: ModuleNotFoundError: No module named 'cachetools')*

------
https://chatgpt.com/codex/tasks/task_e_68495f333238832e96277177f0915340