### PR TITLE
Add news summaries to home page

### DIFF
--- a/frontend/src/app/news/ClientPage.tsx
+++ b/frontend/src/app/news/ClientPage.tsx
@@ -8,7 +8,49 @@ interface Article {
   id: number;
   title: string;
   content: string;
+  author: string;
+  date: string;
+  image: string;
 }
+
+const defaultArticles: Article[] = [
+  {
+    id: 1,
+    title: 'Yama Storms Into Gielinor',
+    author: 'ScapeLab Reporter',
+    date: '2025-05-14',
+    image: '/landscape-placeholder.svg',
+    content:
+      'May wrapped up with the fiery arrival of Yama and a flurry of blogs detailing upcoming combat tweaks.',
+  },
+  {
+    id: 2,
+    title: 'Community Cheers for Stackable Clues',
+    author: 'ScapeLab Reporter',
+    date: '2025-05-30',
+    image: '/landscape-placeholder.svg',
+    content:
+      'Poll 84 results kept the one-hour clue timer and let players hold up to five clues at once.',
+  },
+  {
+    id: 3,
+    title: 'A Mixed June for OSRS Events',
+    author: 'ScapeLab Reporter',
+    date: '2025-06-08',
+    image: '/landscape-placeholder.svg',
+    content:
+      'June brought Yama tweaks but no OSRS League as resources shifted to other projects.',
+  },
+  {
+    id: 4,
+    title: "Reddit's Latest Running Jokes",
+    author: 'ScapeLab Reporter',
+    date: '2025-06-10',
+    image: '/landscape-placeholder.svg',
+    content:
+      'Memes about insane grinds and hooded slayer helms kept the community entertained.',
+  },
+];
 
 export default function NewsClientPage() {
   const [articles, setArticles] = useState<Article[]>([]);
@@ -19,11 +61,16 @@ export default function NewsClientPage() {
     const stored = localStorage.getItem('newsArticles');
     if (stored) {
       try {
-        setArticles(JSON.parse(stored));
+        const parsed = JSON.parse(stored);
+        if (Array.isArray(parsed) && parsed.length > 0) {
+          setArticles(parsed);
+          return;
+        }
       } catch {
-        setArticles([]);
+        // ignore
       }
     }
+    setArticles(defaultArticles);
   }, []);
 
   useEffect(() => {
@@ -35,7 +82,14 @@ export default function NewsClientPage() {
     if (!title.trim() || !content.trim()) return;
     setArticles(prev => [
       ...prev,
-      { id: Date.now(), title: title.trim(), content: content.trim() },
+      {
+        id: Date.now(),
+        title: title.trim(),
+        content: content.trim(),
+        author: 'ScapeLab Reporter',
+        date: new Date().toISOString().slice(0, 10),
+        image: '/landscape-placeholder.svg',
+      },
     ]);
     setTitle('');
     setContent('');
@@ -62,8 +116,20 @@ export default function NewsClientPage() {
       </form>
       <ul className="space-y-6 max-w-xl mx-auto">
         {articles.map(article => (
-          <li key={article.id} className="border p-4 rounded">
-            <h2 className="text-xl font-semibold mb-2">{article.title}</h2>
+          <li
+            key={article.id}
+            id={`article-${article.id}`}
+            className="border p-4 rounded"
+          >
+            <img
+              src={article.image}
+              alt=""
+              className="mb-2 w-full h-48 object-cover rounded"
+            />
+            <h2 className="text-xl font-semibold mb-1">{article.title}</h2>
+            <p className="text-gray-500 text-sm mb-2">
+              {article.author} - {new Date(article.date).toLocaleDateString()}
+            </p>
             <p>{article.content}</p>
           </li>
         ))}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -28,6 +28,36 @@ export const metadata: Metadata = {
 };
 
 export default function Home() {
+  const articleSummaries = [
+    {
+      id: 1,
+      title: 'Yama Storms Into Gielinor',
+      author: 'ScapeLab Reporter',
+      date: '2025-05-14',
+      image: '/landscape-placeholder.svg',
+    },
+    {
+      id: 2,
+      title: 'Community Cheers for Stackable Clues',
+      author: 'ScapeLab Reporter',
+      date: '2025-05-30',
+      image: '/landscape-placeholder.svg',
+    },
+    {
+      id: 3,
+      title: 'A Mixed June for OSRS Events',
+      author: 'ScapeLab Reporter',
+      date: '2025-06-08',
+      image: '/landscape-placeholder.svg',
+    },
+    {
+      id: 4,
+      title: "Reddit's Latest Running Jokes",
+      author: 'ScapeLab Reporter',
+      date: '2025-06-10',
+      image: '/landscape-placeholder.svg',
+    },
+  ];
   return (
     <>
       <HomeHero />
@@ -69,6 +99,28 @@ export default function Home() {
               </CardHeader>
             </Card>
           </Link>
+        </div>
+        <h2 className="mt-16 mb-6 text-2xl font-bold">Latest News</h2>
+        <div className="grid gap-6 sm:grid-cols-2 md:grid-cols-4">
+          {articleSummaries.map(article => (
+            <Link key={article.id} href={`/news#article-${article.id}`}>
+              <Card className="hover:border-primary transition-colors text-left">
+                <img
+                  src={article.image}
+                  alt=""
+                  className="w-full h-32 object-cover rounded-t"
+                />
+                <CardHeader>
+                  <CardTitle className="text-base font-semibold">
+                    {article.title}
+                  </CardTitle>
+                  <CardDescription>
+                    {article.author} - {new Date(article.date).toLocaleDateString()}
+                  </CardDescription>
+                </CardHeader>
+              </Card>
+            </Link>
+          ))}
         </div>
       </main>
     </>


### PR DESCRIPTION
## Summary
- populate news page with starter articles
- show article metadata and link anchors
- display latest news cards on the home page linking to news articles

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684985b6bcc0832eafc174c1b3e0378e