### PR TITLE
Filter invalid boss forms

### DIFF
--- a/frontend/src/__tests__/reference-data-store.test.ts
+++ b/frontend/src/__tests__/reference-data-store.test.ts
@@ -87,4 +87,17 @@ describe('reference data store', () => {
     expect(mockedSpecialApi.getAll).toHaveBeenCalledTimes(1);
     expect(mockedPassiveApi.getAll).toHaveBeenCalledTimes(1);
   });
+
+  it('filters forms with placeholder names', () => {
+    act(() => {
+      getStore().addNpcForms(1, [
+        { id: 10, npc_id: 1, form_name: 'Form 1', defence_level: 10 } as any,
+        { id: 11, npc_id: 1, form_name: 'Normal', defence_level: 20 } as any,
+      ]);
+    });
+
+    const forms = getStore().npcForms[1];
+    expect(forms).toHaveLength(1);
+    expect(forms[0].form_name).toBe('Normal');
+  });
 });

--- a/frontend/src/store/reference-data-store.ts
+++ b/frontend/src/store/reference-data-store.ts
@@ -123,8 +123,13 @@ export const useReferenceDataStore = create<ReferenceDataState>()(
       addNpcForms(id, forms) {
         const hasStats = (f: NpcForm) =>
           f.defence_level !== undefined && f.defence_level !== null;
+        const validName = (f: NpcForm) =>
+          f.form_name && !/^form\s*\d+$/i.test(f.form_name.trim());
         set((state) => ({
-          npcForms: { ...state.npcForms, [id]: forms.filter(hasStats) }
+          npcForms: {
+            ...state.npcForms,
+            [id]: forms.filter((f) => hasStats(f) && validName(f))
+          }
         }));
       },
       addItems(i) {


### PR DESCRIPTION
## Summary
- filter out placeholder boss forms with names like "Form 1"
- test that reference data store removes placeholder forms

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684a66dfa8d4832e9c48efa0436068e2