### PR TITLE
Fix float value for special attacks

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -15,7 +15,7 @@ class DpsResult(BaseModel):
     effective_atk: Optional[int] = None
     damage_multiplier: Optional[float] = None
     mainhand_dps: Optional[float] = None
-    special_attacks: Optional[int] = None
+    special_attacks: Optional[float] = None
     duration: Optional[float] = None
     special_attack_dps: Optional[float] = None
     mainhand_max_hit: Optional[int] = None


### PR DESCRIPTION
## Summary
- allow fractional values for `special_attacks` in `DpsResult`

## Testing
- `python -m unittest discover -s backend/app/testing` *(fails: ODBC driver not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a8c564a88832ea4240835bf1ae7e7