### PR TITLE
Split DPS state

### DIFF
--- a/frontend/src/__tests__/equipment-bonuses-store.test.ts
+++ b/frontend/src/__tests__/equipment-bonuses-store.test.ts
@@ -1,0 +1,15 @@
+import { act } from '@testing-library/react';
+import { useEquipmentBonusesStore } from '../store/equipment-bonuses-store';
+
+describe('equipment bonuses store', () => {
+  it('updates and resets bonuses', () => {
+    act(() => {
+      useEquipmentBonusesStore.getState().setBonuses({ melee_attack_bonus: 5 });
+    });
+    expect(useEquipmentBonusesStore.getState().melee_attack_bonus).toBe(5);
+    act(() => {
+      useEquipmentBonusesStore.getState().resetBonuses();
+    });
+    expect(useEquipmentBonusesStore.getState().melee_attack_bonus).toBe(0);
+  });
+});

--- a/frontend/src/__tests__/special-attack-store.test.ts
+++ b/frontend/src/__tests__/special-attack-store.test.ts
@@ -1,0 +1,14 @@
+import { act } from '@testing-library/react';
+import { useSpecialAttackStore } from '../store/special-attack-store';
+
+describe('special attack store', () => {
+  it('stores weapon and special data', () => {
+    act(() => {
+      useSpecialAttackStore.getState().setWeapon({ id:1, name:'Spec', has_special_attack: true } as any);
+      useSpecialAttackStore.getState().setData({ weapon_name:'Spec', effect:'x', special_cost:50, accuracy_multiplier:1, damage_multiplier:1 });
+    });
+    const state = useSpecialAttackStore.getState();
+    expect(state.weapon?.name).toBe('Spec');
+    expect(state.data?.weapon_name).toBe('Spec');
+  });
+});

--- a/frontend/src/components/features/calculator/CombinedEquipmentDisplay.tsx
+++ b/frontend/src/components/features/calculator/CombinedEquipmentDisplay.tsx
@@ -7,6 +7,10 @@ import { Switch } from '@/components/ui/switch';
 import { Label } from '@/components/ui/label';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { useCalculatorStore } from '@/store/calculator-store';
+import {
+  useEquipmentBonusesStore,
+} from '@/store/equipment-bonuses-store';
+import { useSpecialAttackStore } from '@/store/special-attack-store';
 import { Item, CalculatorParams, NpcForm } from '@/types/calculator';
 import { useToast } from '@/hooks/use-toast';
 import { calculatorApi } from '@/services/api';
