### PR TITLE
Fix raid scaling check

### DIFF
--- a/backend/app/calculators/raid_scaling.py
+++ b/backend/app/calculators/raid_scaling.py
@@ -7,7 +7,8 @@ def apply_raid_scaling(params: Dict[str, Any]) -> Dict[str, Any]:
     """Adjust defensive stats based on raid type and raid level."""
 
     raid = params.get("raid")
-    if not raid:
+    raid_group = params.get("raid_group")
+    if not raid or not raid_group:
         return params
 
     raid = str(raid).lower()

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -200,6 +200,7 @@ class DpsParameters(BaseModel):
     salve_bonus: Optional[float] = None
 
     # Raid parameters
+    raid_group: Optional[str] = None
     raid: Optional[str] = None
     raid_level: Optional[int] = None
     party_size: Optional[int] = None


### PR DESCRIPTION
## Summary
- add `raid_group` field to DPS parameters
- require `raid_group` for raid scaling to activate

## Testing
- `pip install -r backend/requirements.txt`
- `pytest -q` *(fails: ODBC Driver 17 for SQL Server not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a7195bc4c832e95614330fb7b6533