### PR TITLE
Fix missing passive effect exports

### DIFF
--- a/frontend/src/utils/passiveEffectsUtils.ts
+++ b/frontend/src/utils/passiveEffectsUtils.ts
@@ -273,3 +273,10 @@ export function hasCrystalRangedWeapon(equipment: Record<string, Item | null>): 
           (equipment['2h'].name.toLowerCase().includes('crystal bow') || 
            equipment['2h'].name.toLowerCase().includes('bow of faerdhinen')));
 }
+// Aliases exported for calculator compatibility
+export const isTargetDraconic = isNpcDraconic;
+export const isTargetDemonic = isNpcDemonic;
+export const isTargetKalphite = isNpcKalphite;
+export const isTargetTurothKurask = isNpcTurothKurask;
+export const isInWilderness = isNpcInWilderness;
+export const isTargetUndead = isNpcUndead;


### PR DESCRIPTION
## Summary
- add exported aliases in `passiveEffectsUtils` matching calculator imports

## Testing
- `npm test --silent`
- `npm run build --silent`

------
https://chatgpt.com/codex/tasks/task_e_6849715b90f0832ebb72151986ccc550