### PR TITLE
Improve logo transitions and layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ScapeLab DPS Calculator
 
+![ScapeLab Logo](frontend/public/images/logo_transparent_hd.png)
+
 A comprehensive damage-per-second calculator for Old School RuneScape with accurate combat formulas, equipment comparison, and boss statistics.
 
 

--- a/frontend/src/app/about/page.tsx
+++ b/frontend/src/app/about/page.tsx
@@ -26,7 +26,8 @@ export const metadata: Metadata = {
 export default function AboutPage() {
   return (
     <main id="main" className="container mx-auto py-8 px-4">
-      <h1 className="text-4xl font-bold mb-8 text-center">About ScapeLab</h1>
+      <h1 className="text-4xl font-bold mb-4 text-center">About ScapeLab</h1>
+      <img src="/images/logo_transparent_hd.png" alt="ScapeLab logo" className="h-32 mx-auto mb-8" />
 
       <div className="prose dark:prose-invert max-w-3xl mx-auto bg-muted/50 p-6 rounded-lg shadow">
         <p className="lead text-center">

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -379,25 +379,25 @@ select {
 /* Logo fading animation for loading overlay */
 @keyframes logo-cycle {
   0%,
-  20% {
+  33% {
     opacity: 1;
   }
-  33%,
+  66%,
   100% {
     opacity: 0;
   }
 }
 
 .logo-fade-off {
-  animation: logo-cycle 6s linear infinite;
+  animation: logo-cycle 4.5s linear infinite;
 }
 
 .logo-fade-mid {
-  animation: logo-cycle 6s linear infinite;
-  animation-delay: 2s;
+  animation: logo-cycle 4.5s linear infinite;
+  animation-delay: 1.5s;
 }
 
 .logo-fade-on {
-  animation: logo-cycle 6s linear infinite;
-  animation-delay: 4s;
+  animation: logo-cycle 4.5s linear infinite;
+  animation-delay: 3s;
 }

--- a/frontend/src/components/layout/Footer.tsx
+++ b/frontend/src/components/layout/Footer.tsx
@@ -5,14 +5,16 @@ export function Footer() {
     <footer className="border-t w-full py-6 bg-background mt-auto">
       <div className="container mx-auto px-4">
         <div className="flex flex-col md:flex-row justify-between items-center">
-          <div className="mb-4 md:mb-0 text-center md:text-left flex flex-col items-center md:items-start">
-            <img src="/images/logo_transparent_hd.png" alt="ScapeLab logo" className="h-8 w-8 mb-2" />
-            <p className="text-sm text-muted-foreground">
-              © {currentYear} ScapeLab. Not affiliated with Jagex Ltd.
-            </p>
-            <p className="text-xs text-muted-foreground mt-1">
-              Old School RuneScape and Jagex are trademarks of Jagex Ltd.
-            </p>
+          <div className="mb-4 md:mb-0 text-center md:text-left flex items-center space-x-2">
+            <img src="/images/logo_transparent_hd.png" alt="ScapeLab logo" className="h-8 w-8" />
+            <div className="flex flex-col items-center md:items-start">
+              <p className="text-sm text-muted-foreground">
+                © {currentYear} ScapeLab. Not affiliated with Jagex Ltd.
+              </p>
+              <p className="text-xs text-muted-foreground mt-1">
+                Old School RuneScape and Jagex are trademarks of Jagex Ltd.
+              </p>
+            </div>
           </div>
           
           <div className="text-sm text-muted-foreground text-center md:text-right">


### PR DESCRIPTION
## Summary
- cross-fade logo images more quickly
- keep the footer logo inline with copyright text
- show the ScapeLab logo on the About page
- add logo to README

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68496f7b9ac8832ea6a415d06d531757