### PR TITLE
Switch frontend terminology from bosses to NPCs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 ScapeLab DPS Calculator
 
-A comprehensive damage-per-second calculator for Old School RuneScape with accurate combat formulas, equipment comparison, and boss statistics.
+A comprehensive damage-per-second calculator for Old School RuneScape with accurate combat formulas, equipment comparison, and npc statistics.
 
 
 Overview
 
     If you encounter a bug or have a suggestion, submit it from the [Report Bug](/report-bug) page. Reports are automatically converted into GitHub issues via a workflow.
-The ScapeLab DPS Calculator is a powerful tool for Old School RuneScape players to optimize their combat gear and strategies. By accurately implementing the game's combat formulas, this calculator helps players compare different equipment setups, account for special effects, and calculate expected damage against various bosses.
+The ScapeLab DPS Calculator is a powerful tool for Old School RuneScape players to optimize their combat gear and strategies. By accurately implementing the game's combat formulas, this calculator helps players compare different equipment setups, account for special effects, and calculate expected damage against various npcs.
 Key Features
 
     All Combat Styles: Full support for Melee, Ranged, and Magic calculations
     Equipment Database: Comprehensive database of in-game items with their stats and effects
-    Boss Encyclopedia: Detailed information for all bosses including their defensive stats and weaknesses
+    Npc Encyclopedia: Detailed information for all npcs including their defensive stats and weaknesses
     Special Effects: Support for passive effects, set effects, and monster-specific bonuses
     Defense Reduction: Calculate the impact of defense-lowering special attacks
     Visualizations: Save loadouts and view DPS, max hit and hit chance graphs
@@ -69,7 +69,7 @@ Usage Guide
     Select Combat Style: Choose between Melee, Ranged, or Magic
     Set Your Stats: Enter your combat levels and boosts
     Choose Equipment: Select gear for each slot
-    Select Target: Pick a boss or enter custom defense stats
+    Select Target: Pick a npc or enter custom defense stats
     Apply Modifiers: Select prayers, potions, and special attacks
     Calculate: View your expected DPS and other stats
     Compare: Save setups to compare different loadouts
@@ -93,8 +93,8 @@ The frontend is built with Next.js and uses:
 
 State Persistence
 
-The calculator remembers your last selected boss, locked gear, and loadout across
-page reloads using Zustand's `persist` middleware. Boss and item lists are cached
+The calculator remembers your last selected npc, locked gear, and loadout across
+page reloads using Zustand's `persist` middleware. Npc and item lists are cached
 locally for 12 hours so returning to the app doesn't require refetching all
 reference data.
 
@@ -185,10 +185,10 @@ copied from the SQLite sources to keep their ordering consistent across runs,
 and the items table enforces `UNIQUE(name)` to guard against accidental
 duplicates.
 
-The API also caches boss and item lookups in memory. Set the
+The API also caches npc and item lookups in memory. Set the
 `CACHE_TTL_SECONDS` environment variable to control how long (in seconds)
 these results remain cached. The default is `3600` seconds. On the first
-request the server loads and caches the full boss and item lists, and all
+request the server loads and caches the full npc and item lists, and all
 subsequent search requests are served from this in-memory cache so the
 database is only queried when a specific record is requested.
 
@@ -315,12 +315,12 @@ Request Body: `DpsParameters`
 
 Response: A mapping of gear slot to item details.
 
-List Bosses
+List Npcs
 -----------
 
-GET `/bosses`
+GET `/npcs`
 
-GET `/boss/form/{form_id}` - Retrieve boss details by form identifier
+GET `/npc/form/{form_id}` - Retrieve npc details by form identifier
 
 Query Parameters:
 
@@ -330,7 +330,7 @@ Query Parameters:
 Search Endpoints
 ----------------
 
-GET `/search/bosses` - Search for bosses by name
+GET `/search/npcs` - Search for npcs by name
 GET `/search/items` - Search for items by name
 
 Query Parameters:
@@ -353,8 +353,8 @@ Query Parameters:
 Performance & API Best Practices
 -------------------------------
 
-- Use `page` and `page_size` on `/items` and `/bosses` to paginate responses and minimize payload size.
-- Item and boss detail endpoints utilise server-side in-memory caches. Responses include a `Cache-Control` header with a `max-age` matching the `CACHE_TTL_SECONDS` setting.
+- Use `page` and `page_size` on `/items` and `/npcs` to paginate responses and minimize payload size.
+- Item and npc detail endpoints utilise server-side in-memory caches. Responses include a `Cache-Control` header with a `max-age` matching the `CACHE_TTL_SECONDS` setting.
 - Adjust cache duration via the `CACHE_TTL_SECONDS` environment variable when launching the backend.
 
 See the API documentation at /docs for more endpoints.
@@ -363,7 +363,7 @@ See the API documentation at /docs for more endpoints.
 All game data is sourced from the Old School RuneScape Wiki using custom data scrapers. The scraping tools are included in the repository:
 
     osrs_item_scraper.py: Scrapes equipment data
-    extract.py: Scrapes boss data
+    extract.py: Scrapes npc data
 
 🛠️ Contributing
 

--- a/frontend/docs/IMPLEMENTATION.md
+++ b/frontend/docs/IMPLEMENTATION.md
@@ -28,11 +28,11 @@ Endpoints
         POST /calculate/dps - Calculate DPS based on provided parameters
         POST /calculate/item-effect - Calculate special effects for specific items
     Game Data
-        GET /bosses - Get a list of all bosses
-        GET /boss/{boss_id} - Get details for a specific boss
+        GET /npcs - Get a list of all npcs
+        GET /npc/{npc_id} - Get details for a specific npc
         GET /items - Get a list of all items with optional filters
         GET /item/{item_id} - Get details for a specific item
-        GET /search/bosses - Search for bosses by name
+        GET /search/npcs - Search for npcs by name
         GET /search/items - Search for items by name
 
 Key Components
@@ -42,17 +42,17 @@ Key Components
         RangedCalculator - Handles ranged DPS calculations with special effects like Twisted Bow
         MagicCalculator - Handles magic DPS calculations with special effects like Tumeken's Shadow
         DpsCalculator - Main calculator interface that delegates to the specific combat style calculators
-    Database Service - Handles database operations for retrieving boss and item data:
-        SQLite database for bosses with their forms and stats
+    Database Service - Handles database operations for retrieving npc and item data:
+        SQLite database for npcs with their forms and stats
         SQLite database for items with their combat bonuses
-        Search functionality for finding bosses and items
+        Search functionality for finding npcs and items
     Data Models - Pydantic models for type validation and serialization:
         DpsResult - Result of a DPS calculation
-        Boss - Boss data including forms
+        Npc - Npc data including forms
         Item - Item data including combat stats
         DpsParameters - Parameters for DPS calculation
     Data Collection - Scripts for collecting game data:
-        extract.py - Scrapes boss data from the OSRS Wiki
+        extract.py - Scrapes npc data from the OSRS Wiki
         osrs_item_scraper.py - Scrapes item data from the OSRS Wiki
 
 Frontend Overview
@@ -64,9 +64,9 @@ Key Features
         MeleeForm - Form for melee parameters
         RangedForm - Form for ranged parameters
         MagicForm - Form for magic parameters
-    Target Selection - Component for selecting bosses to calculate DPS against:
-        BossSelector - Allows selecting bosses and their forms
-        Automatically updates defense parameters based on the selected boss
+    Target Selection - Component for selecting npcs to calculate DPS against:
+        NpcSelector - Allows selecting npcs and their forms
+        Automatically updates defense parameters based on the selected npc
     Equipment Selection - Component for selecting items:
         ItemSelector - Allows selecting items with combat stats
         Automatically updates attack and strength bonuses based on the selected item
@@ -78,7 +78,7 @@ Key Features
         Comparison data
     API Integration - Services for communicating with the backend:
         calculatorApi - Service for DPS calculations
-        bossesApi - Service for retrieving boss data
+        npcsApi - Service for retrieving npc data
         itemsApi - Service for retrieving item data
 
 Key Algorithms

--- a/frontend/src/__tests__/alt-text.test.tsx
+++ b/frontend/src/__tests__/alt-text.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { BossSelector } from '../components/features/calculator/BossSelector';
+import { NpcSelector } from '../components/features/calculator/NpcSelector';
 import { ItemSelector } from '../components/features/calculator/ItemSelector';
 import { useCalculatorStore } from '../store/calculator-store';
 import { useReferenceDataStore } from '../store/reference-data-store';
