### PR TITLE
Clean canonical names after dedupe

### DIFF
--- a/frontend/src/components/features/calculator/DirectNpcSelector.tsx
+++ b/frontend/src/components/features/calculator/DirectNpcSelector.tsx
@@ -36,15 +36,17 @@ const canonicalName = (name: string) =>
   name
     .split('#')[0]
     .replace(/\([^)]*\)/g, '')
-    .trim()
-    .toLowerCase();
+    .trim();
+
+const canonicalKey = (name: string) => canonicalName(name).toLowerCase();
 
 const dedupeNpcs = (npcs: NpcSummary[]): NpcSummary[] => {
   const seen = new Map<string, NpcSummary>();
   for (const npc of npcs) {
-    const key = canonicalName(npc.name);
+    const clean = canonicalName(npc.name);
+    const key = clean.toLowerCase();
     if (!seen.has(key)) {
-      seen.set(key, npc);
+      seen.set(key, { ...npc, name: clean });
     }
   }
   return Array.from(seen.values());

--- a/frontend/src/components/features/calculator/ItemSelector.tsx
+++ b/frontend/src/components/features/calculator/ItemSelector.tsx
@@ -45,15 +45,17 @@ const canonicalName = (name: string) =>
     // Remove a trailing parenthetical group like "(4)" or "(i)"
 
     .replace(/\s*\([^)]*\)\s*$/, '')
-    .trim()
-    .toLowerCase();
+    .trim();
+
+const canonicalKey = (name: string) => canonicalName(name).toLowerCase();
 
 const dedupeItems = (items: ItemSummary[]): ItemSummary[] => {
   const seen = new Map<string, ItemSummary>();
   for (const item of items) {
-    const key = canonicalName(item.name);
+    const clean = canonicalName(item.name);
+    const key = clean.toLowerCase();
     if (!seen.has(key)) {
-      seen.set(key, item);
+      seen.set(key, { ...item, name: clean });
     }
   }
   return Array.from(seen.values());

--- a/frontend/src/components/features/calculator/NpcSelector.tsx
+++ b/frontend/src/components/features/calculator/NpcSelector.tsx
@@ -41,15 +41,17 @@ const canonicalName = (name: string) =>
   name
     .split('#')[0]
     .replace(/\([^)]*\)/g, '')
-    .trim()
-    .toLowerCase();
+    .trim();
+
+const canonicalKey = (name: string) => canonicalName(name).toLowerCase();
 
 const dedupeNpcs = (npcs: NpcSummary[]): NpcSummary[] => {
   const seen = new Map<string, NpcSummary>();
   for (const npc of npcs) {
-    const key = canonicalName(npc.name);
+    const clean = canonicalName(npc.name);
+    const key = clean.toLowerCase();
     if (!seen.has(key)) {
-      seen.set(key, npc);
+      seen.set(key, { ...npc, name: clean });
     }
   }
   return Array.from(seen.values());


### PR DESCRIPTION
## Summary
- clean canonical item and NPC names when deduplicating dropdown lists
- preserve the deduping key in lowercase while presenting cleaned names

## Testing
- `npm test`
- `pytest -q` *(fails: Client.__init__() got an unexpected keyword argument 'app')*

------
https://chatgpt.com/codex/tasks/task_e_684a6864dfe4832e98550c18a84fb47d