### PR TITLE
Integrate ScapeLab logo and add animated spinner

### DIFF
--- a/frontend/src/components/features/calculator/BossSelector.tsx
+++ b/frontend/src/components/features/calculator/BossSelector.tsx
@@ -2,7 +2,8 @@
 
 import { useState, useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { Search, Loader2, RotateCcw } from 'lucide-react';
+import { Search, RotateCcw } from 'lucide-react';
+import { LogoSpinner } from '@/components/ui/LogoSpinner';
 import { Command as CommandPrimitive } from 'cmdk';
 import { 
   Command, 
@@ -388,7 +389,7 @@ export function BossSelector({ onSelectBoss, onSelectForm }: BossSelectorProps) 
                   <CommandList>
                     {isLoading && searchTerm ? (
                       <div className="flex items-center justify-center p-4">
-                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                        <LogoSpinner className="mr-2 h-4 w-4" />
                         Loading...
                       </div>
                     ) : (
@@ -415,7 +416,7 @@ export function BossSelector({ onSelectBoss, onSelectForm }: BossSelectorProps) 
                   </CommandList>
                   { (isLoading && !searchTerm) || initialLoading ? (
                     <div className="flex items-center justify-center p-2">
-                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      <LogoSpinner className="mr-2 h-4 w-4" />
                     </div>
                   ) : null}
                 </CommandGroup>
@@ -430,7 +431,7 @@ export function BossSelector({ onSelectBoss, onSelectForm }: BossSelectorProps) 
             <label className="text-sm font-medium">Select Form/Phase</label>
             {isLoadingDetails ? (
               <div className="flex items-center text-sm text-muted-foreground">
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                <LogoSpinner className="mr-2 h-4 w-4" />
                 Loading boss details...
               </div>
             ) : (<div className="flex items-center gap-2">

--- a/frontend/src/components/features/calculator/CombinedEquipmentDisplay.tsx
+++ b/frontend/src/components/features/calculator/CombinedEquipmentDisplay.tsx
@@ -10,7 +10,7 @@ import { useCalculatorStore } from '@/store/calculator-store';
 import { Item, CalculatorParams, BossForm } from '@/types/calculator';
 import { useToast } from '@/hooks/use-toast';
 import { calculatorApi } from '@/services/api';
-import { Loader2 } from 'lucide-react';
+import { LogoSpinner } from '@/components/ui/LogoSpinner';
 
 // Import our new components
 import { EquipmentGrid } from './EquipmentGrid';
@@ -476,7 +476,7 @@ export function CombinedEquipmentDisplay({
           )}
           {showSuggestButton && (
             <Button size="sm" onClick={handleSuggestBis} disabled={isSuggesting}>
-              {isSuggesting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}Suggest BIS
+              {isSuggesting && <LogoSpinner className="mr-2 h-4 w-4" />}Suggest BIS
             </Button>
           )}
         </div>

--- a/frontend/src/components/features/calculator/DirectBossSelector.tsx
+++ b/frontend/src/components/features/calculator/DirectBossSelector.tsx
@@ -2,7 +2,8 @@
 
 import { useState, useEffect, useRef } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { Loader2, RotateCcw } from 'lucide-react';
+import { RotateCcw } from 'lucide-react';
+import { LogoSpinner } from '@/components/ui/LogoSpinner';
 import { 
   Command, 
   CommandEmpty, 
@@ -289,7 +290,7 @@ export function DirectBossSelector({ onSelectBoss, onSelectForm, className }: Di
                   <CommandGroup>
                     {isLoading && searchQuery ? (
                       <div className="flex items-center justify-center p-4">
-                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                        <LogoSpinner className="mr-2 h-4 w-4" />
                         Loading...
                       </div>
                     ) : (
@@ -317,7 +318,7 @@ export function DirectBossSelector({ onSelectBoss, onSelectForm, className }: Di
                   </CommandGroup>
                   { (isLoading && !searchQuery) || (storeBosses.length === 0 && !searchQuery) ? (
                     <div className="flex items-center justify-center p-2">
-                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      <LogoSpinner className="mr-2 h-4 w-4" />
                     </div>
                   ) : null}
                 </CommandList>
@@ -332,7 +333,7 @@ export function DirectBossSelector({ onSelectBoss, onSelectForm, className }: Di
             <label className="text-sm font-medium">Select Form/Phase</label>
             {isLoadingDetails ? (
               <div className="flex items-center text-sm text-muted-foreground">
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                <LogoSpinner className="mr-2 h-4 w-4" />
                 Loading boss details...
               </div>
             ) : (<div className="flex items-center gap-2 w-full justify-between">

--- a/frontend/src/components/features/calculator/ItemSelector.tsx
+++ b/frontend/src/components/features/calculator/ItemSelector.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { Search, Loader2 } from 'lucide-react';
+import { Search } from 'lucide-react';
+import { LogoSpinner } from '@/components/ui/LogoSpinner';
 import { 
   Command, 
   CommandEmpty, 
@@ -200,7 +201,7 @@ export function ItemSelector({ slot, specialOnly, onSelectItem }: ItemSelectorPr
                   <CommandList className="max-h-[300px]">
                     {isLoading && searchTerm ? (
                       <div className="flex items-center justify-center p-4">
-                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                        <LogoSpinner className="mr-2 h-4 w-4" />
                         Loading...
                       </div>
                     ) : (
@@ -232,7 +233,7 @@ export function ItemSelector({ slot, specialOnly, onSelectItem }: ItemSelectorPr
                   </CommandList>
                   {isLoading && !searchTerm && (
                     <div className="flex items-center justify-center p-2">
-                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      <LogoSpinner className="mr-2 h-4 w-4" />
                     </div>
                   )}
                 </CommandGroup>

--- a/frontend/src/components/features/simulation/MultiBossSimulation.tsx
+++ b/frontend/src/components/features/simulation/MultiBossSimulation.tsx
@@ -2,7 +2,8 @@
 
 import { useState, useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { Search, Loader2, X } from 'lucide-react';
+import { Search, X } from 'lucide-react';
+import { LogoSpinner } from '@/components/ui/LogoSpinner';
 import {
   Command,
   CommandEmpty,
@@ -287,7 +288,7 @@ export function MultiBossSimulation() {
                   <CommandList>
                     {isLoading && searchTerm ? (
                       <div className="flex items-center justify-center p-4">
-                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                        <LogoSpinner className="mr-2 h-4 w-4" />
                         Loading...
                       </div>
                     ) : (
@@ -326,7 +327,7 @@ export function MultiBossSimulation() {
           </div>
         )}
         <Button onClick={runSimulation} disabled={selectedBosses.length === 0 || isRunning}>
-          {isRunning && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}Run Simulation
+          {isRunning && <LogoSpinner className="mr-2 h-4 w-4" />}Run Simulation
         </Button>
         {results.length > 0 && (
           <Table className="mt-4">

--- a/frontend/src/components/layout/Footer.tsx
+++ b/frontend/src/components/layout/Footer.tsx
@@ -5,7 +5,8 @@ export function Footer() {
     <footer className="border-t w-full py-6 bg-background mt-auto">
       <div className="container mx-auto px-4">
         <div className="flex flex-col md:flex-row justify-between items-center">
-          <div className="mb-4 md:mb-0 text-center md:text-left">
+          <div className="mb-4 md:mb-0 text-center md:text-left flex flex-col items-center md:items-start">
+            <img src="/images/logo_transparent_v2.png" alt="ScapeLab logo" className="h-8 w-8 mb-2" />
             <p className="text-sm text-muted-foreground">
               © {currentYear} ScapeLab. Not affiliated with Jagex Ltd.
             </p>

--- a/frontend/src/components/layout/HomeHero.tsx
+++ b/frontend/src/components/layout/HomeHero.tsx
@@ -1,8 +1,11 @@
+import { LogoSpinner } from '../ui/LogoSpinner';
+
 export default function HomeHero() {
   return (
     <section className="relative bg-[url('/images/hitsplat.2f589c5c.webp')] bg-cover bg-center py-24 mb-12 text-center">
       <div className="absolute inset-0 bg-black/60" aria-hidden="true" />
       <div className="relative container mx-auto px-4">
+        <LogoSpinner className="w-24 h-24 mx-auto mb-6" />
         <h1 className="text-5xl md:text-6xl font-title text-primary drop-shadow-md mb-6">
           ScapeLab Tools
         </h1>

--- a/frontend/src/components/layout/Navigation.tsx
+++ b/frontend/src/components/layout/Navigation.tsx
@@ -14,9 +14,14 @@ export function Navigation() {
         <div className="flex space-x-6 items-center">
           <Link
             href="/"
-            className="text-xl font-bold font-title"
+            className="text-xl font-bold font-title flex items-center space-x-2"
           >
-            ScapeLab
+            <img
+              src="/images/logo_transparent.png"
+              alt="ScapeLab logo"
+              className="w-6 h-6"
+            />
+            <span>ScapeLab</span>
           </Link>
           
           <div className="hidden md:flex space-x-4">

--- a/frontend/src/components/layout/ReferenceDataBanner.tsx
+++ b/frontend/src/components/layout/ReferenceDataBanner.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { Loader2, Check, X } from 'lucide-react';
+import { Check, X } from 'lucide-react';
+import { LogoSpinner } from '@/components/ui/LogoSpinner';
 import { useEffect, useState } from 'react';
 import { useReferenceDataStore } from '@/store/reference-data-store';
 
@@ -44,7 +45,7 @@ export function ReferenceDataBanner() {
         ) : error ? (
           <X className="h-4 w-4" />
         ) : (
-          <Loader2 className="h-4 w-4 animate-spin" />
+          <LogoSpinner className="h-4 w-4" />
         )}
         <span>
           {done

--- a/frontend/src/components/ui/LogoSpinner.tsx
+++ b/frontend/src/components/ui/LogoSpinner.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { cn } from '@/lib/utils';
+
+export function LogoSpinner({ className }: { className?: string }) {
+  return (
+    <div className={cn('relative inline-block', className)}>
+      <img
+        src="/images/logo_transparent.png"
+        alt="ScapeLab logo"
+        className="absolute inset-0 w-full h-full object-contain logo-fade-1"
+      />
+      <img
+        src="/images/logo_transparent_v2.png"
+        alt="ScapeLab logo"
+        className="absolute inset-0 w-full h-full object-contain logo-fade-2"
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create `LogoSpinner` component to fade between both logos
- add logo in header, footer and home hero section
- replace spinners across calculator and simulation features

## Testing
- `npm run lint` *(fails: next not found or lint errors)*
- `npm test`
- `npx tsc --noEmit` *(fails due to type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68495f8361c4832e87b4d53f5da27680