### PR TITLE
Fix overlay progress and smooth logo transitions

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -379,10 +379,10 @@ select {
 /* Logo fading animation for loading overlay */
 @keyframes logo-cycle {
   0%,
-  33% {
+  20% {
     opacity: 1;
   }
-  66%,
+  40%,
   100% {
     opacity: 0;
   }
@@ -392,7 +392,7 @@ select {
 .logo-fade-mid,
 .logo-fade-on {
   opacity: 0;
-  animation: logo-cycle 4.5s linear infinite both;
+  animation: logo-cycle 4.5s cubic-bezier(0.4, 0, 0.2, 1) infinite both;
 }
 
 .logo-fade-mid {

--- a/frontend/src/components/layout/ReferenceDataOverlay.tsx
+++ b/frontend/src/components/layout/ReferenceDataOverlay.tsx
@@ -34,7 +34,7 @@ export function ReferenceDataOverlay() {
       <div className="text-center">
         <div className="relative w-48 h-48 mx-auto">
           <LogoProgressCircle progress={progress} />
-          <div className="absolute inset-0 p-12">
+          <div className="absolute inset-0 p-12 z-10">
             <img
               src="/images/logo_transparent_off.png"
               alt="ScapeLab logo"

--- a/frontend/src/components/ui/LogoProgressCircle.tsx
+++ b/frontend/src/components/ui/LogoProgressCircle.tsx
@@ -11,7 +11,7 @@ export function LogoProgressCircle({ progress }: { progress: number }) {
     <svg
       width={size}
       height={size}
-      className="absolute inset-0 text-primary"
+      className="absolute inset-0 text-primary z-0"
       style={{ transform: "rotate(-90deg)" }}
     >
       <circle


### PR DESCRIPTION
## Summary
- ensure progress circle sits behind the loading images
- add z-index on logos
- make fade animation smoother using a cubic-bezier curve

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68497653a788832ebcedd9e4c27e45f2