@@ -28,12 +28,12 @@ beforeAll(() => {
 describe('image alt text', () => {
   beforeEach(() => {
     useCalculatorStore.setState({
-      selectedBoss: null,
-      selectedBossForm: null,
+      selectedNpc: null,
+      selectedNpcForm: null,
     } as any);
     useReferenceDataStore.setState({
-      bosses: [],
-      bossForms: {},
+      npcs: [],
+      npcForms: {},
       items: [],
       progress: 1,
       initialized: true,
@@ -41,18 +41,18 @@ describe('image alt text', () => {
       error: false,
       timestamp: 0,
       initData: jest.fn(),
-      addBosses: jest.fn(),
-      addBossForms: jest.fn(),
+      addNpces: jest.fn(),
+      addNpcForms: jest.fn(),
       addItems: jest.fn(),
     });
   });
 
-  it('does not render a boss icon', () => {
-    const boss = { id: 1, name: 'Zulrah', icon_url: '/zulrah.png' } as any;
-    useCalculatorStore.getState().setSelectedBoss(boss);
-    useReferenceDataStore.setState({ bosses: [boss], bossForms: { 1: [] } });
+  it('does not render a npc icon', () => {
+    const npc = { id: 1, name: 'Zulrah', icon_url: '/zulrah.png' } as any;
+    useCalculatorStore.getState().setSelectedNpc(npc);
+    useReferenceDataStore.setState({ npcs: [npc], npcForms: { 1: [] } });
 
-    render(<BossSelector />, { wrapper });
+    render(<NpcSelector />, { wrapper });
     expect(screen.queryByAltText('Zulrah icon')).not.toBeInTheDocument();
   });
 

--- a/frontend/src/__tests__/passive-effects-utils.test.ts
+++ b/frontend/src/__tests__/passive-effects-utils.test.ts
@@ -1,12 +1,12 @@
 import {
-  isTargetDraconic,
-  isTargetDemonic,
+  isNpcDraconic,
+  isNpcDemonic,
   hasVoidKnightSet,
   countInquisitorPieces,
 } from '../utils/passiveEffectsUtils';
 
-const dragonBoss = { boss_id: 50, form_name: 'King Black Dragon' } as any;
-const demonBoss = { form_name: "K'ril Tsutsaroth", weakness: 'demon' } as any;
+const dragonNpc = { npc_id: 50, form_name: 'King Black Dragon' } as any;
+const demonNpc = { form_name: "K'ril Tsutsaroth", weakness: 'demon' } as any;
 
 const equipment = {
   body: { name: 'Void knight top' },
@@ -24,8 +24,8 @@ const inquisitorEquip = {
 
 describe('passiveEffectsUtils', () => {
   it('detects target types', () => {
-    expect(isTargetDraconic(dragonBoss)).toBe(true);
-    expect(isTargetDemonic(demonBoss)).toBe(true);
+    expect(isNpcDraconic(dragonNpc)).toBe(true);
+    expect(isNpcDemonic(demonNpc)).toBe(true);
   });
 
   it('detects void set and inquisitor pieces', () => {

--- a/frontend/src/__tests__/reference-data-store.test.ts
+++ b/frontend/src/__tests__/reference-data-store.test.ts
@@ -1,7 +1,7 @@
 import { act } from '@testing-library/react';
 import { useReferenceDataStore } from '../store/reference-data-store';
 import {
-  bossesApi,
+  npcsApi,
   itemsApi,
   specialAttacksApi,
   passiveEffectsApi,
@@ -9,7 +9,7 @@ import {
 
 jest.mock('../services/api');
 
-const mockedBossApi = bossesApi as jest.Mocked<typeof bossesApi>;
+const mockedNpcApi = npcsApi as jest.Mocked<typeof npcsApi>;
 const mockedItemsApi = itemsApi as jest.Mocked<typeof itemsApi>;
 const mockedSpecialApi =
   specialAttacksApi as jest.Mocked<typeof specialAttacksApi>;
@@ -24,8 +24,8 @@ describe('reference data store', () => {
   beforeEach(() => {
     act(() => {
       useReferenceDataStore.setState({
-        bosses: [],
-        bossForms: {},
+        npcs: [],
+        npcForms: {},
         items: [],
         specialAttacks: {},
         passiveEffects: {},
@@ -35,15 +35,15 @@ describe('reference data store', () => {
         error: false,
       });
     });
-    mockedBossApi.getAllBosses.mockReset();
+    mockedNpcApi.getAllNpces.mockReset();
     mockedItemsApi.getAllItems.mockReset();
     mockedSpecialApi.getAll.mockReset();
     mockedPassiveApi.getAll.mockReset();
   });
 
   it('loads data from APIs', async () => {
-    mockedBossApi.getAllBosses
-      .mockResolvedValueOnce([{ id: 1, name: 'Boss' } as any])
+    mockedNpcApi.getAllNpces
+      .mockResolvedValueOnce([{ id: 1, name: 'Npc' } as any])
       .mockResolvedValueOnce([]);
 
     mockedItemsApi.getAllItems
@@ -58,18 +58,18 @@ describe('reference data store', () => {
     });
 
     const state = getStore();
-    expect(state.bosses).toHaveLength(1);
+    expect(state.npcs).toHaveLength(1);
     expect(state.items).toHaveLength(1);
     expect(Object.keys(state.specialAttacks)).toHaveLength(1);
     expect(Object.keys(state.passiveEffects)).toHaveLength(1);
-    expect(mockedBossApi.getAllBosses).toHaveBeenCalledTimes(1);
+    expect(mockedNpcApi.getAllNpces).toHaveBeenCalledTimes(1);
     expect(mockedItemsApi.getAllItems).toHaveBeenCalledTimes(1);
     expect(mockedSpecialApi.getAll).toHaveBeenCalledTimes(1);
     expect(mockedPassiveApi.getAll).toHaveBeenCalledTimes(1);
   });
 
   it('does not load again when initialized', async () => {
-    mockedBossApi.getAllBosses.mockResolvedValue([]);
+    mockedNpcApi.getAllNpces.mockResolvedValue([]);
     mockedItemsApi.getAllItems.mockResolvedValue([]);
     mockedSpecialApi.getAll.mockResolvedValue({});
     mockedPassiveApi.getAll.mockResolvedValue({});
@@ -82,7 +82,7 @@ describe('reference data store', () => {
       await getStore().initData();
     });
 
-    expect(mockedBossApi.getAllBosses).toHaveBeenCalledTimes(1);
+    expect(mockedNpcApi.getAllNpces).toHaveBeenCalledTimes(1);
     expect(mockedItemsApi.getAllItems).toHaveBeenCalledTimes(1);
     expect(mockedSpecialApi.getAll).toHaveBeenCalledTimes(1);
     expect(mockedPassiveApi.getAll).toHaveBeenCalledTimes(1);

--- a/frontend/src/__tests__/use-combat-form.test.ts
+++ b/frontend/src/__tests__/use-combat-form.test.ts
@@ -38,7 +38,7 @@ describe('useCombatForm hook', () => {
         formSchema: schema,
         defaultValues,
         gearLockedFields: ['magic_attack_bonus'],
-        bossLockedFields: ['target_magic_level'],
+        npcLockedFields: ['target_magic_level'],
       })
     );
 
@@ -54,20 +54,20 @@ describe('useCombatForm hook', () => {
     expect(state.target_magic_level).toBe(75);
   });
 
-  it('respects gear and boss locks', () => {
+  it('respects gear and npc locks', () => {
     const { result } = renderHook(() =>
       useCombatForm<FormValues>({
         combatStyle: 'magic',
         formSchema: schema,
         defaultValues,
         gearLockedFields: ['magic_attack_bonus'],
-        bossLockedFields: ['target_magic_level'],
+        npcLockedFields: ['target_magic_level'],
       })
     );
 
     act(() => {
       useCalculatorStore.getState().lockGear();
-      useCalculatorStore.getState().lockBoss();
+      useCalculatorStore.getState().lockNpc();
     });
 
     act(() => {

--- a/frontend/src/app/about/page.tsx
+++ b/frontend/src/app/about/page.tsx
@@ -31,7 +31,7 @@ export default function AboutPage() {
       <div className="prose dark:prose-invert max-w-3xl mx-auto bg-muted/50 p-6 rounded-lg shadow">
         <p className="lead text-center">
           ScapeLab is an open-source DPS calculator and gear optimizer for Old School RuneScape.
-          Use it to compare different loadouts and plan for maximum damage against any boss or monster.
+          Use it to compare different loadouts and plan for maximum damage against any npc or monster.
         </p>
         
         <h2>How It Works</h2>
@@ -51,7 +51,7 @@ export default function AboutPage() {
         <h2>Features</h2>
         <ul>
           <li>Calculate DPS for all three combat styles: Melee, Ranged, and Magic</li>
-          <li>Select from a database of bosses with accurate defense stats</li>
+          <li>Select from a database of npcs with accurate defense stats</li>
           <li>Choose from combat equipment with their respective bonuses</li>
           <li>Compare different setups side-by-side</li>
           <li>Accurate calculations for weapon special effects</li>
@@ -59,7 +59,7 @@ export default function AboutPage() {
         
         <h2>Data Sources</h2>
         <p>
-          The data for bosses, monsters, and items is sourced from the 
+          The data for npcs, monsters, and items is sourced from the 
           <a href="https://oldschool.runescape.wiki/" target="_blank" rel="noopener noreferrer" className="mx-1">
             Old School RuneScape Wiki
           </a>

--- a/frontend/src/app/simulate/page.tsx
+++ b/frontend/src/app/simulate/page.tsx
@@ -1,15 +1,15 @@
-import MultiBossSimulation from '@/components/features/simulation/MultiBossSimulation';
+import MultiNpcSimulation from '@/components/features/simulation/MultiNpcSimulation';
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
-  title: 'Multi-Boss Simulation',
-  description: 'Run combat simulations against multiple bosses with your gear.',
+  title: 'Multi-Npc Simulation',
+  description: 'Run combat simulations against multiple npcs with your gear.',
   alternates: {
     canonical: '/simulate',
   },
   openGraph: {
-    title: 'Multi-Boss Simulation',
-    description: 'Run combat simulations against multiple bosses with your gear.',
+    title: 'Multi-Npc Simulation',
+    description: 'Run combat simulations against multiple npcs with your gear.',
     url: '/simulate',
     siteName: 'ScapeLab',
     images: ['/favicon.ico'],
@@ -18,19 +18,19 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'Multi-Boss Simulation',
-    description: 'Run combat simulations against multiple bosses with your gear.',
+    title: 'Multi-Npc Simulation',
+    description: 'Run combat simulations against multiple npcs with your gear.',
   },
 };
 
 export default function SimulatePage() {
   return (
     <main id="main" className="container mx-auto py-8 px-4 pb-16">
-      <h1 className="text-4xl font-bold mb-6 text-center">Multi-Boss Simulation</h1>
+      <h1 className="text-4xl font-bold mb-6 text-center">Multi-Npc Simulation</h1>
       <p className="text-center text-muted-foreground mb-8 max-w-2xl mx-auto">
-        Test your current gear and stats against a group of bosses to see how your setup performs.
+        Test your current gear and stats against a group of npcs to see how your setup performs.
       </p>
-      <MultiBossSimulation />
+      <MultiNpcSimulation />
     </main>
   );
 }

--- a/frontend/src/components/features/calculator/AttackStyleSelector.tsx
+++ b/frontend/src/components/features/calculator/AttackStyleSelector.tsx
@@ -10,7 +10,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { Item } from "@/types/calculator";
-import { BossForm } from "@/types/calculator";
+import { NpcForm } from "@/types/calculator";
 
 // Define attack styles with their bonuses
 export interface AttackStyleDefinition {
@@ -102,7 +102,7 @@ export const DEFAULT_ATTACK_STYLES: Record<
 interface AttackStyleSelectorProps {
   loadout: Record<string, Item | null>;
   combatStyle: string;
-  bossForm?: BossForm | null;
+  npcForm?: NpcForm | null;
   attackStyles: Record<string, AttackStyleDefinition>;
   availableAttackStyles: string[];
   selectedAttackStyle: string;
@@ -112,7 +112,7 @@ interface AttackStyleSelectorProps {
 export function AttackStyleSelector({
   loadout,
   combatStyle,
-  bossForm,
+  npcForm,
   attackStyles,
   availableAttackStyles,
   selectedAttackStyle,

--- a/frontend/src/components/features/calculator/BestInSlotCalculator.tsx
+++ b/frontend/src/components/features/calculator/BestInSlotCalculator.tsx
@@ -4,7 +4,7 @@ import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Info } from 'lucide-react';
 import { useEffect, useState, useCallback } from 'react';
 import { useReferenceDataStore } from '@/store/reference-data-store';
-import { BossSelector } from './BossSelector';
+import { NpcSelector } from './NpcSelector';
 import { EquipmentPanel } from './EquipmentPanel';
 import { PrayerPotionSelector } from './PrayerPotionSelector';
 import { CalculatorForms } from './CalculatorForms';
@@ -32,8 +32,8 @@ export function BestInSlotCalculator() {
     handleReset,
     handleTabChange,
     handleEquipmentUpdate,
-    handleBossUpdate,
-    currentBossForm,
+    handleNpcUpdate,
+    currentNpcForm,
   } = useDpsCalculator();
   const initData = useReferenceDataStore((s) => s.initData);
   const { toast } = useToast();
@@ -144,7 +144,7 @@ export function BestInSlotCalculator() {
           {/* Character equipment section */}
           <EquipmentPanel
             onEquipmentUpdate={handleEquipmentUpdate}
-            bossForm={currentBossForm}
+            npcForm={currentNpcForm}
           />
         </div>
 
@@ -153,7 +153,7 @@ export function BestInSlotCalculator() {
           {/* Prayer/Potion selector */}
           <PrayerPotionSelector />
           {/* Target selection section */}
-          <BossSelector onSelectForm={handleBossUpdate} />
+          <NpcSelector onSelectForm={handleNpcUpdate} />
         </div>
       </div>
     </div>

--- a/frontend/src/components/features/calculator/CombinedEquipmentDisplay.tsx
+++ b/frontend/src/components/features/calculator/CombinedEquipmentDisplay.tsx
@@ -7,7 +7,7 @@ import { Switch } from '@/components/ui/switch';
 import { Label } from '@/components/ui/label';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { useCalculatorStore } from '@/store/calculator-store';
-import { Item, CalculatorParams, BossForm } from '@/types/calculator';
+import { Item, CalculatorParams, NpcForm } from '@/types/calculator';
 import { useToast } from '@/hooks/use-toast';
 import { calculatorApi } from '@/services/api';
 import { LogoSpinner } from '@/components/ui/LogoSpinner';
@@ -49,14 +49,14 @@ function isMagicParams(params: CalculatorParams): params is CalculatorParams & {
 
 interface CombinedEquipmentDisplayProps {
   onEquipmentUpdate?: (loadout: Record<string, Item | null>) => void;
-  bossForm?: BossForm | null;
+  npcForm?: NpcForm | null;
   loadoutPreset?: Record<string, Item | null>;
   showSuggestButton?: boolean;
 }
 
 export function CombinedEquipmentDisplay({
   onEquipmentUpdate,
-  bossForm,
+  npcForm,
   loadoutPreset,
   showSuggestButton = false,
 }: CombinedEquipmentDisplayProps) {
@@ -347,21 +347,21 @@ export function CombinedEquipmentDisplay({
         const atkBonuses = weapon?.combat_stats?.attack_bonuses || {};
         updateParams.melee_attack_bonus = atkBonuses[type as keyof typeof atkBonuses] ?? 0;
         updateParams.target_defence_type = ATTACK_TYPE_TO_DEFENCE_TYPE[type];
-        updateParams.target_defence_bonus = bossForm?.[ATTACK_TYPE_TO_DEFENCE_TYPE[type] as keyof BossForm] ?? 0;
+        updateParams.target_defence_bonus = npcForm?.[ATTACK_TYPE_TO_DEFENCE_TYPE[type] as keyof NpcForm] ?? 0;
       }
 
       if (isRangedParams(params)) {
         updateParams.ranged_attack_bonus = params.ranged_attack_bonus;
         updateParams.ranged_strength_bonus = params.ranged_strength_bonus;
         updateParams.target_defence_type = 'defence_ranged_standard';
-        updateParams.target_defence_bonus = bossForm?.defence_ranged_standard ?? 0;
+        updateParams.target_defence_bonus = npcForm?.defence_ranged_standard ?? 0;
       }
 
       if (isMagicParams(params)) {
         updateParams.magic_attack_bonus = params.magic_attack_bonus;
         updateParams.magic_damage_bonus = params.magic_damage_bonus;
         updateParams.target_defence_type = 'defence_magic';
-        updateParams.target_defence_bonus = bossForm?.defence_magic ?? 0;
+        updateParams.target_defence_bonus = npcForm?.defence_magic ?? 0;
       }
 
       setParams(updateParams);
@@ -371,7 +371,7 @@ export function CombinedEquipmentDisplay({
     weaponStats,
     combatStyle,
     loadout,
-    bossForm,
+    npcForm,
     setParams,
     params
   ]);
@@ -458,7 +458,7 @@ export function CombinedEquipmentDisplay({
           <AttackStyleSelector
             loadout={loadout}
             combatStyle={combatStyle}
-            bossForm={bossForm}
+            npcForm={npcForm}
             attackStyles={getAttackStylesForDisplay()}
             availableAttackStyles={availableAttackStyles}
             selectedAttackStyle={selectedAttackStyle}

--- a/frontend/src/components/features/calculator/DefenceReductionPanel.tsx
+++ b/frontend/src/components/features/calculator/DefenceReductionPanel.tsx
@@ -106,7 +106,7 @@ export function DefenceReductionPanel() {
           <Shield className="h-5 w-5 mr-2 text-rs-gold" />
           Defensive Reductions
         </CardTitle>
-        <CardDescription>Track special attack effects on boss defence</CardDescription>
+        <CardDescription>Track special attack effects on npc defence</CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
         {numericEffects.map(({ key, label }) => (

--- a/frontend/src/components/features/calculator/EquipmentDisplay.tsx
+++ b/frontend/src/components/features/calculator/EquipmentDisplay.tsx
@@ -55,7 +55,7 @@ interface EquipmentDisplayProps {
 }
 
 export function EquipmentDisplay({ loadout, totals }: EquipmentDisplayProps) {
-  const { params, setParams, bossLocked } = useCalculatorStore();
+  const { params, setParams, npcLocked } = useCalculatorStore();
   const [isExpanded, setIsExpanded] = useState(true);
   const [selectedAttackType, setSelectedAttackType] = useState<string>('slash');
   const [selectedAttackStyle, setSelectedAttackStyle] = useState<string>('aggressive');
@@ -356,9 +356,9 @@ export function EquipmentDisplay({ loadout, totals }: EquipmentDisplayProps) {
                   </TooltipTrigger>
                   <TooltipContent>
                     <p>Select your attack type and style to optimize your DPS.</p>
-                    {bossLocked && combatStyle === 'melee' && (
+                    {npcLocked && combatStyle === 'melee' && (
                       <p className="text-xs mt-1 text-green-500">
-                        Attack type will be used to determine boss defense.
+                        Attack type will be used to determine npc defense.
                       </p>
                     )}
                   </TooltipContent>
@@ -383,9 +383,9 @@ export function EquipmentDisplay({ loadout, totals }: EquipmentDisplayProps) {
                     ))}
                   </TabsList>
                 </Tabs>
-                {bossLocked && (
+                {npcLocked && (
                   <p className="text-xs text-amber-500 mt-1">
-                    Using {selectedAttackType} attack against boss&rsquo;s {selectedAttackType} defense
+                    Using {selectedAttackType} attack against npc&rsquo;s {selectedAttackType} defense
                   </p>
                 )}
               </div>

--- a/frontend/src/components/features/calculator/EquipmentLoadout.tsx
+++ b/frontend/src/components/features/calculator/EquipmentLoadout.tsx
@@ -59,13 +59,13 @@ interface EquipmentLoadoutProps {
 
 export function EquipmentLoadout({ onEquipmentUpdate }: EquipmentLoadoutProps) {
   const { toast } = useToast();
-  const { params, setParams, lockGear, unlockGear, gearLocked, bossLocked } = useCalculatorStore();
+  const { params, setParams, lockGear, unlockGear, gearLocked, npcLocked } = useCalculatorStore();
   const combatStyle = params.combat_style;
   const [selectedSlot, setSelectedSlot] = useState<string | null>(null);
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [loadout, setLoadout] = useState<Record<string, Item | null>>({});
   const [isExpanded, setIsExpanded] = useState(true);
-  const [selectedBossForm, setSelectedBossForm] = useState(null);
+  const [selectedNpcForm, setSelectedNpcForm] = useState(null);
   // Default to 1H weapon with offhand
   const [show2hOption, setShow2hOption] = useState(false); // Add missing state
 
@@ -80,18 +80,18 @@ export function EquipmentLoadout({ onEquipmentUpdate }: EquipmentLoadoutProps) {
     'magic damage percent': 0,
   });
 
-  // Effect to fetch the current boss form when boss is locked
+  // Effect to fetch the current npc form when npc is locked
   useEffect(() => {
-    // This would need to be implemented to fetch the current boss form
-    // from the BossSelector component or from an API
-    if (bossLocked) {
-      // fetchCurrentBossForm().then(form => setSelectedBossForm(form));
+    // This would need to be implemented to fetch the current npc form
+    // from the NpcSelector component or from an API
+    if (npcLocked) {
+      // fetchCurrentNpcForm().then(form => setSelectedNpcForm(form));
       // For now we'll just use null
-      setSelectedBossForm(null);
+      setSelectedNpcForm(null);
     } else {
-      setSelectedBossForm(null);
+      setSelectedNpcForm(null);
     }
-  }, [bossLocked]);
+  }, [npcLocked]);
 
   // Helper function to apply gear totals to the store
   const applyGearTotals = useCallback((totals: Record<string, number>) => {

--- a/frontend/src/components/features/calculator/EquipmentPanel.tsx
+++ b/frontend/src/components/features/calculator/EquipmentPanel.tsx
@@ -1,18 +1,18 @@
 'use client';
 
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { BossForm, Item } from '@/types/calculator';
+import { NpcForm, Item } from '@/types/calculator';
 import { LoadoutTabs } from './LoadoutTabs';
 
 interface EquipmentPanelProps {
   onEquipmentUpdate?: (loadout: Record<string, Item | null>) => void;
-  bossForm?: BossForm | null;
+  npcForm?: NpcForm | null;
 }
 
 /**
  * Equipment panel that wraps the LoadoutTabs with a consistent card style
  */
-export function EquipmentPanel({ onEquipmentUpdate, bossForm }: EquipmentPanelProps) {
+export function EquipmentPanel({ onEquipmentUpdate, npcForm }: EquipmentPanelProps) {
   return (
     <Card className="w-full h-full">
       <CardHeader className="flex flex-col items-center pb-2 text-center">
@@ -20,7 +20,7 @@ export function EquipmentPanel({ onEquipmentUpdate, bossForm }: EquipmentPanelPr
         <CardDescription>Configure your gear and attack style</CardDescription>
       </CardHeader>
       <CardContent>
-        <LoadoutTabs bossForm={bossForm} onEquipmentUpdate={onEquipmentUpdate} />
+        <LoadoutTabs npcForm={npcForm} onEquipmentUpdate={onEquipmentUpdate} />
       </CardContent>
     </Card>
   );

--- a/frontend/src/components/features/calculator/ImprovedDpsCalculator.tsx
+++ b/frontend/src/components/features/calculator/ImprovedDpsCalculator.tsx
@@ -26,17 +26,17 @@ export function ImprovedDpsCalculator() {
     handleReset,
     handleTabChange,
     handleEquipmentUpdate,
-    handleBossUpdate,
+    handleNpcUpdate,
     isCalculating,
     currentLoadout,
-    currentBossForm,
+    currentNpcForm,
   } = useDpsCalculator();
   const initData = useReferenceDataStore((s) => s.initData);
-  const selectedBoss = useCalculatorStore((s) => s.selectedBoss);
+  const selectedNpc = useCalculatorStore((s) => s.selectedNpc);
   const [raidConfig, setRaidConfig] = useState<RaidScalingConfig>({ teamSize: 1 });
 
-  const selectedRaid = selectedBoss?.raid_group
-    ? RAID_NAME_TO_ID[selectedBoss.raid_group]
+  const selectedRaid = selectedNpc?.raid_group
+    ? RAID_NAME_TO_ID[selectedNpc.raid_group]
     : undefined;
 
   useEffect(() => {
@@ -58,8 +58,8 @@ export function ImprovedDpsCalculator() {
 
       <MiddleColumns
         onEquipmentUpdate={handleEquipmentUpdate}
-        onSelectForm={handleBossUpdate}
-        currentBossForm={currentBossForm}
+        onSelectForm={handleNpcUpdate}
+        currentNpcForm={currentNpcForm}
         selectedRaid={selectedRaid}
         raidConfig={raidConfig}
         onRaidConfigChange={setRaidConfig}

--- a/frontend/src/components/features/calculator/LoadoutTabs.tsx
+++ b/frontend/src/components/features/calculator/LoadoutTabs.tsx
@@ -6,9 +6,9 @@ import { Button } from '@/components/ui/button';
 import { CombinedEquipmentDisplay } from './CombinedEquipmentDisplay';
 import { useCalculatorStore } from '@/store/calculator-store';
 import { encodeSeed } from '@/utils/seed';
-import { BossForm, Item } from '@/types/calculator';
+import { NpcForm, Item } from '@/types/calculator';
 
-export function LoadoutTabs({ bossForm, onEquipmentUpdate }: { bossForm?: BossForm | null; onEquipmentUpdate?: (loadout: Record<string, Item | null>) => void }) {
+export function LoadoutTabs({ npcForm, onEquipmentUpdate }: { npcForm?: NpcForm | null; onEquipmentUpdate?: (loadout: Record<string, Item | null>) => void }) {
   const presets = useCalculatorStore((s) => s.presets);
   const addPreset = useCalculatorStore((s) => s.addPreset);
   const setLoadout = useCalculatorStore((s) => s.setLoadout);
@@ -65,7 +65,7 @@ export function LoadoutTabs({ bossForm, onEquipmentUpdate }: { bossForm?: BossFo
       </TabsList>
       <TabsContent value={activePreset} className="w-full">
         <CombinedEquipmentDisplay
-          bossForm={bossForm}
+          npcForm={npcForm}
           showSuggestButton={false}
           onEquipmentUpdate={onEquipmentUpdate}
         />

--- a/frontend/src/components/features/calculator/MagicForm.tsx
+++ b/frontend/src/components/features/calculator/MagicForm.tsx
@@ -79,7 +79,7 @@ export function MagicForm() {
       god_spell_charged: false
     },
     gearLockedFields: ['magic_attack_bonus', 'magic_damage_bonus'],
-    bossLockedFields: ['target_magic_level', 'target_magic_defence'],
+    npcLockedFields: ['target_magic_level', 'target_magic_defence'],
   });
 
   // Cast params to magic params for type safety
@@ -491,7 +491,7 @@ export function MagicForm() {
                       className={isFieldDisabled('target_magic_level') ? "opacity-50" : ""}
                     />
                   </FormControl>
-                  {isFieldDisabled('target_magic_level') && <FormDescription className="text-amber-500">Using target stats from boss</FormDescription>}
+                  {isFieldDisabled('target_magic_level') && <FormDescription className="text-amber-500">Using target stats from npc</FormDescription>}
                 </FormItem>
               )}
             />
@@ -519,7 +519,7 @@ export function MagicForm() {
                       className={isFieldDisabled('target_magic_defence') ? "opacity-50" : ""}
                     />
                   </FormControl>
-                  {isFieldDisabled('target_magic_defence') && <FormDescription className="text-amber-500">Using target stats from boss</FormDescription>}
+                  {isFieldDisabled('target_magic_defence') && <FormDescription className="text-amber-500">Using target stats from npc</FormDescription>}
                 </FormItem>
               )}
             />

--- a/frontend/src/components/features/calculator/MeleeForm.tsx
+++ b/frontend/src/components/features/calculator/MeleeForm.tsx
@@ -69,7 +69,7 @@ export function MeleeForm() {
     formSchema: meleeFormSchema,
     defaultValues,
     gearLockedFields: ['melee_strength_bonus', 'melee_attack_bonus'],
-    bossLockedFields: ['target_defence_level', 'target_defence_bonus'],
+    npcLockedFields: ['target_defence_level', 'target_defence_bonus'],
   });
 
   const meleeParams = params as MeleeCalculatorParams;
@@ -250,7 +250,7 @@ export function MeleeForm() {
                       value={meleeParams.target_defence_level} // Ensure we display the actual store value
                     />
                   </FormControl>
-                  {isFieldDisabled('target_defence_level') && <FormDescription className="text-amber-500">Using target stats from boss</FormDescription>}
+                  {isFieldDisabled('target_defence_level') && <FormDescription className="text-amber-500">Using target stats from npc</FormDescription>}
                 </FormItem>
               )}
             />
@@ -279,7 +279,7 @@ export function MeleeForm() {
                       value={meleeParams.target_defence_bonus} // Ensure we display the actual store value
                     />
                   </FormControl>
-                  {isFieldDisabled('target_defence_bonus') && <FormDescription className="text-amber-500">Using target stats from boss</FormDescription>}
+                  {isFieldDisabled('target_defence_bonus') && <FormDescription className="text-amber-500">Using target stats from npc</FormDescription>}
                 </FormItem>
               )}
             />

--- a/frontend/src/components/features/calculator/NpcSelector.tsx
+++ b/frontend/src/components/features/calculator/NpcSelector.tsx
@@ -30,29 +30,29 @@ import {
 } from '@/components/ui/select';
 import { useToast } from '@/hooks/use-toast';
 import { useDebounce } from '@/hooks/useDebounce';
-import { bossesApi } from '@/services/api';
-import { BossSummary, BossForm, MeleeCalculatorParams, RangedCalculatorParams, MagicCalculatorParams } from '@/types/calculator';
+import { npcsApi } from '@/services/api';
+import { NpcSummary, NpcForm, MeleeCalculatorParams, RangedCalculatorParams, MagicCalculatorParams } from '@/types/calculator';
 import { useCalculatorStore } from '@/store/calculator-store';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { useReferenceDataStore } from '@/store/reference-data-store';
 
-interface BossSelectorProps {
-  onSelectBoss?: (boss: BossSummary) => void;
-  onSelectForm?: (form: BossForm | null) => void;
+interface NpcSelectorProps {
+  onSelectNpc?: (npc: NpcSummary) => void;
+  onSelectForm?: (form: NpcForm | null) => void;
 }
 
-export function BossSelector({ onSelectBoss, onSelectForm }: BossSelectorProps) {
+export function NpcSelector({ onSelectNpc, onSelectForm }: NpcSelectorProps) {
   const [open, setOpen] = useState(false);
-  const selectedBoss = useCalculatorStore((s) => s.selectedBoss);
-  const setSelectedBoss = useCalculatorStore((s) => s.setSelectedBoss);
-  const selectedForm = useCalculatorStore((s) => s.selectedBossForm);
-  const setSelectedForm = useCalculatorStore((s) => s.setSelectedBossForm);
-  const storeBosses = useReferenceDataStore((s) => s.bosses);
-  const storeBossForms = useReferenceDataStore((s) => s.bossForms);
+  const selectedNpc = useCalculatorStore((s) => s.selectedNpc);
+  const setSelectedNpc = useCalculatorStore((s) => s.setSelectedNpc);
+  const selectedForm = useCalculatorStore((s) => s.selectedNpcForm);
+  const setSelectedForm = useCalculatorStore((s) => s.setSelectedNpcForm);
+  const storeNpcs = useReferenceDataStore((s) => s.npcs);
+  const storeNpcForms = useReferenceDataStore((s) => s.npcForms);
   const initData = useReferenceDataStore((s) => s.initData);
-  const addBosses = useReferenceDataStore((s) => s.addBosses);
-  const addBossForms = useReferenceDataStore((s) => s.addBossForms);
-  const { params, setParams, lockBoss, unlockBoss, bossLocked } = useCalculatorStore();
+  const addNpces = useReferenceDataStore((s) => s.addNpces);
+  const addNpcForms = useReferenceDataStore((s) => s.addNpcForms);
+  const { params, setParams, lockNpc, unlockNpc, npcLocked } = useCalculatorStore();
   const { toast } = useToast();
 
   useEffect(() => {
@@ -62,32 +62,32 @@ export function BossSelector({ onSelectBoss, onSelectForm }: BossSelectorProps) 
   const [searchTerm, setSearchTerm] = useState('');
   const debouncedSearch = useDebounce(searchTerm, 300);
 
-  const initialLoading = storeBosses.length === 0 && searchTerm.length === 0;
+  const initialLoading = storeNpcs.length === 0 && searchTerm.length === 0;
 
   const {
     data: searchResults,
     isLoading,
   } = useQuery({
-    queryKey: ['boss-search', debouncedSearch],
-    queryFn: () => bossesApi.searchBosses(debouncedSearch),
+    queryKey: ['npc-search', debouncedSearch],
+    queryFn: () => npcsApi.searchNpces(debouncedSearch),
     enabled: debouncedSearch.length > 0,
     staleTime: Infinity,
-    onSuccess: (d) => addBosses(d),
-    onError: (e: any) => toast.error(`Boss search failed: ${e.message}`),
+    onSuccess: (d) => addNpces(d),
+    onError: (e: any) => toast.error(`Npc search failed: ${e.message}`),
   });
 
-  // Fetch specific boss details when a boss is selected
-  const { data: bossDetails, isLoading: isLoadingDetails } = useQuery({
-    queryKey: ['boss', selectedBoss?.id],
-    queryFn: () => selectedBoss ? bossesApi.getBossById(selectedBoss.id) : null,
-    enabled: !!selectedBoss && !storeBossForms[selectedBoss!.id],
+  // Fetch specific npc details when a npc is selected
+  const { data: npcDetails, isLoading: isLoadingDetails } = useQuery({
+    queryKey: ['npc', selectedNpc?.id],
+    queryFn: () => selectedNpc ? npcsApi.getNpcById(selectedNpc.id) : null,
+    enabled: !!selectedNpc && !storeNpcForms[selectedNpc!.id],
     staleTime: Infinity,
-    onSuccess: (d) => addBossForms(d.id, d.forms || []),
-    onError: (e: any) => toast.error(`Failed to load boss: ${e.message}`),
+    onSuccess: (d) => addNpcForms(d.id, d.forms || []),
+    onError: (e: any) => toast.error(`Failed to load npc: ${e.message}`),
   });
 
-  const combinedBossDetails = selectedBoss
-    ? { ...selectedBoss, forms: storeBossForms[selectedBoss.id] ?? bossDetails?.forms }
+  const combinedNpcDetails = selectedNpc
+    ? { ...selectedNpc, forms: storeNpcForms[selectedNpc.id] ?? npcDetails?.forms }
     : null;
 
   const rangedWeakness = selectedForm &&
@@ -104,26 +104,26 @@ export function BossSelector({ onSelectBoss, onSelectForm }: BossSelectorProps) 
   // Effect to clean up when combat style changes or component unmounts
   useEffect(() => {
     return () => {
-      // Ensure we're not leaving stale boss locked state on unmount
+      // Ensure we're not leaving stale npc locked state on unmount
       if (!selectedForm) {
-        unlockBoss();
+        unlockNpc();
       }
     };
-  }, [unlockBoss, selectedForm]);
+  }, [unlockNpc, selectedForm]);
 
-  // Handle boss selection
-  const handleSelectBoss = (boss: BossSummary) => {
-    setSelectedBoss(boss);
+  // Handle npc selection
+  const handleSelectNpc = (npc: NpcSummary) => {
+    setSelectedNpc(npc);
     setSelectedForm(null);
     setOpen(false);
 
-    if (onSelectBoss) {
-      onSelectBoss(boss);
+    if (onSelectNpc) {
+      onSelectNpc(npc);
     }
   };
 
   // Handle form selection and update calculator params
-  const handleSelectForm = (form: BossForm) => {
+  const handleSelectForm = (form: NpcForm) => {
     setSelectedForm(form);
 
     // Log the values before update
@@ -155,7 +155,7 @@ export function BossSelector({ onSelectBoss, onSelectForm }: BossSelectorProps) 
       }
     }
 
-    // Update the calculator params with the selected boss's defense stats
+    // Update the calculator params with the selected npc's defense stats
     const combatStyle = params.combat_style;
     
     if (combatStyle === 'melee') {
@@ -201,7 +201,7 @@ export function BossSelector({ onSelectBoss, onSelectForm }: BossSelectorProps) 
         if (currentParams.combat_style === 'melee') {
           const meleeParams = currentParams as MeleeCalculatorParams;
           if (process.env.NODE_ENV !== 'production') {
-            console.log('[DEBUG] Verified melee boss stats after update:', {
+            console.log('[DEBUG] Verified melee npc stats after update:', {
               target_defence_level: meleeParams.target_defence_level,
               target_defence_bonus: meleeParams.target_defence_bonus,
               target_defence_type: meleeParams.target_defence_type
@@ -232,7 +232,7 @@ export function BossSelector({ onSelectBoss, onSelectForm }: BossSelectorProps) 
         if (currentParams.combat_style === 'ranged') {
           const rangedParams = currentParams as RangedCalculatorParams;
           if (process.env.NODE_ENV !== 'production') {
-            console.log('[DEBUG] Verified ranged boss stats after update:', {
+            console.log('[DEBUG] Verified ranged npc stats after update:', {
               target_defence_level: rangedParams.target_defence_level,
               target_defence_bonus: rangedParams.target_defence_bonus,
               target_defence_type: rangedParams.target_defence_type
@@ -265,7 +265,7 @@ export function BossSelector({ onSelectBoss, onSelectForm }: BossSelectorProps) 
         if (currentParams.combat_style === 'magic') {
           const magicParams = currentParams as MagicCalculatorParams;
           if (process.env.NODE_ENV !== 'production') {
-            console.log('[DEBUG] Verified magic boss stats after update:', {
+            console.log('[DEBUG] Verified magic npc stats after update:', {
               target_magic_level: magicParams.target_magic_level,
               target_magic_defence: magicParams.target_magic_defence,
               target_defence_type: magicParams.target_defence_type
@@ -275,20 +275,20 @@ export function BossSelector({ onSelectBoss, onSelectForm }: BossSelectorProps) 
       }, 0);
     }
 
-    // Lock boss inputs
-    lockBoss();
+    // Lock npc inputs
+    lockNpc();
     
     // Show success notification
-    toast.success(`Target stats updated: ${form.form_name || form.boss_id}`);
+    toast.success(`Target stats updated: ${form.form_name || form.npc_id}`);
 
     if (onSelectForm) {
       onSelectForm(form);
     }
   };
 
-  // Reset boss selection
-  const handleResetBoss = () => {
-    setSelectedBoss(null);
+  // Reset npc selection
+  const handleResetNpc = () => {
+    setSelectedNpc(null);
     setSelectedForm(null);
     
     // Reset the defense parameters to default values based on combat style
@@ -314,7 +314,7 @@ export function BossSelector({ onSelectBoss, onSelectForm }: BossSelectorProps) 
       });
     }
     
-    unlockBoss();
+    unlockNpc();
     
     // Show toast notification
     toast.info("Target selection reset");
@@ -329,20 +329,20 @@ export function BossSelector({ onSelectBoss, onSelectForm }: BossSelectorProps) 
     <Card>
       <CardHeader>
         <CardTitle>Target Selection</CardTitle>
-        <CardDescription>Select a boss to calculate DPS against</CardDescription>
+        <CardDescription>Select a npc to calculate DPS against</CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
-        {bossLocked && (
+        {npcLocked && (
           <Alert className="mb-4 border-blue-200 dark:border-blue-800 bg-blue-100 dark:bg-blue-900">
             <AlertDescription>
-              Target stats from boss are being used. Manual target stat inputs are disabled.
+              Target stats from npc are being used. Manual target stat inputs are disabled.
             </AlertDescription>
           </Alert>
         )}
         
-        {/* Boss selector */}
+        {/* Npc selector */}
         <div className="space-y-2">
-          <label className="text-sm font-medium">Select Boss</label>
+          <label className="text-sm font-medium">Select Npc</label>
           <Popover open={open} onOpenChange={setOpen}>
             <PopoverTrigger asChild>
               <Button
@@ -351,7 +351,7 @@ export function BossSelector({ onSelectBoss, onSelectForm }: BossSelectorProps) 
                 aria-expanded={open}
                 className="w-full justify-between"
               >
-                {selectedBoss ? selectedBoss.name : "Select a boss..."}
+                {selectedNpc ? selectedNpc.name : "Select a npc..."}
                 <Search className="ml-2 h-4 w-4 shrink-0 opacity-50" />
               </Button>
             </PopoverTrigger>
@@ -359,13 +359,13 @@ export function BossSelector({ onSelectBoss, onSelectForm }: BossSelectorProps) 
               <Command>
                 <div className="flex h-9 items-center gap-2 border-b px-3">
                   <CommandPrimitive.Input
-                    placeholder="Search bosses..."
+                    placeholder="Search npcs..."
                     value={searchTerm}
                     onValueChange={setSearchTerm}
                     className="placeholder:text-muted-foreground flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50"
                   />
                 </div>
-                <CommandEmpty>No boss found.</CommandEmpty>
+                <CommandEmpty>No npc found.</CommandEmpty>
                 <CommandGroup>
                   <CommandList>
                     {isLoading && searchTerm ? (
@@ -374,16 +374,16 @@ export function BossSelector({ onSelectBoss, onSelectForm }: BossSelectorProps) 
                         Loading...
                       </div>
                     ) : (
-                      (searchTerm.length > 0 ? searchResults ?? [] : storeBosses).map((boss) => (
+                      (searchTerm.length > 0 ? searchResults ?? [] : storeNpcs).map((npc) => (
                         <CommandItem
-                          key={boss.id}
-                          value={boss.name}
-                          onSelect={() => handleSelectBoss(boss)}
+                          key={npc.id}
+                          value={npc.name}
+                          onSelect={() => handleSelectNpc(npc)}
                         >
-                          {boss.name}
-                          {boss.raid_group && (
+                          {npc.name}
+                          {npc.raid_group && (
                             <Badge variant="outline" className="ml-2">
-                              {boss.raid_group}
+                              {npc.raid_group}
                             </Badge>
                           )}
                         </CommandItem>
@@ -402,19 +402,19 @@ export function BossSelector({ onSelectBoss, onSelectForm }: BossSelectorProps) 
         </div>
 
         {/* Form selector */}
-        {selectedBoss && (
+        {selectedNpc && (
           <div className="space-y-2">
             <label className="text-sm font-medium">Select Form/Phase</label>
             {isLoadingDetails ? (
               <div className="flex items-center text-sm text-muted-foreground">
                 <LogoSpinner className="mr-2 h-4 w-4" />
-                Loading boss details...
+                Loading npc details...
               </div>
             ) : (<div className="flex items-center gap-2">
                 <Select
                   value={selectedForm?.id.toString() || ''}
                   onValueChange={(value: string) => {
-                      const form = combinedBossDetails?.forms?.find(f => f.id.toString() === value);
+                      const form = combinedNpcDetails?.forms?.find(f => f.id.toString() === value);
                       if (form) {
                           handleSelectForm(form);
                       }
@@ -424,14 +424,14 @@ export function BossSelector({ onSelectBoss, onSelectForm }: BossSelectorProps) 
                   <SelectValue placeholder="Select a form/phase" />
                 </SelectTrigger>
                 <SelectContent>
-                  {(combinedBossDetails?.forms ?? []).map((form) => (
+                  {(combinedNpcDetails?.forms ?? []).map((form) => (
                     <SelectItem key={form.id} value={form.id.toString()}>
                       {form.form_name} (Combat Lvl: {form.combat_level || 'Unknown'})
                     </SelectItem>
                   ))}
                 </SelectContent>
               </Select>
-                <Button variant="outline" size="sm" onClick={handleResetBoss}>
+                <Button variant="outline" size="sm" onClick={handleResetNpc}>
                   <RotateCcw className="h-4 w-4 mr-2" />
                   Reset
                 </Button>
@@ -440,7 +440,7 @@ export function BossSelector({ onSelectBoss, onSelectForm }: BossSelectorProps) 
           </div>
         )}
 
-        {/* Display the selected boss stats if a form is selected */}
+        {/* Display the selected npc stats if a form is selected */}
         {selectedForm && (
           <div className="pt-2 space-y-2 flex flex-col items-center">
             {(selectedForm.icons?.[0] || selectedForm.image_url) && (

--- a/frontend/src/components/features/calculator/PassiveEffectCalculator.tsx
+++ b/frontend/src/components/features/calculator/PassiveEffectCalculator.tsx
@@ -1,4 +1,4 @@
-import { CalculatorParams, Item, BossForm } from '@/types/calculator';
+import { CalculatorParams, Item, NpcForm } from '@/types/calculator';
 import {
   isTargetDraconic,
   isTargetDemonic,
@@ -40,7 +40,7 @@ const effects: Array<{ name: string; description: string }> = [];
 export function calculatePassiveEffectBonuses(
   params: CalculatorParams,
   equipment: Record<string, Item | null>,
-  target?: BossForm | null
+  target?: NpcForm | null
 ): PassiveEffectBonus {
   // Default bonus (no change)
   const bonus: PassiveEffectBonus = {

--- a/frontend/src/components/features/calculator/PassiveEffectsDisplay.tsx
+++ b/frontend/src/components/features/calculator/PassiveEffectsDisplay.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { Card, CardContent } from '@/components/ui/card';
 import { useCalculatorStore } from '@/store/calculator-store';
-import { Item, BossForm } from '@/types/calculator';
+import { Item, NpcForm } from '@/types/calculator';
 import { safeFixed } from '@/utils/format';
 import calculatePassiveEffectBonuses from './PassiveEffectCalculator';
 import { Badge } from '@/components/ui/badge';
@@ -29,7 +29,7 @@ import {
 
 interface PassiveEffectsDisplayProps {
   loadout: Record<string, Item | null>;
-  target?: BossForm | null;
+  target?: NpcForm | null;
 }
 
 export function PassiveEffectsDisplay({ loadout, target }: PassiveEffectsDisplayProps) {

--- a/frontend/src/components/features/calculator/RangedForm.tsx
+++ b/frontend/src/components/features/calculator/RangedForm.tsx
@@ -64,7 +64,7 @@ export function RangedForm() {
     formSchema: rangedFormSchema,
     defaultValues,
     gearLockedFields: ['ranged_strength_bonus', 'ranged_attack_bonus'],
-    bossLockedFields: ['target_defence_level', 'target_defence_bonus'],
+    npcLockedFields: ['target_defence_level', 'target_defence_bonus'],
   });
 
   const rangedParams = params as RangedCalculatorParams;
@@ -316,7 +316,7 @@ export function RangedForm() {
                       value={rangedParams.target_defence_level} // Ensure we display the actual store value
                     />
                   </FormControl>
-                  {isFieldDisabled('target_defence_level') && <FormDescription className="text-amber-500">Using target stats from boss</FormDescription>}
+                  {isFieldDisabled('target_defence_level') && <FormDescription className="text-amber-500">Using target stats from npc</FormDescription>}
                 </FormItem>
               )}
             />
@@ -345,7 +345,7 @@ export function RangedForm() {
                       value={rangedParams.target_defence_bonus} // Ensure we display the actual store value
                     />
                   </FormControl>
-                  {isFieldDisabled('target_defence_bonus') && <FormDescription className="text-amber-500">Using target stats from boss</FormDescription>}
+                  {isFieldDisabled('target_defence_bonus') && <FormDescription className="text-amber-500">Using target stats from npc</FormDescription>}
                 </FormItem>
               )}
             />

--- a/frontend/src/components/features/calculator/improved/MiddleColumns.tsx
+++ b/frontend/src/components/features/calculator/improved/MiddleColumns.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { Card, CardContent } from '@/components/ui/card';
-import { BossSelector } from '../BossSelector';
+import { NpcSelector } from '../NpcSelector';
 import { EquipmentPanel } from '../EquipmentPanel';
 import { PrayerPotionSelector } from '../PrayerPotionSelector';
 import RaidScalingPanel, { RaidScalingConfig } from '../../simulation/RaidScalingPanel';
@@ -10,7 +10,7 @@ import { Raid } from '@/types/raid';
 interface MiddleColumnsProps {
   onEquipmentUpdate: (slot: string, item: any) => void;
   onSelectForm: (form: any) => void;
-  currentBossForm: any;
+  currentNpcForm: any;
   selectedRaid?: Raid;
   raidConfig: RaidScalingConfig;
   onRaidConfigChange: (config: RaidScalingConfig) => void;
@@ -19,7 +19,7 @@ interface MiddleColumnsProps {
 export function MiddleColumns({
   onEquipmentUpdate,
   onSelectForm,
-  currentBossForm,
+  currentNpcForm,
   selectedRaid,
   raidConfig,
   onRaidConfigChange,
@@ -29,12 +29,12 @@ export function MiddleColumns({
       <div className="space-y-6 flex flex-col">
         <EquipmentPanel
           onEquipmentUpdate={onEquipmentUpdate}
-          bossForm={currentBossForm}
+          npcForm={currentNpcForm}
         />
       </div>
       <div className="space-y-6 flex flex-col flex-grow">
         <PrayerPotionSelector />
-        <BossSelector onSelectForm={onSelectForm} />
+        <NpcSelector onSelectForm={onSelectForm} />
         {selectedRaid && (
           <RaidScalingPanel raid={selectedRaid} config={raidConfig} onChange={onRaidConfigChange} />
         )}

--- a/frontend/src/hooks/useCombatForm.ts
+++ b/frontend/src/hooks/useCombatForm.ts
@@ -38,8 +38,8 @@ export interface UseCombatFormOptions<T extends FieldValues> {
   // Mapping of equipment fields to check gearLocked status
   gearLockedFields: string[];
   
-  // Mapping of target fields to check bossLocked status
-  bossLockedFields: string[];
+  // Mapping of target fields to check npcLocked status
+  npcLockedFields: string[];
 }
 
 export interface UseCombatFormResult<T extends FieldValues> {
@@ -54,7 +54,7 @@ export interface UseCombatFormResult<T extends FieldValues> {
   params: CalculatorParams;
   setParams: (params: Partial<CalculatorParams>) => void;
   gearLocked: boolean;
-  bossLocked: boolean;
+  npcLocked: boolean;
 }
 
 /**
@@ -65,9 +65,9 @@ export function useCombatForm<T extends FieldValues>({
   formSchema,
   defaultValues,
   gearLockedFields,
-  bossLockedFields
+  npcLockedFields
 }: UseCombatFormOptions<T>): UseCombatFormResult<T> {
-  const { params, setParams, gearLocked, bossLocked } = useCalculatorStore();
+  const { params, setParams, gearLocked, npcLocked } = useCalculatorStore();
   
   // Initialize form with validation
   const form = useForm<T>({
@@ -98,9 +98,9 @@ type ParamsRecord = Record<string, unknown>;
 
     for (const key of Object.keys(storeValues)) {
       const isGearLockedField = gearLocked && gearLockedFields.includes(key);
-      const isBossLockedField = bossLocked && bossLockedFields.includes(key);
+      const isNpcLockedField = npcLocked && npcLockedFields.includes(key);
 
-      if (!isGearLockedField && !isBossLockedField) {
+      if (!isGearLockedField && !isNpcLockedField) {
         merged[key] = storeValues[key];
       }
     }
@@ -127,9 +127,9 @@ type ParamsRecord = Record<string, unknown>;
       });
     }
     
-    // Don't update target stats if boss is locked
-    if (bossLocked) {
-      bossLockedFields.forEach(field => {
+    // Don't update target stats if npc is locked
+    if (npcLocked) {
+      npcLockedFields.forEach(field => {
         delete updatedValuesRecord[field];
       });
     }
@@ -142,7 +142,7 @@ type ParamsRecord = Record<string, unknown>;
       // Set parameters in the store - use type assertion for safety
       setParams(updatedValues as unknown as Partial<CalculatorParams>);
     }
-  }, [setParams, gearLocked, bossLocked, gearLockedFields, bossLockedFields, combatStyle]);
+  }, [setParams, gearLocked, npcLocked, gearLockedFields, npcLockedFields, combatStyle]);
   
   // Helper to check if field should be disabled
   const isFieldDisabled = useCallback((fieldName: string) => {
@@ -151,13 +151,13 @@ type ParamsRecord = Record<string, unknown>;
       return true;
     }
     
-    // Target stat fields should be disabled when boss is locked
-    if (bossLocked && bossLockedFields.includes(fieldName)) {
+    // Target stat fields should be disabled when npc is locked
+    if (npcLocked && npcLockedFields.includes(fieldName)) {
       return true;
     }
     
     return false;
-  }, [gearLocked, bossLocked, gearLockedFields, bossLockedFields]);
+  }, [gearLocked, npcLocked, gearLockedFields, npcLockedFields]);
   
   return {
     form,
@@ -166,6 +166,6 @@ type ParamsRecord = Record<string, unknown>;
     params,
     setParams,
     gearLocked,
-    bossLocked
+    npcLocked
   };
 }

--- a/frontend/src/hooks/useDpsCalculator.ts
+++ b/frontend/src/hooks/useDpsCalculator.ts
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { useMutation } from '@tanstack/react-query';
 import { calculatorApi } from '@/services/api';
 import { useCalculatorStore } from '@/store/calculator-store';
-import { CalculatorParams, Item, BossForm, CombatStyle } from '@/types/calculator';
+import { CalculatorParams, Item, NpcForm, CombatStyle } from '@/types/calculator';
 import calculatePassiveEffectBonuses from '@/components/features/calculator/PassiveEffectCalculator';
 import { useToast } from './use-toast';
 import { safeFixed } from '@/utils/format';
@@ -20,14 +20,14 @@ export function useDpsCalculator() {
 
   const [activeTab, setActiveTab] = useState<CombatStyle>(params.combat_style);
   const [currentLoadout, setCurrentLoadout] = useState<Record<string, Item | null>>(storeLoadout);
-  const storeBossForm = useCalculatorStore((s) => s.selectedBossForm);
-  const setStoreBossForm = useCalculatorStore((s) => s.setSelectedBossForm);
-  const [currentBossForm, setCurrentBossForm] = useState<BossForm | null>(storeBossForm);
+  const storeNpcForm = useCalculatorStore((s) => s.selectedNpcForm);
+  const setStoreNpcForm = useCalculatorStore((s) => s.setSelectedNpcForm);
+  const [currentNpcForm, setCurrentNpcForm] = useState<NpcForm | null>(storeNpcForm);
   const [appliedPassiveEffects, setAppliedPassiveEffects] = useState<any>(null);
 
   useEffect(() => {
-    setCurrentBossForm(storeBossForm);
-  }, [storeBossForm]);
+    setCurrentNpcForm(storeNpcForm);
+  }, [storeNpcForm]);
 
   useEffect(() => {
     setCurrentLoadout(storeLoadout);
@@ -39,8 +39,8 @@ export function useDpsCalculator() {
   }, [params.combat_style]);
 
   const calculateEffects = useCallback(() => {
-    return calculatePassiveEffectBonuses(params, currentLoadout, currentBossForm);
-  }, [params, currentLoadout, currentBossForm]);
+    return calculatePassiveEffectBonuses(params, currentLoadout, currentNpcForm);
+  }, [params, currentLoadout, currentNpcForm]);
 
   useEffect(() => {
     const effects = calculateEffects();
@@ -137,8 +137,8 @@ export function useDpsCalculator() {
           currentLoadout['mainhand']!.name.toLowerCase().includes('twisted bow'));
       if (!specItem && twistedBowEquipped && params.combat_style === 'ranged') {
         (clean as any).weapon_name = 'twisted bow';
-        if (currentBossForm?.magic_level) {
-          (clean as any).target_magic_level = currentBossForm.magic_level;
+        if (currentNpcForm?.magic_level) {
+          (clean as any).target_magic_level = currentNpcForm.magic_level;
         }
         (clean as any).ranged_attack_bonus = (params as any).ranged_attack_bonus;
         (clean as any).ranged_strength_bonus = (params as any).ranged_strength_bonus;
@@ -157,7 +157,7 @@ export function useDpsCalculator() {
       }
     }
     calculateMutation.mutate(clean);
-  }, [params, currentLoadout, currentBossForm, calculateMutation, sanitizeParams]);
+  }, [params, currentLoadout, currentNpcForm, calculateMutation, sanitizeParams]);
 
   const handleReset = () => {
     resetParams();
@@ -166,7 +166,7 @@ export function useDpsCalculator() {
     setAppliedPassiveEffects(null);
     setCurrentLoadout({});
     setStoreLoadout({});
-    setCurrentBossForm(null);
+    setCurrentNpcForm(null);
     toast.success('Calculator reset to defaults');
   };
 
@@ -181,9 +181,9 @@ export function useDpsCalculator() {
     setStoreLoadout(loadout);
   };
 
-  const handleBossUpdate = (bossForm: BossForm | null) => {
-    setCurrentBossForm(bossForm);
-    setStoreBossForm(bossForm);
+  const handleNpcUpdate = (npcForm: NpcForm | null) => {
+    setCurrentNpcForm(npcForm);
+    setStoreNpcForm(npcForm);
   };
 
   return {
@@ -192,12 +192,12 @@ export function useDpsCalculator() {
     activeTab,
     appliedPassiveEffects,
     currentLoadout,
-    currentBossForm,
+    currentNpcForm,
     isCalculating: calculateMutation.isPending,
     handleCalculate,
     handleReset,
     handleTabChange,
     handleEquipmentUpdate,
-    handleBossUpdate,
+    handleNpcUpdate,
   };
 }

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -2,11 +2,11 @@ import axios from 'axios';
 import {
   CalculatorParams,
   DpsResult,
-  Boss,
-  BossSummary,
+  Npc,
+  NpcSummary,
   Item,
   ItemSummary,
-  BossForm,
+  NpcForm,
   SpecialAttack,
   PassiveEffect
 } from '@/types/calculator';
@@ -71,73 +71,73 @@ export const calculatorApi = {
   },
 };
 
-// Bosses API
-export const bossesApi = {
+// Npces API
+export const npcsApi = {
 
-  getAllBosses: async (
+  getAllNpces: async (
     params?: { page?: number; page_size?: number }
-  ): Promise<BossSummary[]> => {
+  ): Promise<NpcSummary[]> => {
     try {
-      const { data } = await apiClient.get('/bosses', { params });
+      const { data } = await apiClient.get('/npcs', { params });
       return data;
     } catch (err: any) {
       throw handleError(err);
     }
   },
 
-  getBossesWithForms: async (
+  getNpcesWithForms: async (
     params?: { page?: number; page_size?: number }
-  ): Promise<Boss[]> => {
+  ): Promise<Npc[]> => {
     try {
-      const { data } = await apiClient.get('/bosses/full', { params });
+      const { data } = await apiClient.get('/npcs/full', { params });
       return data;
     } catch (err: any) {
       throw handleError(err);
     }
   },
 
-  getBossById: async (id: number): Promise<Boss> => {
+  getNpcById: async (id: number): Promise<Npc> => {
     try {
-      const { data } = await apiClient.get(`/boss/${id}`);
+      const { data } = await apiClient.get(`/npc/${id}`);
       return data;
     } catch (err: any) {
       if (err.response?.status === 404) {
-        const { data } = await apiClient.get(`/boss/form/${id}`);
+        const { data } = await apiClient.get(`/npc/form/${id}`);
         return data;
       }
       throw handleError(err);
     }
   },
 
-  getBossByFormId: async (formId: number): Promise<Boss> => {
+  getNpcByFormId: async (formId: number): Promise<Npc> => {
     try {
-      const { data } = await apiClient.get(`/boss/form/${formId}`);
+      const { data } = await apiClient.get(`/npc/form/${formId}`);
       return data;
     } catch (err: any) {
       throw handleError(err);
     }
   },
 
-  getBossForms: async (bossId: number): Promise<BossForm[]> => {
+  getNpcForms: async (npcId: number): Promise<NpcForm[]> => {
     try {
-      const { data } = await apiClient.get(`/boss/${bossId}`);
+      const { data } = await apiClient.get(`/npc/${npcId}`);
       return data.forms || [];
     } catch (err: any) {
       if (err.response?.status === 404) {
-        const { data } = await apiClient.get(`/boss/form/${bossId}`);
+        const { data } = await apiClient.get(`/npc/form/${npcId}`);
         return data.forms || [];
       }
       throw handleError(err);
     }
   },
 
-  searchBosses: async (query: string, limit?: number): Promise<BossSummary[]> => {
+  searchNpces: async (query: string, limit?: number): Promise<NpcSummary[]> => {
     const params: Record<string, unknown> = { query };
     if (limit !== undefined) {
       params.limit = limit;
     }
     try {
-      const { data } = await apiClient.get('/search/bosses', { params });
+      const { data } = await apiClient.get('/search/npcs', { params });
       return data;
     } catch (err: any) {
       throw handleError(err);

--- a/frontend/src/store/calculator-store.ts
+++ b/frontend/src/store/calculator-store.ts
@@ -8,8 +8,8 @@ import {
   RangedCalculatorParams,
   MagicCalculatorParams,
   Item,
-  Boss,
-  BossForm,
+  Npc,
+  NpcForm,
   Preset,
 } from '@/types/calculator';
 
@@ -22,10 +22,10 @@ interface CalculatorState {
     results: DpsResult;
   }>;
   gearLocked: boolean;
-  bossLocked: boolean;
+  npcLocked: boolean;
   loadout: Record<string, Item | null>;
-  selectedBoss: Boss | null;
-  selectedBossForm: BossForm | null;
+  selectedNpc: Npc | null;
+  selectedNpcForm: NpcForm | null;
   presets: Preset[];
 
   setParams: (params: Partial<CalculatorParams>) => void;
@@ -37,12 +37,12 @@ interface CalculatorState {
   resetParams: () => void;
   lockGear: () => void;
   unlockGear: () => void;
-  lockBoss: () => void;
-  unlockBoss: () => void;
+  lockNpc: () => void;
+  unlockNpc: () => void;
   resetLocks: () => void;
   setLoadout: (loadout: Record<string, Item | null>) => void;
-  setSelectedBoss: (boss: Boss | null) => void;
-  setSelectedBossForm: (form: BossForm | null) => void;
+  setSelectedNpc: (npc: Npc | null) => void;
+  setSelectedNpcForm: (form: NpcForm | null) => void;
   setPresets: (presets: Preset[]) => void;
   addPreset: (preset: Preset) => void;
   removePreset: (id: string) => void;
@@ -154,10 +154,10 @@ export const useCalculatorStore = create<CalculatorState>()(
       results: null,
       comparisonResults: [],
       gearLocked: false,
-      bossLocked: false,
+      npcLocked: false,
       loadout: {},
-      selectedBoss: null,
-      selectedBossForm: null,
+      selectedNpc: null,
+      selectedNpcForm: null,
       presets: [],
 
       setParams: (newParams: Partial<CalculatorParams>) => set((state): Partial<CalculatorState> => {
@@ -194,22 +194,22 @@ export const useCalculatorStore = create<CalculatorState>()(
           case 'melee': return { 
             params: defaultMeleeParams,
             gearLocked: false,
-            bossLocked: false
+            npcLocked: false
           };
           case 'ranged': return { 
             params: defaultRangedParams,
             gearLocked: false,
-            bossLocked: false
+            npcLocked: false
           };
           case 'magic': return { 
             params: defaultMagicParams,
             gearLocked: false,
-            bossLocked: false
+            npcLocked: false
           };
           default: return { 
             params: defaultMeleeParams,
             gearLocked: false,
-            bossLocked: false
+            npcLocked: false
           };
         }
       }),
@@ -230,25 +230,25 @@ export const useCalculatorStore = create<CalculatorState>()(
         const style = state.params.combat_style;
         switch (style) {
           case 'melee':
-            return { params: defaultMeleeParams, gearLocked: false, bossLocked: false };
+            return { params: defaultMeleeParams, gearLocked: false, npcLocked: false };
           case 'ranged':
-            return { params: defaultRangedParams, gearLocked: false, bossLocked: false };
+            return { params: defaultRangedParams, gearLocked: false, npcLocked: false };
           case 'magic':
-            return { params: defaultMagicParams, gearLocked: false, bossLocked: false };
+            return { params: defaultMagicParams, gearLocked: false, npcLocked: false };
           default:
-            return { params: defaultMeleeParams, gearLocked: false, bossLocked: false };
+            return { params: defaultMeleeParams, gearLocked: false, npcLocked: false };
         }
       }),
 
 
       lockGear: () => set({ gearLocked: true }),
       unlockGear: () => set({ gearLocked: false }),
-      lockBoss: () => set({ bossLocked: true }),
-      unlockBoss: () => set({ bossLocked: false }),
-      resetLocks: () => set({ gearLocked: false, bossLocked: false }),
+      lockNpc: () => set({ npcLocked: true }),
+      unlockNpc: () => set({ npcLocked: false }),
+      resetLocks: () => set({ gearLocked: false, npcLocked: false }),
       setLoadout: (loadout) => set({ loadout }),
-      setSelectedBoss: (boss) => set({ selectedBoss: boss }),
-      setSelectedBossForm: (form) => set({ selectedBossForm: form }),
+      setSelectedNpc: (npc) => set({ selectedNpc: npc }),
+      setSelectedNpcForm: (form) => set({ selectedNpcForm: form }),
       setPresets: (presets) => set({ presets }),
       addPreset: (preset) =>
         set((state) => ({ presets: [...state.presets, preset] })),
@@ -268,10 +268,10 @@ export const useCalculatorStore = create<CalculatorState>()(
       partialize: (state) => ({
         params: state.params,
         gearLocked: state.gearLocked,
-        bossLocked: state.bossLocked,
+        npcLocked: state.npcLocked,
         loadout: state.loadout,
-        selectedBoss: state.selectedBoss,
-        selectedBossForm: state.selectedBossForm,
+        selectedNpc: state.selectedNpc,
+        selectedNpcForm: state.selectedNpcForm,
         presets: state.presets,
       })
     }

--- a/frontend/src/store/reference-data-store.ts
+++ b/frontend/src/store/reference-data-store.ts
@@ -4,22 +4,22 @@ import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 import { safeStorage } from '@/utils/safeStorage';
 import {
-  bossesApi,
+  npcsApi,
   itemsApi,
   specialAttacksApi,
   passiveEffectsApi,
 } from '@/services/api';
 import {
-  BossForm,
-  BossSummary,
+  NpcForm,
+  NpcSummary,
   ItemSummary,
   SpecialAttack,
   PassiveEffect,
 } from '@/types/calculator';
 
 interface ReferenceDataState {
-  bosses: BossSummary[];
-  bossForms: Record<number, BossForm[]>;
+  npcs: NpcSummary[];
+  npcForms: Record<number, NpcForm[]>;
   items: ItemSummary[];
   specialAttacks: Record<string, SpecialAttack>;
   passiveEffects: Record<string, PassiveEffect>;
@@ -31,8 +31,8 @@ interface ReferenceDataState {
   error: boolean;
   timestamp: number;
   initData: () => Promise<void>;
-  addBosses: (b: BossSummary[]) => void;
-  addBossForms: (id: number, forms: BossForm[]) => void;
+  addNpces: (b: NpcSummary[]) => void;
+  addNpcForms: (id: number, forms: NpcForm[]) => void;
   addItems: (i: ItemSummary[]) => void;
   setSpecialAttacks: (a: Record<string, SpecialAttack>) => void;
   setPassiveEffects: (e: Record<string, PassiveEffect>) => void;
@@ -43,8 +43,8 @@ const REFERENCE_TTL_MS = 12 * 60 * 60 * 1000; // 12 hours
 export const useReferenceDataStore = create<ReferenceDataState>()(
   persist(
     (set, get) => ({
-      bosses: [],
-      bossForms: {},
+      npcs: [],
+      npcForms: {},
       items: [],
       specialAttacks: {},
       passiveEffects: {},
@@ -58,13 +58,13 @@ export const useReferenceDataStore = create<ReferenceDataState>()(
         set({ loading: true, progress: 0, timestamp: Date.now(), error: false });
         const pageSize = 50;
         let page = 1;
-        const bosses: BossSummary[] = [];
+        const npcs: NpcSummary[] = [];
         let error = false;
         while (true) {
           try {
-            const data = await bossesApi.getAllBosses({ page, page_size: pageSize });
+            const data = await npcsApi.getAllNpces({ page, page_size: pageSize });
             if (!data.length) break;
-            bosses.push(...data);
+            npcs.push(...data);
             if (data.length < pageSize) break;
             page += 1;
           } catch {
@@ -107,7 +107,7 @@ export const useReferenceDataStore = create<ReferenceDataState>()(
         set({ progress: 0.75 });
 
         set({
-          bosses,
+          npcs,
           items,
           specialAttacks,
           passiveEffects,
@@ -117,11 +117,11 @@ export const useReferenceDataStore = create<ReferenceDataState>()(
           progress: 1,
         });
       },
-      addBosses(b) {
-        set((state) => ({ bosses: [...state.bosses, ...b] }));
+      addNpces(b) {
+        set((state) => ({ npcs: [...state.npcs, ...b] }));
       },
-      addBossForms(id, forms) {
-        set((state) => ({ bossForms: { ...state.bossForms, [id]: forms } }));
+      addNpcForms(id, forms) {
+        set((state) => ({ npcForms: { ...state.npcForms, [id]: forms } }));
       },
       addItems(i) {
         set((state) => ({ items: [...state.items, ...i] }));
@@ -137,8 +137,8 @@ export const useReferenceDataStore = create<ReferenceDataState>()(
       name: 'osrs-reference-data',
       storage: createJSONStorage(() => safeStorage),
       partialize: (state) => ({
-        bosses: state.bosses,
-        bossForms: state.bossForms,
+        npcs: state.npcs,
+        npcForms: state.npcForms,
         items: state.items,
         specialAttacks: state.specialAttacks,
         passiveEffects: state.passiveEffects,
@@ -148,11 +148,11 @@ export const useReferenceDataStore = create<ReferenceDataState>()(
         if (!stored) return;
         const expired = Date.now() - stored.timestamp > REFERENCE_TTL_MS;
         if (expired) {
-          state.setState({ bosses: [], bossForms: {}, items: [], specialAttacks: {}, passiveEffects: {}, initialized: false, loading: false, progress: 0, error: false, timestamp: Date.now() });
+          state.setState({ npcs: [], npcForms: {}, items: [], specialAttacks: {}, passiveEffects: {}, initialized: false, loading: false, progress: 0, error: false, timestamp: Date.now() });
         } else {
           state.setState({
-            bosses: stored.bosses || [],
-            bossForms: stored.bossForms || {},
+            npcs: stored.npcs || [],
+            npcForms: stored.npcForms || {},
             items: stored.items || [],
             specialAttacks: stored.specialAttacks || {},
             passiveEffects: stored.passiveEffects || {},

--- a/frontend/src/types/calculator.ts
+++ b/frontend/src/types/calculator.ts
@@ -186,7 +186,7 @@ export interface Preset {
   seed?: string;
 }
 
-export interface Boss {
+export interface Npc {
   id: number;
   name: string;
   raid_group?: string;
@@ -196,13 +196,13 @@ export interface Boss {
   hitpoints?: number;
   examine?: string;
   has_multiple_forms?: boolean;
-  forms?: BossForm[];
+  forms?: NpcForm[];
   weakness?: CombatStyle | null;
 }
 
-export interface BossForm {
+export interface NpcForm {
   id: number;
-  boss_id: number;
+  npc_id: number;
   form_name: string;
   form_order: number;
   combat_level?: number;
@@ -212,7 +212,7 @@ export interface BossForm {
   defence_level?: number;
   magic_level?: number;
   ranged_level?: number;
-  defence_stab?: number;   // <-- Ensure these exist in your boss form
+  defence_stab?: number;   // <-- Ensure these exist in your npc form
   defence_slash?: number;
   defence_crush?: number;
   defence_magic?: number;
@@ -228,7 +228,7 @@ export interface BossForm {
   size?: number;
 }
 
-export interface BossSummary {
+export interface NpcSummary {
   id: number;
   name: string;
   raid_group?: string;
@@ -308,7 +308,7 @@ export interface ComparisonResult {
   params: CalculatorParams;
   results: DpsResult;
   equipment?: EquipmentLoadout;
-  target?: BossForm;
+  target?: NpcForm;
 }
 
 export interface SearchParams {

--- a/frontend/src/utils/passiveEffectsUtils.ts
+++ b/frontend/src/utils/passiveEffectsUtils.ts
@@ -1,21 +1,21 @@
-import { Item, BossForm, CombatStyle } from '@/types/calculator';
+import { Item, NpcForm, CombatStyle } from '@/types/calculator';
 
-// Extended type for Boss weakness that includes monster types
-type BossWeaknessType = CombatStyle | 'dragon' | 'demon' | 'kalphite' | 'undead' | null | undefined;
+// Extended type for Npc weakness that includes monster types
+type NpcWeaknessType = CombatStyle | 'dragon' | 'demon' | 'kalphite' | 'undead' | null | undefined;
 
 /**
  * Utility functions for checking target types and equipment effects
  */
 
 // Target type checker functions
-export function isTargetDraconic(target?: BossForm | null): boolean {
+export function isNpcDraconic(target?: NpcForm | null): boolean {
   if (!target) return false;
   
-  // Check for specific boss ID (e.g., KBD)
-  if (target.boss_id === 50) return true;
+  // Check for specific npc ID (e.g., KBD)
+  if (target.npc_id === 50) return true;
   
   // Check for weakness property - with proper type checking
-  if (target.weakness && (target.weakness as BossWeaknessType) === "dragon") return true;
+  if (target.weakness && (target.weakness as NpcWeaknessType) === "dragon") return true;
   
   // Check name contains dragon-related terms
   if (target.form_name) {
@@ -29,11 +29,11 @@ export function isTargetDraconic(target?: BossForm | null): boolean {
   return false;
 }
 
-export function isTargetDemonic(target?: BossForm | null): boolean {
+export function isNpcDemonic(target?: NpcForm | null): boolean {
   if (!target) return false;
   
   // Check for weakness property - with proper type checking
-  if (target.weakness && (target.weakness as BossWeaknessType) === "demon") return true;
+  if (target.weakness && (target.weakness as NpcWeaknessType) === "demon") return true;
   
   // Check name contains demon-related terms
   if (target.form_name) {
@@ -47,11 +47,11 @@ export function isTargetDemonic(target?: BossForm | null): boolean {
   return false;
 }
 
-export function isTargetKalphite(target?: BossForm | null): boolean {
+export function isNpcKalphite(target?: NpcForm | null): boolean {
   if (!target) return false;
   
   // Check for weakness property - with proper type checking
-  if (target.weakness && (target.weakness as BossWeaknessType) === "kalphite") return true;
+  if (target.weakness && (target.weakness as NpcWeaknessType) === "kalphite") return true;
   
   // Check name contains kalphite-related terms
   if (target.form_name) {
@@ -64,7 +64,7 @@ export function isTargetKalphite(target?: BossForm | null): boolean {
   return false;
 }
 
-export function isTargetTurothKurask(target?: BossForm | null): boolean {
+export function isNpcTurothKurask(target?: NpcForm | null): boolean {
   if (!target) return false;
   
   // Check name contains turoth/kurask
@@ -76,10 +76,10 @@ export function isTargetTurothKurask(target?: BossForm | null): boolean {
   return false;
 }
 
-export function isInWilderness(target?: BossForm | null): boolean {
+export function isNpcInWilderness(target?: NpcForm | null): boolean {
   if (!target) return false;
   
-  // Check name contains wilderness boss names
+  // Check name contains wilderness npc names
   if (target.form_name) {
     const name = target.form_name.toLowerCase();
     return name.includes('revenant') || 
@@ -92,11 +92,11 @@ export function isInWilderness(target?: BossForm | null): boolean {
   return false;
 }
 
-export function isTargetUndead(target?: BossForm | null): boolean {
+export function isNpcUndead(target?: NpcForm | null): boolean {
   if (!target) return false;
   
   // Check for weakness property - with proper type checking
-  if (target.weakness && (target.weakness as BossWeaknessType) === "undead") return true;
+  if (target.weakness && (target.weakness as NpcWeaknessType) === "undead") return true;
   
   // Check name contains undead-related terms
   if (target.form_name) {


### PR DESCRIPTION
## Summary
- rename BossSelector to NpcSelector
- rename DirectBossSelector to DirectNpcSelector
- rename MultiBossSimulation to MultiNpcSimulation
- replace boss references with npc across frontend code and docs
- update README API docs

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68496ddae61c832ebc41eec9fe12e483