### PR TITLE
Update logo references and animations

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -377,17 +377,27 @@ select {
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 /* Logo fading animation for loading overlay */
-@keyframes logo-fade-1 {
-  0%, 50% { opacity: 1; }
-  25% { opacity: 0; }
+@keyframes logo-cycle {
+  0%,
+  20% {
+    opacity: 1;
+  }
+  33%,
+  100% {
+    opacity: 0;
+  }
 }
-@keyframes logo-fade-2 {
-  0%, 50% { opacity: 0; }
-  25% { opacity: 1; }
+
+.logo-fade-off {
+  animation: logo-cycle 6s linear infinite;
 }
-.logo-fade-1 {
-  animation: logo-fade-1 4s linear infinite;
+
+.logo-fade-mid {
+  animation: logo-cycle 6s linear infinite;
+  animation-delay: 2s;
 }
-.logo-fade-2 {
-  animation: logo-fade-2 4s linear infinite;
+
+.logo-fade-on {
+  animation: logo-cycle 6s linear infinite;
+  animation-delay: 4s;
 }

--- a/frontend/src/components/layout/Footer.tsx
+++ b/frontend/src/components/layout/Footer.tsx
@@ -6,7 +6,7 @@ export function Footer() {
       <div className="container mx-auto px-4">
         <div className="flex flex-col md:flex-row justify-between items-center">
           <div className="mb-4 md:mb-0 text-center md:text-left flex flex-col items-center md:items-start">
-            <img src="/images/logo_transparent_v2.png" alt="ScapeLab logo" className="h-8 w-8 mb-2" />
+            <img src="/images/logo_transparent_hd.png" alt="ScapeLab logo" className="h-8 w-8 mb-2" />
             <p className="text-sm text-muted-foreground">
               © {currentYear} ScapeLab. Not affiliated with Jagex Ltd.
             </p>

--- a/frontend/src/components/layout/Navigation.tsx
+++ b/frontend/src/components/layout/Navigation.tsx
@@ -17,7 +17,7 @@ export function Navigation() {
             className="text-xl font-bold font-title flex items-center space-x-2"
           >
             <img
-              src="/images/logo_transparent.png"
+              src="/images/logo_transparent_on.png"
               alt="ScapeLab logo"
               className="w-6 h-6"
             />

--- a/frontend/src/components/layout/ReferenceDataOverlay.tsx
+++ b/frontend/src/components/layout/ReferenceDataOverlay.tsx
@@ -25,16 +25,21 @@ export function ReferenceDataOverlay() {
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-background">
       <div className="text-center">
-        <div className="relative w-48 h-48 mx-auto logo-fade-container">
+        <div className="relative w-48 h-48 mx-auto">
           <img
-            src="/images/logo_transparent.png"
+            src="/images/logo_transparent_off.png"
             alt="ScapeLab logo"
-            className="absolute inset-0 w-full h-full object-contain logo-fade-1"
+            className="absolute inset-0 w-full h-full object-contain logo-fade-off"
           />
           <img
-            src="/images/logo_transparent_v2.png"
+            src="/images/logo_transparent_mid.png"
             alt="ScapeLab logo"
-            className="absolute inset-0 w-full h-full object-contain logo-fade-2"
+            className="absolute inset-0 w-full h-full object-contain logo-fade-mid"
+          />
+          <img
+            src="/images/logo_transparent_on.png"
+            alt="ScapeLab logo"
+            className="absolute inset-0 w-full h-full object-contain logo-fade-on"
           />
         </div>
         <p className="mt-4 text-lg">{error ? 'Failed to load game data' : 'Loading game data...'}</p>

--- a/frontend/src/components/ui/LogoSpinner.tsx
+++ b/frontend/src/components/ui/LogoSpinner.tsx
@@ -5,14 +5,19 @@ export function LogoSpinner({ className }: { className?: string }) {
   return (
     <div className={cn('relative inline-block', className)}>
       <img
-        src="/images/logo_transparent.png"
+        src="/images/logo_transparent_off.png"
         alt="ScapeLab logo"
-        className="absolute inset-0 w-full h-full object-contain logo-fade-1"
+        className="absolute inset-0 w-full h-full object-contain logo-fade-off"
       />
       <img
-        src="/images/logo_transparent_v2.png"
+        src="/images/logo_transparent_mid.png"
         alt="ScapeLab logo"
-        className="absolute inset-0 w-full h-full object-contain logo-fade-2"
+        className="absolute inset-0 w-full h-full object-contain logo-fade-mid"
+      />
+      <img
+        src="/images/logo_transparent_on.png"
+        alt="ScapeLab logo"
+        className="absolute inset-0 w-full h-full object-contain logo-fade-on"
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- hook up new logo image files
- update animation CSS to cycle through off/mid/on frames
- use HD logo in footer
- reference new logos in navigation and loading overlay

## Testing
- `npm test` in `frontend`
- `npm run lint` *(fails: `Unexpected any` errors)*
- `pytest backend/app/testing` *(fails: ODBC Driver not found)*

------
https://chatgpt.com/codex/tasks/task_e_68496c013900832ea3405375b2e20874