### PR TITLE
Restore applied passive effects display

### DIFF
--- a/frontend/src/components/features/calculator/BestInSlotCalculator.tsx
+++ b/frontend/src/components/features/calculator/BestInSlotCalculator.tsx
@@ -10,6 +10,7 @@ import { PrayerPotionSelector } from './PrayerPotionSelector';
 import { CalculatorForms } from './CalculatorForms';
 import { CombatStyleTabs } from './CombatStyleTabs';
 import { DpsResultDisplay } from './DpsResultDisplay';
+import PassiveEffectsDisplay from './PassiveEffectsDisplay';
 import { useDpsCalculator } from '@/hooks/useDpsCalculator';
 import { calculatorApi } from '@/services/api';
 import { useToast } from '@/hooks/use-toast';
@@ -34,6 +35,7 @@ export function BestInSlotCalculator() {
     handleEquipmentUpdate,
     handleNpcUpdate,
     currentNpcForm,
+    currentLoadout,
   } = useDpsCalculator();
   const initData = useReferenceDataStore((s) => s.initData);
   const { toast } = useToast();
@@ -137,6 +139,11 @@ export function BestInSlotCalculator() {
           )}
         </CardContent>
       </Card>
+
+      {Object.keys(currentLoadout).length > 0 && (
+        <PassiveEffectsDisplay loadout={currentLoadout} target={currentNpcForm} />
+      )}
+
       {/* Two-column layout for middle sections */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* Left column */}

--- a/frontend/src/components/features/calculator/ImprovedDpsCalculator.tsx
+++ b/frontend/src/components/features/calculator/ImprovedDpsCalculator.tsx
@@ -5,6 +5,7 @@ import { useDpsCalculator } from '@/hooks/useDpsCalculator';
 import { Raid, RAID_NAME_TO_ID } from '@/types/raid';
 import { useCalculatorStore } from '@/store/calculator-store';
 import { Header } from './improved/Header';
+import PassiveEffectsDisplay from './PassiveEffectsDisplay';
 import { MiddleColumns } from './improved/MiddleColumns';
 import { RaidScalingConfig } from '../simulation/RaidScalingPanel';
 
@@ -55,6 +56,10 @@ export function ImprovedDpsCalculator() {
         results={results}
         appliedPassiveEffects={appliedPassiveEffects}
       />
+
+      {Object.keys(currentLoadout).length > 0 && (
+        <PassiveEffectsDisplay loadout={currentLoadout} target={currentNpcForm} />
+      )}
 
       <MiddleColumns
         onEquipmentUpdate={handleEquipmentUpdate}


### PR DESCRIPTION
## Summary
- show PassiveEffectsDisplay between the forms and equipment panel on DPS calc
- show PassiveEffectsDisplay in the BIS calculator

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684980d942bc832eb22f99484ba72c55