### PR TITLE
Deduplicate NPC names in selectors

### DIFF
--- a/frontend/src/components/features/calculator/DirectNpcSelector.tsx
+++ b/frontend/src/components/features/calculator/DirectNpcSelector.tsx
@@ -31,6 +31,25 @@ import { Alert, AlertDescription } from '@/components/ui/alert';
 import { useReferenceDataStore } from '@/store/reference-data-store';
 import { cn } from '@/lib/utils';
 
+// Helper to normalize npc names and remove variant markers
+const canonicalName = (name: string) =>
+  name
+    .split('#')[0]
+    .replace(/\([^)]*\)/g, '')
+    .trim()
+    .toLowerCase();
+
+const dedupeNpcs = (npcs: NpcSummary[]): NpcSummary[] => {
+  const seen = new Map<string, NpcSummary>();
+  for (const npc of npcs) {
+    const key = canonicalName(npc.name);
+    if (!seen.has(key)) {
+      seen.set(key, npc);
+    }
+  }
+  return Array.from(seen.values());
+};
+
 interface DirectNpcSelectorProps {
   onSelectNpc?: (npc: NpcSummary) => void;
   onSelectForm?: (form: NpcForm | null) => void;
@@ -275,7 +294,9 @@ export function DirectNpcSelector({ onSelectNpc, onSelectForm, className }: Dire
                         Loading...
                       </div>
                     ) : (
-                      (searchQuery.length > 0 ? searchResults ?? [] : storeNpcs).map((npc) => (
+                      dedupeNpcs(
+                        searchQuery.length > 0 ? searchResults ?? [] : storeNpcs
+                      ).map((npc) => (
                         <CommandItem
                           key={npc.id}
                           value={npc.name}

--- a/frontend/src/components/features/calculator/NpcSelector.tsx
+++ b/frontend/src/components/features/calculator/NpcSelector.tsx
@@ -36,6 +36,25 @@ import { useCalculatorStore } from '@/store/calculator-store';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { useReferenceDataStore } from '@/store/reference-data-store';
 
+// Helper to normalize npc names and remove variant markers
+const canonicalName = (name: string) =>
+  name
+    .split('#')[0]
+    .replace(/\([^)]*\)/g, '')
+    .trim()
+    .toLowerCase();
+
+const dedupeNpcs = (npcs: NpcSummary[]): NpcSummary[] => {
+  const seen = new Map<string, NpcSummary>();
+  for (const npc of npcs) {
+    const key = canonicalName(npc.name);
+    if (!seen.has(key)) {
+      seen.set(key, npc);
+    }
+  }
+  return Array.from(seen.values());
+};
+
 interface NpcSelectorProps {
   onSelectNpc?: (npc: NpcSummary) => void;
   onSelectForm?: (form: NpcForm | null) => void;
@@ -374,7 +393,9 @@ export function NpcSelector({ onSelectNpc, onSelectForm }: NpcSelectorProps) {
                         Loading...
                       </div>
                     ) : (
-                      (searchTerm.length > 0 ? searchResults ?? [] : storeNpcs).map((npc) => (
+                      dedupeNpcs(
+                        searchTerm.length > 0 ? searchResults ?? [] : storeNpcs
+                      ).map((npc) => (
                         <CommandItem
                           key={npc.id}
                           value={npc.name}


### PR DESCRIPTION
## Summary
- hide NPC name variants in drop-downs
- update both direct and standard NPC selectors to remove variant text

## Testing
- `npm test` *(fails: jest not found)*
- `python -m pytest` *(fails: can't open ODBC driver)*

------
https://chatgpt.com/codex/tasks/task_e_684a615302e0832eb1e73311581887fc