### PR TITLE
Enhance calculation results display

### DIFF
--- a/backend/app/calculators/__init__.py
+++ b/backend/app/calculators/__init__.py
@@ -168,6 +168,13 @@ class DpsCalculator:
         result["dps"] = (regular_total + special_total) / duration
         result["special_attacks"] = special_count
         result["duration"] = duration
+        result["mainhand_max_hit"] = regular_result.get("max_hit")
+        result["special_attack_max_hit"] = special_result.get("max_hit")
+        result["mainhand_hit_chance"] = regular_result.get("hit_chance")
+        result["special_attack_hit_chance"] = special_result.get("hit_chance")
+        result["max_hit"] = max(
+            regular_result.get("max_hit", 0), special_result.get("max_hit", 0)
+        )
         return result
 
     @staticmethod

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -18,6 +18,10 @@ class DpsResult(BaseModel):
     special_attacks: Optional[int] = None
     duration: Optional[float] = None
     special_attack_dps: Optional[float] = None
+    mainhand_max_hit: Optional[int] = None
+    special_attack_max_hit: Optional[int] = None
+    mainhand_hit_chance: Optional[float] = None
+    special_attack_hit_chance: Optional[float] = None
 
 
 class BossForm(BaseModel):

--- a/frontend/src/components/features/calculator/DpsResultDisplay.tsx
+++ b/frontend/src/components/features/calculator/DpsResultDisplay.tsx
@@ -1,6 +1,5 @@
 'use client';
 import { Card, CardContent } from '@/components/ui/card';
-import { Calculator } from 'lucide-react';
 import { CalculatorParams, DpsResult } from '@/types/calculator';
 import { safeFixed } from '@/utils/format';
 
@@ -13,10 +12,6 @@ interface DpsResultDisplayProps {
 export function DpsResultDisplay({ params, results, appliedPassiveEffects }: DpsResultDisplayProps) {
   return (
     <div className="mt-8 space-y-4">
-      <h2 className="text-xl font-bold border-b pb-2 flex items-center justify-center section-heading">
-        <Calculator className="h-5 w-5 mr-2 text-primary" />
-        Calculation Results
-      </h2>
       <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
         <Card className="bg-muted/30 border">
           <CardContent className="pt-6">
@@ -36,12 +31,24 @@ export function DpsResultDisplay({ params, results, appliedPassiveEffects }: Dps
           <CardContent className="pt-6">
             <div className="text-sm font-medium text-muted-foreground">Max Hit</div>
             <div className="text-3xl font-bold text-primary">{results.max_hit}</div>
+            {results.special_attack_dps !== undefined && (
+              <div className="text-xs text-muted-foreground">
+                Base {results.mainhand_max_hit ?? results.max_hit} + Special{' '}
+                {results.special_attack_max_hit ?? 0}
+              </div>
+            )}
           </CardContent>
         </Card>
         <Card className="bg-muted/30 border">
           <CardContent className="pt-6">
             <div className="text-sm font-medium text-muted-foreground">Hit Chance</div>
             <div className="text-3xl font-bold text-primary">{safeFixed(results.hit_chance * 100, 1)}%</div>
+            {results.special_attack_dps !== undefined && (
+              <div className="text-xs text-muted-foreground">
+                Base {safeFixed((results.mainhand_hit_chance ?? results.hit_chance) * 100, 1)}% + Special{' '}
+                {safeFixed((results.special_attack_hit_chance ?? results.hit_chance) * 100, 1)}%
+              </div>
+            )}
           </CardContent>
         </Card>
         {results.special_attack_dps !== undefined && (

--- a/frontend/src/types/calculator.ts
+++ b/frontend/src/types/calculator.ts
@@ -164,6 +164,10 @@ export interface DpsResult {
   duration?: number;
   special_attack_dps?: number;
   mainhand_dps?: number;
+  mainhand_max_hit?: number;
+  special_attack_max_hit?: number;
+  mainhand_hit_chance?: number;
+  special_attack_hit_chance?: number;
 }
 
 // Expanded DPS result with additional information


### PR DESCRIPTION
## Summary
- expose mainhand/special stats from calculator backend
- display base and special details on DPS, Max Hit, and Hit Chance cards
- remove `Calculation Results` heading

## Testing
- `python app/testing/UnitTest.py`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68498151bf5c832e88f6d6a37f00e178