### PR TITLE
Enable scroll wheel for selects

### DIFF
--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -6,10 +6,38 @@ import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 
+const OpenContext = React.createContext<((open: boolean) => void) | null>(null)
+
 function Select({
+  open: openProp,
+  defaultOpen,
+  onOpenChange,
+  children,
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Root>) {
-  return <SelectPrimitive.Root data-slot="select" {...props} />
+  const isControlled = openProp !== undefined
+  const [open, setOpen] = React.useState(defaultOpen ?? false)
+  const handleOpenChange = React.useCallback(
+    (o: boolean) => {
+      if (!isControlled) setOpen(o)
+      onOpenChange?.(o)
+    },
+    [isControlled, onOpenChange]
+  )
+
+  return (
+    <OpenContext.Provider value={handleOpenChange}>
+      <SelectPrimitive.Root
+        data-slot="select"
+        open={isControlled ? openProp : open}
+        onOpenChange={handleOpenChange}
+        defaultOpen={defaultOpen}
+        {...props}
+      >
+        {children}
+      </SelectPrimitive.Root>
+    </OpenContext.Provider>
+  )
 }
 
 function SelectGroup({
@@ -32,15 +60,23 @@ function SelectTrigger({
 }: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
   size?: "sm" | "default"
 }) {
+  const setOpen = React.useContext(OpenContext)
+  const { onWheel, ...rest } = props
   return (
     <SelectPrimitive.Trigger
       data-slot="select-trigger"
       data-size={size}
       className={cn(
         "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-        className
+      className
       )}
-      {...props}
+      {...rest}
+      onWheel={(e) => {
+        onWheel?.(e)
+        if (!e.defaultPrevented) {
+          setOpen?.(true)
+        }
+      }}
     >
       {children}
       <SelectPrimitive.Icon asChild>


### PR DESCRIPTION
## Summary
- expose open control context in `Select` component
- allow `SelectTrigger` to open on mouse wheel scroll

## Testing
- `npm test`
- `npm run lint` *(fails: lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_684a60876c08832eaa86ec28b0aed852