@@ -135,6 +139,8 @@ export function CombinedEquipmentDisplay({
   
   // Update bonuses when loadout changes
   const lastBonusRef = useRef<Partial<CalculatorParams>>({});
+  const setBonuses = useEquipmentBonusesStore((s) => s.setBonuses);
+  const setSpecWeapon = useSpecialAttackStore((s) => s.setWeapon);
   useEffect(() => {
     const current = useCalculatorStore.getState().params;
     const updates: Partial<CalculatorParams> = {};
@@ -188,6 +194,15 @@ export function CombinedEquipmentDisplay({
       if (prev.magic_damage_bonus !== magicDmg) updates.magic_damage_bonus = magicDmg;
     }
 
+    setBonuses({
+      melee_attack_bonus: meleeAtk,
+      melee_strength_bonus: meleeStr,
+      ranged_attack_bonus: rangedAtk,
+      ranged_strength_bonus: rangedStr,
+      magic_attack_bonus: magicAtk,
+      magic_damage_bonus: magicDmg,
+    });
+
     if (Object.keys(updates).length > 0) {
       if (process.env.NODE_ENV !== 'production') {
         console.log('[DEBUG] Updating combat totals:', updates);
@@ -223,6 +238,11 @@ export function CombinedEquipmentDisplay({
       console.log('[DEBUG] Processing weapon:', weapon.name);
     }
   }, [loadout]);
+
+  // Update special attack weapon when spec slot changes
+  useEffect(() => {
+    setSpecWeapon(loadout['spec'] || null);
+  }, [loadout, setSpecWeapon]);
 
   // Automatically switch combat style based on weapon attack types
   useEffect(() => {

--- a/frontend/src/components/features/calculator/DpsResultDisplay.tsx
+++ b/frontend/src/components/features/calculator/DpsResultDisplay.tsx
@@ -12,19 +12,31 @@ interface DpsResultDisplayProps {
 export function DpsResultDisplay({ params, results, appliedPassiveEffects }: DpsResultDisplayProps) {
   return (
     <div className="mt-8 space-y-4">
-      <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+      <div className="grid grid-cols-1 md:grid-cols-5 gap-4">
+        <Card className="bg-muted/30 border">
+          <CardContent className="pt-6">
+            <div className="text-sm font-medium text-muted-foreground">Gear DPS</div>
+            <div className="text-3xl font-bold text-primary">
+              {safeFixed(results.mainhand_dps ?? results.dps, 2)}
+            </div>
+          </CardContent>
+        </Card>
+        {results.special_attack_dps !== undefined && (
+          <Card className="bg-muted/30 border">
+            <CardContent className="pt-6">
+              <div className="text-sm font-medium text-muted-foreground">Special DPS</div>
+              <div className="text-3xl font-bold text-primary">
+                {safeFixed(results.special_attack_dps, 2)}
+              </div>
+            </CardContent>
+          </Card>
+        )}
         <Card className="bg-muted/30 border">
           <CardContent className="pt-6">
             <div className="text-sm font-medium text-muted-foreground">Total DPS</div>
             <div className="text-3xl font-bold text-primary">
               {safeFixed(results.dps, 2)}
             </div>
-            {results.special_attack_dps !== undefined && (
-              <div className="text-xs text-muted-foreground">
-                Base {safeFixed(results.mainhand_dps ?? 0, 2)} + Special{' '}
-                {safeFixed(results.special_attack_dps, 2)}
-              </div>
-            )}
           </CardContent>
         </Card>
         <Card className="bg-muted/30 border">

--- a/frontend/src/store/equipment-bonuses-store.ts
+++ b/frontend/src/store/equipment-bonuses-store.ts
@@ -1,0 +1,27 @@
+import { create } from 'zustand';
+
+export interface EquipmentBonusesState {
+  melee_attack_bonus: number;
+  melee_strength_bonus: number;
+  ranged_attack_bonus: number;
+  ranged_strength_bonus: number;
+  magic_attack_bonus: number;
+  magic_damage_bonus: number;
+  setBonuses: (b: Partial<EquipmentBonusesState>) => void;
+  resetBonuses: () => void;
+}
+
+const defaultState: Omit<EquipmentBonusesState, 'setBonuses' | 'resetBonuses'> = {
+  melee_attack_bonus: 0,
+  melee_strength_bonus: 0,
+  ranged_attack_bonus: 0,
+  ranged_strength_bonus: 0,
+  magic_attack_bonus: 0,
+  magic_damage_bonus: 0,
+};
+
+export const useEquipmentBonusesStore = create<EquipmentBonusesState>((set) => ({
+  ...defaultState,
+  setBonuses: (b) => set((state) => ({ ...state, ...b })),
+  resetBonuses: () => set({ ...defaultState }),
+}));

--- a/frontend/src/store/special-attack-store.ts
+++ b/frontend/src/store/special-attack-store.ts
@@ -1,0 +1,16 @@
+import { create } from 'zustand';
+import { Item, SpecialAttack } from '@/types/calculator';
+
+export interface SpecialAttackState {
+  weapon: Item | null;
+  data: SpecialAttack | null;
+  setWeapon: (w: Item | null) => void;
+  setData: (d: SpecialAttack | null) => void;
+}
+
+export const useSpecialAttackStore = create<SpecialAttackState>((set) => ({
+  weapon: null,
+  data: null,
+  setWeapon: (weapon) => set({ weapon }),
+  setData: (data) => set({ data }),
+}));


### PR DESCRIPTION
## Summary
- add store for aggregated equipment bonuses
- add store for spec weapon
- update equipment display to populate the new stores
- show separate Gear DPS and Special DPS in the results
- add tests for new stores

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, no-unused-vars, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684988746b84832ea8621ae3fbfd21f9