### PR TITLE
Fix logo spinner animation and spacing

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -388,16 +388,17 @@ select {
   }
 }
 
-.logo-fade-off {
-  animation: logo-cycle 4.5s linear infinite;
+.logo-fade-off,
+.logo-fade-mid,
+.logo-fade-on {
+  opacity: 0;
+  animation: logo-cycle 4.5s linear infinite both;
 }
 
 .logo-fade-mid {
-  animation: logo-cycle 4.5s linear infinite;
   animation-delay: 1.5s;
 }
 
 .logo-fade-on {
-  animation: logo-cycle 4.5s linear infinite;
   animation-delay: 3s;
 }

--- a/frontend/src/components/layout/ReferenceDataOverlay.tsx
+++ b/frontend/src/components/layout/ReferenceDataOverlay.tsx
@@ -34,21 +34,23 @@ export function ReferenceDataOverlay() {
       <div className="text-center">
         <div className="relative w-48 h-48 mx-auto">
           <LogoProgressCircle progress={progress} />
-          <img
-            src="/images/logo_transparent_off.png"
-            alt="ScapeLab logo"
-            className="absolute inset-0 w-full h-full object-contain logo-fade-off"
-          />
-          <img
-            src="/images/logo_transparent_mid.png"
-            alt="ScapeLab logo"
-            className="absolute inset-0 w-full h-full object-contain logo-fade-mid"
-          />
-          <img
-            src="/images/logo_transparent_on.png"
-            alt="ScapeLab logo"
-            className="absolute inset-0 w-full h-full object-contain logo-fade-on"
-          />
+          <div className="absolute inset-0 p-12">
+            <img
+              src="/images/logo_transparent_off.png"
+              alt="ScapeLab logo"
+              className="absolute inset-0 w-full h-full object-contain logo-fade-off"
+            />
+            <img
+              src="/images/logo_transparent_mid.png"
+              alt="ScapeLab logo"
+              className="absolute inset-0 w-full h-full object-contain logo-fade-mid"
+            />
+            <img
+              src="/images/logo_transparent_on.png"
+              alt="ScapeLab logo"
+              className="absolute inset-0 w-full h-full object-contain logo-fade-on"
+            />
+          </div>
         </div>
         <p className="mt-4 text-lg">
           {error ? "Failed to load game data" : "Loading game data..."}


### PR DESCRIPTION
## Summary
- add padding around logo images so the progress ring has room
- ensure each logo fades in sequence by defaulting opacity to zero

## Testing
- `npm test --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_68497193db18832eb0c62e9607cc7503