### PR TITLE
Remove item icons from calculator selector

### DIFF
--- a/frontend/src/__tests__/alt-text.test.tsx
+++ b/frontend/src/__tests__/alt-text.test.tsx
@@ -69,6 +69,6 @@ describe('image alt text', () => {
 
     render(<ItemSelector />, { wrapper });
     await userEvent.click(screen.getByRole('combobox'));
-    expect(screen.getByAltText('Dragon scimitar icon')).toBeInTheDocument();
+    expect(screen.getByText('Dragon scimitar')).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/features/calculator/ItemSelector.tsx
+++ b/frontend/src/components/features/calculator/ItemSelector.tsx
@@ -176,13 +176,6 @@ export function ItemSelector({ slot, specialOnly, onSelectItem }: ItemSelectorPr
                 aria-expanded={open}
                 className="w-full justify-between"
               >
-                {selectedItem && (
-                  <img
-                    src={selectedItem.icons?.[0] || (selectedItem as any)?.image_url}
-                    alt={`${selectedItem.name} icon`}
-                    className="w-4 h-4 mr-2 inline-block"
-                  />
-                )}
                 {selectedItem ? selectedItem.name : `Select an item...`}
                 <Search className="ml-2 h-4 w-4 shrink-0 opacity-50" />
               </Button>
@@ -210,11 +203,6 @@ export function ItemSelector({ slot, specialOnly, onSelectItem }: ItemSelectorPr
                           value={item.name}
                           onSelect={() => handleSelectItem(item)}
                         >
-                          <img
-                            src={item.icons?.[0] || (item as any)?.image_url}
-                            alt={`${item.name} icon`}
-                            className="w-4 h-4 mr-2 inline-block"
-                          />
                           {item.name}
                           {item.has_special_attack && (
                             <Badge variant="secondary" className="ml-2">


### PR DESCRIPTION
## Summary
- update item selector to show names only
- adjust tests for new behavior

## Testing
- `npm test --silent`
- `python -m unittest discover -s app/testing -p '*test*.py'` *(fails: ODBC Driver not found)*

------
https://chatgpt.com/codex/tasks/task_e_68495f30e5cc832e902ccb14ad56caba