### PR TITLE
Auto-fill special attack parameters

### DIFF
--- a/frontend/src/components/features/calculator/SpecialAttackForm.tsx
+++ b/frontend/src/components/features/calculator/SpecialAttackForm.tsx
@@ -3,11 +3,14 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { useCalculatorStore } from '@/store/calculator-store';
+import { useSpecialAttackStore } from '@/store/special-attack-store';
 import { Swords } from 'lucide-react';
 
 export default function SpecialAttackForm() {
   const params = useCalculatorStore((s) => s.params);
   const setParams = useCalculatorStore((s) => s.setParams);
+  const weapon = useSpecialAttackStore((s) => s.weapon);
+  const specialData = useSpecialAttackStore((s) => s.data);
 
   return (
     <Card className="w-full border">
@@ -16,6 +19,16 @@ export default function SpecialAttackForm() {
         <CardTitle>Special Attack</CardTitle>
       </CardHeader>
       <CardContent className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {weapon && (
+          <div className="md:col-span-2 space-y-1">
+            <div className="text-sm font-semibold">{weapon.name}</div>
+            {specialData?.effect && (
+              <div className="text-sm text-muted-foreground">
+                {specialData.effect}
+              </div>
+            )}
+          </div>
+        )}
         <div>
           <Label>Damage Multiplier</Label>
           <Input

--- a/frontend/src/hooks/useDpsCalculator.ts
+++ b/frontend/src/hooks/useDpsCalculator.ts
@@ -155,6 +155,7 @@ export function useDpsCalculator() {
       if (specItem) {
         (clean as any).special_attack_speed =
           specItem.combat_stats?.attack_speed ?? clean.attack_speed;
+        (clean as any).weapon_name = specItem.name;
       }
     }
     calculateMutation.mutate(clean);


### PR DESCRIPTION
## Summary
- update loadout UI to lookup special attacks when spec slot changes
- send spec weapon name with DPS calculations
- display selected special attack details in form

## Testing
- `npm test`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cachetools')*

------
https://chatgpt.com/codex/tasks/task_e_684a77d44f7c832eba0e6c08765dd768