### PR TITLE
Sync presets between loadout tabs and page

### DIFF
--- a/frontend/src/components/features/calculator/LoadoutTabs.tsx
+++ b/frontend/src/components/features/calculator/LoadoutTabs.tsx
@@ -1,14 +1,20 @@
-'use client';
+"use client";
 
-import { useState } from 'react';
-import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
-import { Button } from '@/components/ui/button';
-import { CombinedEquipmentDisplay } from './CombinedEquipmentDisplay';
-import { useCalculatorStore } from '@/store/calculator-store';
-import { encodeSeed } from '@/utils/seed';
-import { NpcForm, Item } from '@/types/calculator';
+import { useState, useEffect } from "react";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import { Button } from "@/components/ui/button";
+import { CombinedEquipmentDisplay } from "./CombinedEquipmentDisplay";
+import { useCalculatorStore } from "@/store/calculator-store";
+import { encodeSeed } from "@/utils/seed";
+import { NpcForm, Item } from "@/types/calculator";
 
-export function LoadoutTabs({ npcForm, onEquipmentUpdate }: { npcForm?: NpcForm | null; onEquipmentUpdate?: (loadout: Record<string, Item | null>) => void }) {
+export function LoadoutTabs({
+  npcForm,
+  onEquipmentUpdate,
+}: {
+  npcForm?: NpcForm | null;
+  onEquipmentUpdate?: (loadout: Record<string, Item | null>) => void;
+}) {
   const presets = useCalculatorStore((s) => s.presets);
   const addPreset = useCalculatorStore((s) => s.addPreset);
   const setLoadout = useCalculatorStore((s) => s.setLoadout);
@@ -17,11 +23,20 @@ export function LoadoutTabs({ npcForm, onEquipmentUpdate }: { npcForm?: NpcForm 
   const params = useCalculatorStore((s) => s.params);
   const loadout = useCalculatorStore((s) => s.loadout);
 
-  const [activePreset, setActivePreset] = useState('current');
+  const [activePreset, setActivePreset] = useState("current");
+
+  useEffect(() => {
+    if (
+      activePreset !== "current" &&
+      !presets.find((p) => p.id === activePreset)
+    ) {
+      setActivePreset("current");
+    }
+  }, [presets, activePreset]);
 
   const handlePresetChange = (id: string) => {
     setActivePreset(id);
-    if (id === 'current') return;
+    if (id === "current") return;
     const preset = presets.find((p) => p.id === id);
     if (preset) {
       switchCombatStyle(preset.params.combat_style as any);
@@ -31,7 +46,7 @@ export function LoadoutTabs({ npcForm, onEquipmentUpdate }: { npcForm?: NpcForm 
   };
 
   const handleAddPreset = () => {
-    const name = prompt('Preset name?');
+    const name = prompt("Preset name?");
     if (!name) return;
     const newPreset = {
       id: Date.now().toString(),
@@ -53,14 +68,18 @@ export function LoadoutTabs({ npcForm, onEquipmentUpdate }: { npcForm?: NpcForm 
       className="w-full flex flex-col items-center"
     >
       <TabsList className="mb-4 flex gap-2 flex-wrap justify-center w-full text-center">
-        <TabsTrigger value="current" className="text-center">Current</TabsTrigger>
+        <TabsTrigger value="current" className="text-center">
+          Current
+        </TabsTrigger>
         {presets.slice(0, 6).map((p) => (
           <TabsTrigger key={p.id} value={p.id} className="text-center">
             {p.name}
           </TabsTrigger>
         ))}
         {presets.length < 6 && (
-          <Button variant="outline" size="sm" onClick={handleAddPreset}>+</Button>
+          <Button variant="outline" size="sm" onClick={handleAddPreset}>
+            +
+          </Button>
         )}
       </TabsList>
       <TabsContent value={activePreset} className="w-full">

--- a/frontend/src/components/features/calculator/PresetSelector.tsx
+++ b/frontend/src/components/features/calculator/PresetSelector.tsx
@@ -1,12 +1,18 @@
-'use client';
+"use client";
 
-import { useState, useEffect } from 'react';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { Save, Trash2, ClipboardCopy, ArrowUp, ArrowDown } from 'lucide-react';
-import { safeFixed } from '@/utils/format';
+import { useState, useEffect } from "react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Save, Trash2, ClipboardCopy, ArrowUp, ArrowDown } from "lucide-react";
+import { safeFixed } from "@/utils/format";
 import {
   Dialog,
   DialogContent,
@@ -21,13 +27,13 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { useCalculatorStore } from '@/store/calculator-store';
-import { CombatStyle, CalculatorParams, Item } from '@/types/calculator';
-import { Badge } from '@/components/ui/badge';
+import { useCalculatorStore } from "@/store/calculator-store";
+import { CombatStyle, CalculatorParams, Item } from "@/types/calculator";
+import { Badge } from "@/components/ui/badge";
 
-import { cn } from '@/lib/utils';
-import { encodeSeed, decodeSeed } from '@/utils/seedUtils';
-import { useToast } from '@/hooks/use-toast';
+import { cn } from "@/lib/utils";
+import { encodeSeed, decodeSeed } from "@/utils/seedUtils";
+import { useToast } from "@/hooks/use-toast";
 
 interface PresetSelectorProps {
   onPresetLoad?: () => void;
@@ -43,7 +49,10 @@ interface Preset {
   equipment: Record<string, Item | null>;
 }
 
-export function PresetSelector({ onPresetLoad, className }: PresetSelectorProps) {
+export function PresetSelector({
+  onPresetLoad,
+  className,
+}: PresetSelectorProps) {
   const {
     params,
     loadout,
@@ -54,25 +63,33 @@ export function PresetSelector({ onPresetLoad, className }: PresetSelectorProps)
     setPresets: setStorePresets,
     removePreset,
     reorderPresets,
+    presets: storePresets,
   } = useCalculatorStore();
   const { toast } = useToast();
   const [hasMounted, setHasMounted] = useState(false);
   const [saveDialogOpen, setSaveDialogOpen] = useState(false);
   const [seedDialogOpen, setSeedDialogOpen] = useState(false);
-  const [presetName, setPresetName] = useState('');
+  const [presetName, setPresetName] = useState("");
   const [presets, setPresets] = useState<Preset[]>([]);
-  const [generatedSeed, setGeneratedSeed] = useState('');
-  const [importSeedValue, setImportSeedValue] = useState('');
+  const [generatedSeed, setGeneratedSeed] = useState("");
+  const [importSeedValue, setImportSeedValue] = useState("");
 
   useEffect(() => {
     setHasMounted(true);
-    if (typeof window !== 'undefined') {
-      const savedPresets = localStorage.getItem('osrs-dps-presets');
+    if (typeof window !== "undefined") {
+      const savedPresets = localStorage.getItem("osrs-dps-presets");
       const loaded = savedPresets ? JSON.parse(savedPresets) : [];
       setPresets(loaded);
       setStorePresets(loaded);
     }
   }, []);
+
+  useEffect(() => {
+    setPresets(storePresets);
+    if (typeof window !== "undefined") {
+      localStorage.setItem("osrs-dps-presets", JSON.stringify(storePresets));
+    }
+  }, [storePresets]);
 
   useEffect(() => {
     if (seedDialogOpen) {
@@ -96,13 +113,12 @@ export function PresetSelector({ onPresetLoad, className }: PresetSelectorProps)
 
     const updatedPresets = [...presets, newPreset];
     setPresets(updatedPresets);
-    setStorePresets(updatedPresets);
     addPreset(newPreset);
-    if (typeof window !== 'undefined') {
-      localStorage.setItem('osrs-dps-presets', JSON.stringify(updatedPresets));
+    if (typeof window !== "undefined") {
+      localStorage.setItem("osrs-dps-presets", JSON.stringify(updatedPresets));
     }
     setSaveDialogOpen(false);
-    setPresetName('');
+    setPresetName("");
   };
 
   const loadPreset = (preset: Preset) => {
@@ -114,49 +130,48 @@ export function PresetSelector({ onPresetLoad, className }: PresetSelectorProps)
 
   const handleLoadSeed = async () => {
     try {
-      const { params: newParams, loadout: newLoadout } = await decodeSeed(importSeedValue);
+      const { params: newParams, loadout: newLoadout } =
+        await decodeSeed(importSeedValue);
       switchCombatStyle(newParams.combat_style);
       setParams(newParams);
       setLoadout(newLoadout);
-      toast.success('Seed loaded');
+      toast.success("Seed loaded");
       setSeedDialogOpen(false);
     } catch {
-      toast.error('Invalid seed');
+      toast.error("Invalid seed");
     }
   };
 
   const handleCopySeed = async () => {
     try {
       await navigator.clipboard.writeText(generatedSeed);
-      toast.success('Seed copied');
+      toast.success("Seed copied");
     } catch {
-      toast.error('Failed to copy');
+      toast.error("Failed to copy");
     }
   };
 
   const deletePreset = (presetId: string) => {
-    const updatedPresets = presets.filter(preset => preset.id !== presetId);
+    const updatedPresets = presets.filter((preset) => preset.id !== presetId);
     setPresets(updatedPresets);
-    setStorePresets(updatedPresets);
     removePreset(presetId);
-    if (typeof window !== 'undefined') {
-      localStorage.setItem('osrs-dps-presets', JSON.stringify(updatedPresets));
+    if (typeof window !== "undefined") {
+      localStorage.setItem("osrs-dps-presets", JSON.stringify(updatedPresets));
     }
   };
 
-  const movePreset = (presetId: string, direction: 'up' | 'down') => {
-    const index = presets.findIndex(p => p.id === presetId);
+  const movePreset = (presetId: string, direction: "up" | "down") => {
+    const index = presets.findIndex((p) => p.id === presetId);
     if (index === -1) return;
-    const newIndex = direction === 'up' ? index - 1 : index + 1;
+    const newIndex = direction === "up" ? index - 1 : index + 1;
     if (newIndex < 0 || newIndex >= presets.length) return;
     const updated = [...presets];
     const [moved] = updated.splice(index, 1);
     updated.splice(newIndex, 0, moved);
     setPresets(updated);
-    setStorePresets(updated);
     reorderPresets(index, newIndex);
-    if (typeof window !== 'undefined') {
-      localStorage.setItem('osrs-dps-presets', JSON.stringify(updated));
+    if (typeof window !== "undefined") {
+      localStorage.setItem("osrs-dps-presets", JSON.stringify(updated));
     }
   };
 
@@ -166,27 +181,27 @@ export function PresetSelector({ onPresetLoad, className }: PresetSelectorProps)
 
   const getPresetSummary = (preset: Preset) => {
     const { params } = preset;
-    if (params.combat_style === 'melee') {
+    if (params.combat_style === "melee") {
       return `ATK: ${params.attack_level}, STR: ${params.strength_level}, ATK Bonus: ${params.melee_attack_bonus}, STR Bonus: ${params.melee_strength_bonus}`;
-    } else if (params.combat_style === 'ranged') {
+    } else if (params.combat_style === "ranged") {
       return `RNG: ${params.ranged_level}, ATK Bonus: ${params.ranged_attack_bonus}, STR Bonus: ${params.ranged_strength_bonus}`;
-    } else if (params.combat_style === 'magic') {
+    } else if (params.combat_style === "magic") {
       return `MAG: ${params.magic_level}, ATK Bonus: ${params.magic_attack_bonus}, DMG Bonus: ${safeFixed(params.magic_damage_bonus * 100, 0)}%`;
     }
-    return '';
+    return "";
   };
 
   const groupedPresets = {
     all: presets,
-    melee: presets.filter(p => p.combatStyle === 'melee'),
-    ranged: presets.filter(p => p.combatStyle === 'ranged'),
-    magic: presets.filter(p => p.combatStyle === 'magic'),
+    melee: presets.filter((p) => p.combatStyle === "melee"),
+    ranged: presets.filter((p) => p.combatStyle === "ranged"),
+    magic: presets.filter((p) => p.combatStyle === "magic"),
   };
 
   if (!hasMounted) return null;
 
   return (
-    <Card className={cn('w-full flex flex-col', className)}>
+    <Card className={cn("w-full flex flex-col", className)}>
       <CardHeader>
         <CardTitle>Presets</CardTitle>
         <CardDescription>Save and load your equipment setups</CardDescription>
@@ -195,7 +210,9 @@ export function PresetSelector({ onPresetLoad, className }: PresetSelectorProps)
         {presets.length === 0 ? (
           <div className="text-center py-8 text-muted-foreground">
             <p>You haven&apos;t saved any presets yet.</p>
-            <p className="text-sm">Save your current setup to create a preset.</p>
+            <p className="text-sm">
+              Save your current setup to create a preset.
+            </p>
             <div className="mt-4 flex justify-center gap-2">
               <Dialog open={saveDialogOpen} onOpenChange={setSaveDialogOpen}>
                 <DialogTrigger asChild>
@@ -218,11 +235,16 @@ export function PresetSelector({ onPresetLoad, className }: PresetSelectorProps)
                       onChange={(e) => setPresetName(e.target.value)}
                     />
                     <div className="text-sm">
-                      <p>Combat Style: <Badge>{params.combat_style}</Badge></p>
+                      <p>
+                        Combat Style: <Badge>{params.combat_style}</Badge>
+                      </p>
                     </div>
                   </div>
                   <div className="flex justify-end gap-2">
-                    <Button variant="outline" onClick={() => setSaveDialogOpen(false)}>
+                    <Button
+                      variant="outline"
+                      onClick={() => setSaveDialogOpen(false)}
+                    >
                       Cancel
                     </Button>
                     <Button onClick={savePreset} disabled={!presetName.trim()}>
@@ -253,7 +275,9 @@ export function PresetSelector({ onPresetLoad, className }: PresetSelectorProps)
                       value={generatedSeed}
                     />
                     <div className="flex justify-end">
-                      <Button size="sm" onClick={handleCopySeed}>Copy</Button>
+                      <Button size="sm" onClick={handleCopySeed}>
+                        Copy
+                      </Button>
                     </div>
                   </div>
                   <div className="space-y-2 py-2">
@@ -264,15 +288,23 @@ export function PresetSelector({ onPresetLoad, className }: PresetSelectorProps)
                       onChange={(e) => setImportSeedValue(e.target.value)}
                     />
                     <div className="flex justify-end gap-2">
-                      <Button variant="outline" size="sm" onClick={() => setSeedDialogOpen(false)}>Cancel</Button>
-                      <Button size="sm" onClick={handleLoadSeed}>Load</Button>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => setSeedDialogOpen(false)}
+                      >
+                        Cancel
+                      </Button>
+                      <Button size="sm" onClick={handleLoadSeed}>
+                        Load
+                      </Button>
                     </div>
                   </div>
                 </DialogContent>
               </Dialog>
             </div>
           </div>
-          ) : (
+        ) : (
           <>
             <div className="flex justify-end mb-4 gap-2">
               <Dialog open={saveDialogOpen} onOpenChange={setSaveDialogOpen}>
@@ -296,11 +328,16 @@ export function PresetSelector({ onPresetLoad, className }: PresetSelectorProps)
                       onChange={(e) => setPresetName(e.target.value)}
                     />
                     <div className="text-sm">
-                      <p>Combat Style: <Badge>{params.combat_style}</Badge></p>
+                      <p>
+                        Combat Style: <Badge>{params.combat_style}</Badge>
+                      </p>
                     </div>
                   </div>
                   <div className="flex justify-end gap-2">
-                    <Button variant="outline" onClick={() => setSaveDialogOpen(false)}>
+                    <Button
+                      variant="outline"
+                      onClick={() => setSaveDialogOpen(false)}
+                    >
                       Cancel
                     </Button>
                     <Button onClick={savePreset} disabled={!presetName.trim()}>
@@ -331,7 +368,9 @@ export function PresetSelector({ onPresetLoad, className }: PresetSelectorProps)
                       value={generatedSeed}
                     />
                     <div className="flex justify-end">
-                      <Button size="sm" onClick={handleCopySeed}>Copy</Button>
+                      <Button size="sm" onClick={handleCopySeed}>
+                        Copy
+                      </Button>
                     </div>
                   </div>
                   <div className="space-y-2 py-2">
@@ -342,8 +381,16 @@ export function PresetSelector({ onPresetLoad, className }: PresetSelectorProps)
                       onChange={(e) => setImportSeedValue(e.target.value)}
                     />
                     <div className="flex justify-end gap-2">
-                      <Button variant="outline" size="sm" onClick={() => setSeedDialogOpen(false)}>Cancel</Button>
-                      <Button size="sm" onClick={handleLoadSeed}>Load</Button>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => setSeedDialogOpen(false)}
+                      >
+                        Cancel
+                      </Button>
+                      <Button size="sm" onClick={handleLoadSeed}>
+                        Load
+                      </Button>
                     </div>
                   </div>
                 </DialogContent>
@@ -355,60 +402,82 @@ export function PresetSelector({ onPresetLoad, className }: PresetSelectorProps)
                 <TabsTrigger value="melee">Melee</TabsTrigger>
                 <TabsTrigger value="ranged">Ranged</TabsTrigger>
                 <TabsTrigger value="magic">Magic</TabsTrigger>
-            </TabsList>
-            {Object.entries(groupedPresets).map(([key, group]) => (
-              <TabsContent key={key} value={key} className="space-y-2">
-                {group.length === 0 ? (
-                  <div className="text-center py-4 text-muted-foreground">
-                    <p>No {key} presets saved</p>
-                  </div>
-                ) : (
-                  group.map(preset => (
-                    <div
-                      key={preset.id}
-                      className="flex items-center justify-between p-3 border rounded-md hover:bg-slate-100 dark:hover:bg-slate-800"
-                    >
-                      <div className="flex-1 overflow-hidden">
-                        <div className="font-medium truncate">{preset.name}</div>
-                        <div className="text-xs text-muted-foreground">{getFormattedDate(preset.timestamp)}</div>
-                        <div className="text-xs truncate">{getPresetSummary(preset)}</div>
-                      </div>
-                      <div className="flex gap-2">
-                        <TooltipProvider>
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <Button variant="outline" size="sm" onClick={() => loadPreset(preset)}>
-                                Load
-                              </Button>
-                            </TooltipTrigger>
-                            <TooltipContent>
-                              <p>Load this preset</p>
-                            </TooltipContent>
-                          </Tooltip>
-                        </TooltipProvider>
-                        <TooltipProvider>
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <Button variant="ghost" size="sm" onClick={() => deletePreset(preset.id)}>
-                                <Trash2 className="h-4 w-4 text-red-500" />
-                              </Button>
-                            </TooltipTrigger>
-                            <TooltipContent>
-                              <p>Delete this preset</p>
-                            </TooltipContent>
-                          </Tooltip>
-                        </TooltipProvider>
-                        <Button variant="ghost" size="sm" onClick={() => movePreset(preset.id, 'up')}>
-                          <ArrowUp className="h-4 w-4" />
-                        </Button>
-                        <Button variant="ghost" size="sm" onClick={() => movePreset(preset.id, 'down')}>
-                          <ArrowDown className="h-4 w-4" />
-                        </Button>
-                      </div>
+              </TabsList>
+              {Object.entries(groupedPresets).map(([key, group]) => (
+                <TabsContent key={key} value={key} className="space-y-2">
+                  {group.length === 0 ? (
+                    <div className="text-center py-4 text-muted-foreground">
+                      <p>No {key} presets saved</p>
                     </div>
-                  ))
-                )}
-              </TabsContent>
+                  ) : (
+                    group.map((preset) => (
+                      <div
+                        key={preset.id}
+                        className="flex items-center justify-between p-3 border rounded-md hover:bg-slate-100 dark:hover:bg-slate-800"
+                      >
+                        <div className="flex-1 overflow-hidden">
+                          <div className="font-medium truncate">
+                            {preset.name}
+                          </div>
+                          <div className="text-xs text-muted-foreground">
+                            {getFormattedDate(preset.timestamp)}
+                          </div>
+                          <div className="text-xs truncate">
+                            {getPresetSummary(preset)}
+                          </div>
+                        </div>
+                        <div className="flex gap-2">
+                          <TooltipProvider>
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <Button
+                                  variant="outline"
+                                  size="sm"
+                                  onClick={() => loadPreset(preset)}
+                                >
+                                  Load
+                                </Button>
+                              </TooltipTrigger>
+                              <TooltipContent>
+                                <p>Load this preset</p>
+                              </TooltipContent>
+                            </Tooltip>
+                          </TooltipProvider>
+                          <TooltipProvider>
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <Button
+                                  variant="ghost"
+                                  size="sm"
+                                  onClick={() => deletePreset(preset.id)}
+                                >
+                                  <Trash2 className="h-4 w-4 text-red-500" />
+                                </Button>
+                              </TooltipTrigger>
+                              <TooltipContent>
+                                <p>Delete this preset</p>
+                              </TooltipContent>
+                            </Tooltip>
+                          </TooltipProvider>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => movePreset(preset.id, "up")}
+                          >
+                            <ArrowUp className="h-4 w-4" />
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => movePreset(preset.id, "down")}
+                          >
+                            <ArrowDown className="h-4 w-4" />
+                          </Button>
+                        </div>
+                      </div>
+                    ))
+                  )}
+                </TabsContent>
               ))}
             </Tabs>
           </>


### PR DESCRIPTION
## Summary
- keep equipment tab presets in sync with preset page
- reset tab selection if preset removed

## Testing
- `python -m pytest backend/app/testing/test_api.py` *(fails: ModuleNotFoundError: httpx)*
- `npm test` in `frontend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684981082160832e90677a938bc02ad2