### PR TITLE
Filter out entries with missing stats

### DIFF
--- a/frontend/src/__tests__/alt-text.test.tsx
+++ b/frontend/src/__tests__/alt-text.test.tsx
@@ -64,6 +64,7 @@ describe('image alt text', () => {
       slot: 'weapon',
       has_special_attack: false,
       has_passive_effect: false,
+      has_combat_stats: true,
     } as any;
     useReferenceDataStore.setState({ items: [item] });
 

--- a/frontend/src/components/features/calculator/DirectNpcSelector.tsx
+++ b/frontend/src/components/features/calculator/DirectNpcSelector.tsx
@@ -102,6 +102,9 @@ export function DirectNpcSelector({ onSelectNpc, onSelectForm, className }: Dire
     ? { ...selectedNpc, forms: storeNpcForms[selectedNpc.id] ?? npcDetails?.forms }
     : null;
 
+  const formHasStats = (form: NpcForm) =>
+    form.defence_level !== undefined && form.defence_level !== null;
+
   const rangedWeakness = selectedForm &&
     typeof selectedForm.defence_ranged_light === 'number' &&
     typeof selectedForm.defence_ranged_heavy === 'number'
@@ -296,7 +299,12 @@ export function DirectNpcSelector({ onSelectNpc, onSelectForm, className }: Dire
                     ) : (
                       dedupeNpcs(
                         searchQuery.length > 0 ? searchResults ?? [] : storeNpcs
-                      ).map((npc) => (
+                      )
+                        .filter(npc => {
+                          const forms = storeNpcForms[npc.id];
+                          return !forms || forms.some(formHasStats);
+                        })
+                        .map((npc) => (
                         <CommandItem
                           key={npc.id}
                           value={npc.name}
@@ -347,11 +355,13 @@ export function DirectNpcSelector({ onSelectNpc, onSelectForm, className }: Dire
                   <SelectValue placeholder="Select a form/phase" />
                 </SelectTrigger>
                 <SelectContent>
-                  {(combinedNpcDetails?.forms ?? []).map((form) => (
-                    <SelectItem key={form.id} value={form.id.toString()}>
-                      {form.form_name || `${combinedNpcDetails?.name} (${form.combat_level || 'Unknown'})`}
-                    </SelectItem>
-                  ))}
+                  {(combinedNpcDetails?.forms ?? [])
+                    .filter(formHasStats)
+                    .map((form) => (
+                      <SelectItem key={form.id} value={form.id.toString()}>
+                        {form.form_name || `${combinedNpcDetails?.name} (${form.combat_level || 'Unknown'})`}
+                      </SelectItem>
+                    ))}
                 </SelectContent>
               </Select>
                 <Button variant="outline" size="sm" onClick={handleResetNpc}>

--- a/frontend/src/components/features/calculator/ItemSelector.tsx
+++ b/frontend/src/components/features/calculator/ItemSelector.tsx
@@ -121,12 +121,12 @@ export function ItemSelector({ slot, specialOnly, onSelectItem }: ItemSelectorPr
 
   const filteredItems = filterBySlot(storeItems);
   const searchFiltered = searchResults ? filterBySlot(searchResults) : [];
-  const baseItems =
-    searchTerm.length > 0 ? searchFiltered : filteredItems;
+  const baseItems = searchTerm.length > 0 ? searchFiltered : filteredItems;
+  const combatItems = baseItems.filter((item) => item.has_combat_stats);
   const itemsToDisplay = dedupeItems(
     specialOnly
-      ? baseItems.filter((item) => item.has_special_attack)
-      : baseItems
+      ? combatItems.filter((item) => item.has_special_attack)
+      : combatItems
   );
 
   // Handle item selection and update calculator params based on its stats

--- a/frontend/src/store/reference-data-store.ts
+++ b/frontend/src/store/reference-data-store.ts
@@ -121,10 +121,14 @@ export const useReferenceDataStore = create<ReferenceDataState>()(
         set((state) => ({ npcs: [...state.npcs, ...b] }));
       },
       addNpcForms(id, forms) {
-        set((state) => ({ npcForms: { ...state.npcForms, [id]: forms } }));
+        const hasStats = (f: NpcForm) =>
+          f.defence_level !== undefined && f.defence_level !== null;
+        set((state) => ({
+          npcForms: { ...state.npcForms, [id]: forms.filter(hasStats) }
+        }));
       },
       addItems(i) {
-        set((state) => ({ items: [...state.items, ...i] }));
+        set((state) => ({ items: [...state.items, ...i.filter(it => it.has_combat_stats)] }));
       },
       setSpecialAttacks(a) {
         set({ specialAttacks: a });


### PR DESCRIPTION
## Summary
- exclude items without combat stats when listing items
- exclude NPC forms without defense stats
- avoid displaying NPCs with no statted forms
- filter stats before saving to store
- adjust alt-text test fixture

## Testing
- `npm test --silent`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_684a6562a1e4832e88e36b2e9de5dee8