### PR TITLE
Refactor DPS hook to use stores directly

### DIFF
--- a/frontend/src/hooks/useDpsCalculator.ts
+++ b/frontend/src/hooks/useDpsCalculator.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useEffect, useCallback, useState } from 'react';
 import { useMutation } from '@tanstack/react-query';
 import { calculatorApi } from '@/services/api';
 import { useCalculatorStore } from '@/store/calculator-store';
@@ -15,28 +15,12 @@ export function useDpsCalculator() {
   const switchCombatStyle = useCalculatorStore((s) => s.switchCombatStyle);
   const resetParams = useCalculatorStore((s) => s.resetParams);
   const resetLocks = useCalculatorStore((s) => s.resetLocks);
-  const storeLoadout = useCalculatorStore((s) => s.loadout);
+  const currentLoadout = useCalculatorStore((s) => s.loadout);
   const setStoreLoadout = useCalculatorStore((s) => s.setLoadout);
-
-  const [activeTab, setActiveTab] = useState<CombatStyle>(params.combat_style);
-  const [currentLoadout, setCurrentLoadout] = useState<Record<string, Item | null>>(storeLoadout);
-  const storeNpcForm = useCalculatorStore((s) => s.selectedNpcForm);
+  const currentNpcForm = useCalculatorStore((s) => s.selectedNpcForm);
   const setStoreNpcForm = useCalculatorStore((s) => s.setSelectedNpcForm);
-  const [currentNpcForm, setCurrentNpcForm] = useState<NpcForm | null>(storeNpcForm);
+  const activeTab = params.combat_style;
   const [appliedPassiveEffects, setAppliedPassiveEffects] = useState<any>(null);
-
-  useEffect(() => {
-    setCurrentNpcForm(storeNpcForm);
-  }, [storeNpcForm]);
-
-  useEffect(() => {
-    setCurrentLoadout(storeLoadout);
-  }, [storeLoadout]);
-
-  // keep local tab state in sync with store combat style
-  useEffect(() => {
-    setActiveTab(params.combat_style);
-  }, [params.combat_style]);
 
   const calculateEffects = useCallback(() => {
     return calculatePassiveEffectBonuses(params, currentLoadout, currentNpcForm);
@@ -164,25 +148,21 @@ export function useDpsCalculator() {
     resetLocks();
     setResults(null);
     setAppliedPassiveEffects(null);
-    setCurrentLoadout({});
     setStoreLoadout({});
-    setCurrentNpcForm(null);
+    setStoreNpcForm(null);
     toast.success('Calculator reset to defaults');
   };
 
   const handleTabChange = (style: CombatStyle) => {
-    setActiveTab(style);
     switchCombatStyle(style);
     toast.info(`Switched to ${style} combat style`);
   };
 
   const handleEquipmentUpdate = (loadout: Record<string, Item | null>) => {
-    setCurrentLoadout(loadout);
     setStoreLoadout(loadout);
   };
 
   const handleNpcUpdate = (npcForm: NpcForm | null) => {
-    setCurrentNpcForm(npcForm);
     setStoreNpcForm(npcForm);
   };
 


### PR DESCRIPTION
## Summary
- simplify `useDpsCalculator` to rely directly on calculator stores
- remove duplicated local state for loadout, npc form and combat style

## Testing
- `npm test --prefix frontend` *(fails: jest not installed)*
- `python -m pytest backend/app` *(fails: ModuleNotFoundError: httpx, cachetools)*

------
https://chatgpt.com/codex/tasks/task_e_684a6f83a7c0832e971e20abdb8229b0