### PR TITLE
Add logo fade-in effect

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -378,8 +378,13 @@ select {
 }
 /* Logo fading animation for loading overlay */
 @keyframes logo-cycle {
-  0%,
-  20% {
+  0% {
+    opacity: 0;
+  }
+  10% {
+    opacity: 1;
+  }
+  30% {
     opacity: 1;
   }
   40%,


### PR DESCRIPTION
## Summary
- adjust logo spinner CSS to fade each image in before fading out

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68497a85bd00832ea46ddf8de3e6e24b