### PR TITLE
Fix special attack cost handling

### DIFF
--- a/backend/app/calculators/__init__.py
+++ b/backend/app/calculators/__init__.py
@@ -91,11 +91,11 @@ class DpsCalculator:
         if "special_accuracy_modifier" in params:
             params["special_accuracy_multiplier"] = params["special_accuracy_modifier"]
         cost = params.get("special_energy_cost")
-        if cost is None:
+        if cost is None or cost <= 0:
             cost = params.get("special_attack_cost")
 
-        # If no special attack cost provided, just return normal DPS
-        if cost is None:
+        # If no special attack cost provided or it is non-positive, just return normal DPS
+        if cost is None or cost <= 0:
             return calculator.calculate_dps(params)
 
         # Calculate regular and special attack damage per hit

--- a/backend/app/testing/UnitTest.py
+++ b/backend/app/testing/UnitTest.py
@@ -161,6 +161,33 @@ class TestDpsCalculator(unittest.TestCase):
 
         self.assertAlmostEqual(result["dps"], expected_dps, places=5)
 
+    def test_zero_special_energy_cost(self):
+        """Zero special energy cost should disable special attack simulation."""
+        params = {
+            "combat_style": "melee",
+            "strength_level": 99,
+            "strength_boost": 0,
+            "strength_prayer": 1.0,
+            "attack_level": 99,
+            "attack_boost": 0,
+            "attack_prayer": 1.0,
+            "melee_strength_bonus": 80,
+            "melee_attack_bonus": 80,
+            "attack_style_bonus_strength": 3,
+            "attack_style_bonus_attack": 0,
+            "attack_speed": 2.4,
+            "target_defence_level": 100,
+            "target_defence_bonus": 50,
+            "special_damage_multiplier": 1.2,
+            "special_accuracy_modifier": 1.0,
+            "special_energy_cost": 0,
+            "duration": 60,
+        }
+
+        result = DpsCalculator.calculate_dps(params)
+        self.assertNotIn("special_attack_dps", result)
+        self.assertNotIn("special_attacks", result)
+
 
 class TestMeleeCalculator(unittest.TestCase):
     """Test the Melee Calculator functionality."""

--- a/frontend/src/components/features/calculator/BestInSlotCalculator.tsx
+++ b/frontend/src/components/features/calculator/BestInSlotCalculator.tsx
@@ -74,7 +74,7 @@ export function BestInSlotCalculator() {
       delete cleaned.special_damage_multiplier;
     if (cleaned.special_accuracy_modifier === undefined)
       delete cleaned.special_accuracy_modifier;
-    if (cleaned.special_energy_cost === undefined) delete cleaned.special_energy_cost;
+    if (!cleaned.special_energy_cost) delete cleaned.special_energy_cost;
     if (cleaned.special_regen_rate === 10 / 30) delete cleaned.special_regen_rate;
     if (cleaned.initial_special_energy === 100) delete cleaned.initial_special_energy;
     return cleaned;

--- a/frontend/src/components/features/calculator/CombinedEquipmentDisplay.tsx
+++ b/frontend/src/components/features/calculator/CombinedEquipmentDisplay.tsx
@@ -106,7 +106,7 @@ export function CombinedEquipmentDisplay({
     if (cleaned.special_attack_speed === undefined) delete cleaned.special_attack_speed;
     if (cleaned.special_damage_multiplier === undefined) delete cleaned.special_damage_multiplier;
     if (cleaned.special_accuracy_modifier === undefined) delete cleaned.special_accuracy_modifier;
-    if (cleaned.special_energy_cost === undefined) delete cleaned.special_energy_cost;
+    if (!cleaned.special_energy_cost) delete cleaned.special_energy_cost;
     if (cleaned.special_regen_rate === 10 / 30) delete cleaned.special_regen_rate;
     if (cleaned.initial_special_energy === 100) delete cleaned.initial_special_energy;
     return cleaned;

--- a/frontend/src/components/features/simulation/MultiNpcSimulation.tsx
+++ b/frontend/src/components/features/simulation/MultiNpcSimulation.tsx
@@ -155,7 +155,7 @@ export function MultiNpcSimulation() {
       delete cleaned.special_damage_multiplier;
     if (cleaned.special_accuracy_modifier === undefined)
       delete cleaned.special_accuracy_modifier;
-    if (cleaned.special_energy_cost === undefined) delete cleaned.special_energy_cost;
+    if (!cleaned.special_energy_cost) delete cleaned.special_energy_cost;
     if (cleaned.special_regen_rate === 10 / 30) delete cleaned.special_regen_rate;
     if (cleaned.initial_special_energy === 100) delete cleaned.initial_special_energy;
     return cleaned;

--- a/frontend/src/hooks/useDpsCalculator.ts
+++ b/frontend/src/hooks/useDpsCalculator.ts
@@ -112,7 +112,7 @@ export function useDpsCalculator() {
       if (cleaned.special_accuracy_modifier === undefined) {
         delete cleaned.special_accuracy_modifier;
       }
-      if (cleaned.special_energy_cost === undefined) {
+      if (!cleaned.special_energy_cost) {
         delete cleaned.special_energy_cost;
       }
       if (cleaned.special_regen_rate === 10 / 30) {


### PR DESCRIPTION
## Summary
- ignore non-positive special energy cost when calculating DPS
- strip zero `special_energy_cost` in parameter sanitizers
- add a test case for zero special energy cost

## Testing
- `PYTHONPATH=backend python -m unittest backend/app/testing/UnitTest.py`
- `PYTHONPATH=backend python -m unittest backend/app/testing/test_api.py` *(fails: ODBC driver not found)*

------
https://chatgpt.com/codex/tasks/task_e_68497e0588cc832e8416f4cf8f5454da